### PR TITLE
Us117426/org unit filter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,6 @@
     ],
     "rules": {
         "no-console": ["warn"],
-        "sort-class-members/sort-class-members": ["warn"]
+        "sort-class-members/sort-class-members": ["off"]
     }
 }

--- a/components/insights-role-filter.js
+++ b/components/insights-role-filter.js
@@ -3,6 +3,12 @@ import './simple-filter';
 import {html, LitElement} from 'lit-element';
 import Lms from '../model/lms';
 
+const demoData = [
+	{ id: '500', displayName: 'Administrator' },
+	{ id: '600', displayName: 'Instructor' },
+	{ id: '700', displayName: 'Student' }
+];
+
 /**
  * @property {{id: string, displayName: string}[]} _filterData
  * @fires d2l-insights-role-filter-change - detail includes the list of selected role ids
@@ -11,7 +17,8 @@ class InsightsRoleFilter extends LitElement {
 
 	static get properties() {
 		return {
-			_filterData: {type: Array, attribute: false}
+			isDemo: { type: Boolean, attribute: 'demo' },
+			_filterData: { type: Array, attribute: false }
 		};
 	}
 
@@ -57,17 +64,21 @@ class InsightsRoleFilter extends LitElement {
 	}
 
 	render() {
+		const filterData = this.isDemo ? demoData : this._filterData;
 		return html`
 			<d2l-simple-filter
 				@d2l-simple-filter-selected="${this._updateFilterSelections}"
 				name="${this._name}"
-				.data="${this._filterData}">
+				.data="${filterData}">
 			</d2l-simple-filter>
 		`;
 	}
 
 	_updateFilterSelections(event) {
 		this._setSelectedState(event.detail.itemId, event.detail.selected);
+		/**
+		 * @event d2l-insights-role-filter-change
+		 */
 		this.dispatchEvent(new Event('d2l-insights-role-filter-change'));
 	}
 }

--- a/components/ou-filter.js
+++ b/components/ou-filter.js
@@ -1,0 +1,57 @@
+import './tree-selector.js';
+import {css, html} from 'lit-element/lit-element.js';
+import { MobxLitElement } from '@adobe/lit-mobx';
+
+class OuFilter extends MobxLitElement {
+
+	static get properties() {
+		return {
+			data: { type: Object, attribute: false }
+		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: inline-block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+		`;
+	}
+
+	render() {
+		this._ous = this._getChildren();
+
+		// NB: relying on mobx rather than lit-element properties to handle update detection: it will trigger a redraw for
+		// any change to a relevant observed property of the Data object
+		// or WILL it??? answer: no, it won't
+		// TODO: rethink data/mobx/redraw relation w. the dashboard component
+		// one idea: maybe make children a property and don't mobx this at all (not thought through...)
+		return html`<div class="ou-filter" ?loading="${this.data.isLoading}">
+			<d2l-insights-tree-selector id="ou-tree-selector" .tree="${this._ous}" @change="${this._onChange}">
+		</div>`;
+	}
+
+	get selected() {
+		return this.shadowRoot.getElementById('ou-tree-selector')
+			.selected;
+	}
+
+	// TODO: constants for array indices
+	_getChildren(id) {
+		return this.data.getChildren(id).map(x => ({
+			name: `${x[1]} (${x[0]})`,
+			getChildren: x[2] === 3 ? null : async() => this._getChildren(x[0])
+		}));
+	}
+
+	_onChange() {
+		this.dispatchEvent(new CustomEvent(
+			'change',
+			{bubbles: true, composed: false}
+		));
+	}
+}
+customElements.define('d2l-insights-ou-filter', OuFilter);

--- a/components/ou-filter.js
+++ b/components/ou-filter.js
@@ -2,6 +2,16 @@ import './tree-selector.js';
 import {css, html} from 'lit-element/lit-element.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 
+// array indices
+const ID = 0;
+const NAME = 1;
+const TYPE = 2;
+const PARENTS = 3;
+const CHILDREN = 4;
+const STATE = 5;
+
+const SEMESTER_TYPE = 5;
+
 class OuFilter extends MobxLitElement {
 
 	static get properties() {
@@ -22,15 +32,10 @@ class OuFilter extends MobxLitElement {
 	}
 
 	render() {
-		this._ous = this._getChildren();
+		this._prepareData();
 
-		// NB: relying on mobx rather than lit-element properties to handle update detection: it will trigger a redraw for
-		// any change to a relevant observed property of the Data object
-		// or WILL it??? answer: no, it won't
-		// TODO: rethink data/mobx/redraw relation w. the dashboard component
-		// one idea: maybe make children a property and don't mobx this at all (not thought through...)
 		return html`<div class="ou-filter" ?loading="${this.data.isLoading}">
-			<d2l-insights-tree-selector id="ou-tree-selector" .tree="${this._ous}" @change="${this._onChange}">
+			<d2l-insights-tree-selector id="ou-tree-selector" .tree="${this._getChildren()}" @change="${this._onChange}">
 		</div>`;
 	}
 
@@ -39,12 +44,36 @@ class OuFilter extends MobxLitElement {
 			.selected;
 	}
 
-	// TODO: constants for array indices
 	_getChildren(id) {
-		return this.data.getChildren(id).map(x => ({
-			name: `${x[1]} (${x[0]})`,
-			getChildren: x[2] === 3 ? null : async() => this._getChildren(x[0])
-		}));
+		console.log(`GET CHILDREN ${id}`);
+		// TODO: handle truncation case (getChildren calls LMS)
+		if (!id) {
+			const rootOrgUnit = this.data.serverData.orgUnits.filter(x => x[PARENTS].includes(0))[0];
+			id = rootOrgUnit && rootOrgUnit[ID];
+		}
+
+		if (!id) {
+			return [];
+		}
+
+		return this._tree[id][CHILDREN]
+			.map(childId => this._tree[childId])
+			.filter(x => x[TYPE] !== SEMESTER_TYPE)
+			.map(x => ({
+				name: `${x[NAME]} (${x[ID]})`,
+				// pre-load down to any selected descendents: otherwise selecting then deselecting this node
+				// before opening it won't deselect them
+				// we could open them here, too, if desired
+				tree: (x[TYPE] !== 3 && x[STATE] === 'indeterminate') ? this._getChildren(x[ID]) : null,
+				getTree: (x[TYPE] === 3 || x[STATE] === 'indeterminate') ? null : async() => this._getChildren(x[ID]),
+				selectedState: x[STATE]
+			}));
+	}
+
+	_markSelected(id, isExplicit) {
+		const node = this._tree[id];
+		node[STATE] = isExplicit || node[CHILDREN].every(childId => this._tree[childId][STATE] === 'explicit') ? 'explicit' : 'indeterminate';
+		node[PARENTS].forEach(parentId => parentId !== 0 && this._markSelected(parentId));
 	}
 
 	_onChange() {
@@ -52,6 +81,21 @@ class OuFilter extends MobxLitElement {
 			'change',
 			{bubbles: true, composed: false}
 		));
+	}
+
+	_prepareData() {
+		// index by id
+		// every object gets an additional two fields: an array of children, and a selectedState
+		this._tree = {};
+		this.data.serverData.orgUnits.forEach(x => {
+			this._tree[x[ID]] = [...x, [], 'none'];
+		});
+
+		// fill in arrays of children, so we can look up both parents and children directly
+		this.data.serverData.orgUnits.forEach(x => x[PARENTS].forEach(y => y !== 0 && this._tree[y][CHILDREN].push(x[ID])));
+
+		// mark selected states
+		this.data.serverData.selectedOrgUnitIds.forEach(x => this._markSelected(x, true));
 	}
 }
 customElements.define('d2l-insights-ou-filter', OuFilter);

--- a/components/ou-filter.js
+++ b/components/ou-filter.js
@@ -39,7 +39,11 @@ class OuFilter extends MobxLitElement {
 		this._prepareData();
 
 		return html`<div class="ou-filter" ?loading="${this.data.isLoading}">
-			<d2l-insights-tree-selector id="ou-tree-selector" name="Org Unit" .tree="${this._getChildren()}" @d2l-insights-tree-selector-change="${this._onChange}">
+			<d2l-insights-tree-selector id="ou-tree-selector"
+				name="Org Unit"
+				.tree="${this._getChildren()}"
+				@d2l-insights-tree-selector-change="${this._onChange}"
+			></d2l-insights-tree-selector>
 		</div>`;
 	}
 

--- a/components/ou-filter.js
+++ b/components/ou-filter.js
@@ -12,6 +12,9 @@ const STATE = 5;
 
 const SEMESTER_TYPE = 5;
 
+/**
+ * @property {Object} data - an instance of Data from model/data.js
+ */
 class OuFilter extends MobxLitElement {
 
 	static get properties() {
@@ -35,18 +38,16 @@ class OuFilter extends MobxLitElement {
 		this._prepareData();
 
 		return html`<div class="ou-filter" ?loading="${this.data.isLoading}">
-			<d2l-insights-tree-selector id="ou-tree-selector" .tree="${this._getChildren()}" @change="${this._onChange}">
+			<d2l-insights-tree-selector id="ou-tree-selector" name="Org Unit" .tree="${this._getChildren()}" @change="${this._onChange}">
 		</div>`;
 	}
 
 	get selected() {
-		return this.shadowRoot.getElementById('ou-tree-selector')
-			.selected;
+		return this.shadowRoot.getElementById('ou-tree-selector').selected;
 	}
 
 	_getChildren(id) {
-		console.log(`GET CHILDREN ${id}`);
-		// TODO: handle truncation case (getChildren calls LMS)
+		// coming soon: handle truncation case (getChildren calls LMS)
 		if (!id) {
 			const rootOrgUnit = this.data.serverData.orgUnits.filter(x => x[PARENTS].includes(0))[0];
 			id = rootOrgUnit && rootOrgUnit[ID];
@@ -63,11 +64,11 @@ class OuFilter extends MobxLitElement {
 				name: `${x[NAME]} (${x[ID]})`,
 				// pre-load down to any selected descendents: otherwise selecting then deselecting this node
 				// before opening it won't deselect them
-				// we could open them here, too, if desired
 				tree: (x[TYPE] !== 3 && x[STATE] === 'indeterminate') ? this._getChildren(x[ID]) : null,
 				getTree: (x[TYPE] === 3 || x[STATE] === 'indeterminate') ? null : async() => this._getChildren(x[ID]),
 				selectedState: x[STATE]
-			}));
+			}))
+			.sort((a, b) => a.name.localeCompare(b.name));
 	}
 
 	_markSelected(id, isExplicit) {
@@ -95,7 +96,7 @@ class OuFilter extends MobxLitElement {
 		this.data.serverData.orgUnits.forEach(x => x[PARENTS].forEach(y => y !== 0 && this._tree[y][CHILDREN].push(x[ID])));
 
 		// mark selected states
-		this.data.serverData.selectedOrgUnitIds.forEach(x => this._markSelected(x, true));
+		this.data.serverData.selectedOrgUnitIds && this.data.serverData.selectedOrgUnitIds.forEach(x => this._markSelected(x, true));
 	}
 }
 customElements.define('d2l-insights-ou-filter', OuFilter);

--- a/components/ou-filter.js
+++ b/components/ou-filter.js
@@ -14,6 +14,7 @@ const SEMESTER_TYPE = 5;
 
 /**
  * @property {Object} data - an instance of Data from model/data.js
+ * @fires d2l-insights-ou-filter-change
  */
 class OuFilter extends MobxLitElement {
 
@@ -38,7 +39,7 @@ class OuFilter extends MobxLitElement {
 		this._prepareData();
 
 		return html`<div class="ou-filter" ?loading="${this.data.isLoading}">
-			<d2l-insights-tree-selector id="ou-tree-selector" name="Org Unit" .tree="${this._getChildren()}" @change="${this._onChange}">
+			<d2l-insights-tree-selector id="ou-tree-selector" name="Org Unit" .tree="${this._getChildren()}" @d2l-insights-tree-selector-change="${this._onChange}">
 		</div>`;
 	}
 
@@ -61,7 +62,7 @@ class OuFilter extends MobxLitElement {
 			.map(childId => this._tree[childId])
 			.filter(x => x[TYPE] !== SEMESTER_TYPE)
 			.map(x => ({
-				name: `${x[NAME]} (${x[ID]})`,
+				name: `${x[NAME]} (Id: ${x[ID]})`,
 				// pre-load down to any selected descendents: otherwise selecting then deselecting this node
 				// before opening it won't deselect them
 				tree: (x[TYPE] !== 3 && x[STATE] === 'indeterminate') ? this._getChildren(x[ID]) : null,
@@ -78,8 +79,11 @@ class OuFilter extends MobxLitElement {
 	}
 
 	_onChange() {
+		/**
+		 * @event d2l-insights-ou-filter-change
+		 */
 		this.dispatchEvent(new CustomEvent(
-			'change',
+			'd2l-insights-ou-filter-change',
 			{bubbles: true, composed: false}
 		));
 	}

--- a/components/tree-selector-node.js
+++ b/components/tree-selector-node.js
@@ -1,0 +1,191 @@
+import '@brightspace-ui/core/components/inputs/input-checkbox';
+
+import {css, html, LitElement} from 'lit-element/lit-element.js';
+
+class TreeSelectorNode extends LitElement {
+
+	static get properties() {
+		return {
+			// todo: https://github.com/BrightspaceUI/guide/wiki/LitElement-Best-Practices-&-Gotchas#-do-use-correct-casing-for-attributes-and-properties
+			name: { type: String },
+			// an array of objects with properties name, [children], getChildren, isOpen, isExplicitlySelected
+			// used to initialize, but not updated after
+			tree: { type: Object, attribute: false },
+			getChildren: { type: Object, attribute: false },
+			// if true, children are loaded (if needed) and shown; if false, children are rendered but hidden
+			isOpen: { type: Boolean, reflect: true },
+			// "explicit", "implicit", "indeterminate", or "none"
+			selectedState: { type: String, reflect: true }
+		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			
+			d2l-input-checkbox {
+				display: inline-block;
+			}
+			.arrow:before {
+				content: "> "
+			}
+			.arrow[open]:before {
+				content: "v "
+			}
+			
+			.subtree {
+				margin-left: 30px;
+			}
+			.subtree[root] {
+				margin-left: 0px;
+			}
+			.subtree[hidden] {
+				display: none;
+			}
+		`;
+	}
+
+	constructor() {
+		super();
+
+		this.isOpen = false;
+		this.selectedState = 'none';
+	}
+
+	render() {
+		return html`
+			${this._renderNode()}
+			${this._renderSubtree()}
+		`;
+	}
+
+	get selected() {
+		if (this.selectedState === 'explicit') {
+			return [this];
+		}
+
+		return this._domChildren.flatMap(x => x.selected);
+	}
+
+	get _domChildren() {
+		const subtree_ = this.shadowRoot.getElementById('subtree');
+		return subtree_ ? [...subtree_.children] : [];
+	}
+
+	_getChildSelectedState(i) {
+		if (this._showSelected) return 'implicit';
+
+		const currentState = (this._domChildren[i] || {}).selectedState || 'none';
+		return currentState === 'implicit' ? 'none' : currentState;
+	}
+
+	get _isRoot() {
+		return !this.name;
+	}
+
+	async _onArrowClick() {
+		this.isOpen = !this.isOpen;
+
+		// lazy load children if needed
+		if (this.isOpen && !this.tree && this.getChildren) {
+			this.tree = await this.getChildren();
+		}
+	}
+
+	_onChange(e) {
+		this.selectedState = e.target.checked ? 'explicit' : 'none';
+
+		this.dispatchEvent(new CustomEvent(
+			'change',
+			{bubbles: true, composed: false}
+		));
+	}
+
+	_onSubtreeChange() {
+		if (!this._isRoot) {
+			const children = this._domChildren;
+
+			// if children were implicitly selected (i.e. this node was shown selected), and
+			// a node has been deselected, explicitly select the other children so just the
+			// one gets unchecked
+			if (this._showSelected) {
+				children.forEach(x => {
+					if (x.selectedState === 'implicit') {
+						x.selectedState = 'explicit';
+					}
+				});
+			}
+
+			// update selected state of this node based on that of its children
+			// if (children.every(x => x.isExplicitlySelected)) {
+			if (children.every(x => x.selectedState === 'explicit')) {
+				this.selectedState = 'explicit';
+			} else if (children.some(x => x.selectedState === 'explicit')) {
+				this.selectedState = 'indeterminate';
+			} else {
+				this.selectedState = children.some(x => x.selectedState === 'indeterminate') ? 'indeterminate' : 'none';
+			}
+		}
+
+		this.dispatchEvent(new CustomEvent(
+			'change',
+			{bubbles: true, composed: false}
+		));
+	}
+
+	_renderArrowControl() {
+		// show the open/close arrow if this is not a leaf
+		if (this.isOpen || this.tree || this.getChildren) {
+			return html`<span class="arrow" ?open="${this.isOpen}" @click="${this._onArrowClick}"></span>`;
+		} else {
+			return html``;
+		}
+	}
+
+	_renderNode() {
+		if (this._isRoot) {
+			return html``;
+		}
+
+		return html`
+			${this._renderArrowControl()}
+			<d2l-input-checkbox
+				?checked="${this._showSelected}"
+				?indeterminate="${this._showIndeterminate}"
+				@change="${this._onChange}"
+			>${this.name}</d2l-input-checkbox>`;
+	}
+
+	_renderSubtree() {
+		if (this.tree) {
+			return html`<div class="subtree" ?hidden="${!this._isRoot && !this.isOpen}" id="subtree" ?root="${this._isRoot}">${this.tree.map((x, i) =>
+				html`<d2l-insights-tree-selector-node
+					name="${x.name}"
+					.tree="${x.children}"
+					.getChildren="${x.getChildren}"
+					?isOpen="${x.isOpen}"
+					selectedState="${this._getChildSelectedState(i)}"
+					@change="${this._onSubtreeChange}"
+				></d2l-insights-tree-selector-node>`
+			)}</div>`;
+		} else {
+			return html``;
+		}
+	}
+
+	get _showIndeterminate() {
+		// return this.isIndeterminate && !this.showSelected;
+		return this.selectedState === 'indeterminate';
+	}
+
+	get _showSelected() {
+		// return this.isExplicitlySelected || this.isImplicitlySelected;
+		return this.selectedState === 'explicit' || this.selectedState === 'implicit';
+	}
+}
+customElements.define('d2l-insights-tree-selector-node', TreeSelectorNode);

--- a/components/tree-selector-node.js
+++ b/components/tree-selector-node.js
@@ -2,15 +2,15 @@ import '@brightspace-ui/core/components/inputs/input-checkbox';
 
 import {css, html, LitElement} from 'lit-element/lit-element.js';
 
+/**
+ * @property {string} name
+ * @property {{name: string, tree:{}[], getTree: function, isOpen: boolean, selectedState: string}[]} tree - used to initialize, but will not be updated
+ * @property {function} getTree - async callback which should return the tree (provide either tree or getTree)
+ * @property {boolean} isOpen
+ * @property {string} selectedState - may be "explicit", "implicit", "indeterminate", or "none"
+ * @fires change - value of this.selected has changed
+ */
 class TreeSelectorNode extends LitElement {
-	/**
-	 * @property {string} name
-	 * @property {{name: string, tree:{}[], getTree: function, isOpen: boolean, selectedState: string}[]} tree - used to initialize, but will not be updated
-	 * @property {function} getTree - async callback which should return the tree (provide either tree or getTree)
-	 * @property {boolean} isOpen
-	 * @property {boolean} selectedState - may be "explicit", "implicit", "indeterminate", or "none"
-	 * @fires change - value of this.selected has changed
-	 */
 	static get properties() {
 		return {
 			name: { type: String },
@@ -22,7 +22,6 @@ class TreeSelectorNode extends LitElement {
 	}
 
 	static get styles() {
-		// TODO: fix indent on childless nodes
 		return css`
 			:host {
 				display: block;
@@ -39,6 +38,9 @@ class TreeSelectorNode extends LitElement {
 			}
 			.arrow[open]:before {
 				content: "v "
+			}
+			.no-arrow {
+				margin-left: 15px
 			}
 			
 			.subtree {
@@ -136,10 +138,10 @@ class TreeSelectorNode extends LitElement {
 			// if (children.every(x => x.isExplicitlySelected)) {
 			if (children.every(x => x.selectedState === 'explicit')) {
 				this.selectedState = 'explicit';
-			} else if (children.some(x => x.selectedState === 'explicit')) {
+			} else if (children.some(x => x.selectedState === 'explicit' || x.selectedState === 'indeterminate')) {
 				this.selectedState = 'indeterminate';
 			} else {
-				this.selectedState = children.some(x => x.selectedState === 'indeterminate') ? 'indeterminate' : 'none';
+				this.selectedState = 'none';
 			}
 		}
 
@@ -154,7 +156,7 @@ class TreeSelectorNode extends LitElement {
 		if (this.isOpen || this.tree || this.getTree) {
 			return html`<span class="arrow" ?open="${this.isOpen}" @click="${this._onArrowClick}"></span>`;
 		} else {
-			return html``;
+			return html`<span class="no-arrow"></span>`;
 		}
 	}
 

--- a/components/tree-selector.js
+++ b/components/tree-selector.js
@@ -1,18 +1,21 @@
 import './tree-selector-node.js';
-import '@brightspace-ui/core/components/inputs/input-checkbox';
+import '@brightspace-ui/core/components/dropdown/dropdown-content';
+import '@brightspace-ui/core/components/dropdown/dropdown';
 
 import {css, html, LitElement} from 'lit-element/lit-element.js';
-
+/**
+ * @property {string} name
+ * @property {{name: string, tree:{}[], getTree: function, isOpen: boolean, selectedState: string}[]} tree - used to initialize, but will not be updated
+ * tree - an array of the same form
+ * getTree - is async callback which should return the tree (provide either tree or getTree for each node)
+ * selectedState - may be "explicit", "implicit", "indeterminate", or "none"
+ * @fires change - value of this.selected has changed
+ */
 class TreeSelector extends LitElement {
 
 	static get properties() {
 		return {
-			/**
-			 * an array of nodes
-			 * each node is an object with properties name, children, getChildren, isOpen, isExplicitlySelected
-			 * where children is an array of the same and getChildren is an async method which should return the
-			 * children of the node or an empty array. All properties but "name" are optional.
-			 */
+			name: { type: String },
 			tree: { type: Object, attribute: false }
 		};
 	}
@@ -43,12 +46,20 @@ class TreeSelector extends LitElement {
 	}
 
 	render() {
-		// TODO: drop-down & list selected
-		return html`<d2l-insights-tree-selector-node
-			id="tree-selector-root-node"
-			.tree="${this.tree}"
-			@change="${this._onChange}"
-		  ></d2l-insights-tree-selector-node>`;
+		return html`
+			<d2l-dropdown>
+				<button class="d2l-dropdown-opener d2l-input-select" aria-label="Open ${this.name} filter">
+					${this.name}
+				</button>
+				<d2l-dropdown-content align="start">
+					<d2l-insights-tree-selector-node
+						id="tree-selector-root-node"
+						.tree="${this.tree}"
+						@change="${this._onChange}"
+					></d2l-insights-tree-selector-node>
+				</d2l-dropdown-content>
+			</d2l-dropdown>
+		`;
 	}
 
 	get selected() {
@@ -56,6 +67,9 @@ class TreeSelector extends LitElement {
 	}
 
 	_onChange() {
+		/**
+		 * @event change
+		 */
 		this.dispatchEvent(new CustomEvent(
 			'change',
 			{bubbles: true, composed: false}

--- a/components/tree-selector.js
+++ b/components/tree-selector.js
@@ -1,0 +1,65 @@
+import './tree-selector-node.js';
+import '@brightspace-ui/core/components/inputs/input-checkbox';
+
+import {css, html, LitElement} from 'lit-element/lit-element.js';
+
+class TreeSelector extends LitElement {
+
+	static get properties() {
+		return {
+			/**
+			 * an array of nodes
+			 * each node is an object with properties name, children, getChildren, isOpen, isExplicitlySelected
+			 * where children is an array of the same and getChildren is an async method which should return the
+			 * children of the node or an empty array. All properties but "name" are optional.
+			 */
+			tree: { type: Object, attribute: false }
+		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: inline-block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			
+			d2l-input-checkbox {
+				display: inline-block;
+			}
+			.arrow:before {
+				content: "> "
+			}
+			.arrow[open]:before {
+				content: "v "
+			}
+			
+			.subtree {
+				margin-left: 30px;
+			}
+		`;
+	}
+
+	render() {
+		// TODO: drop-down & list selected
+		return html`<d2l-insights-tree-selector-node
+			id="tree-selector-root-node"
+			.tree="${this.tree}"
+			@change="${this._onChange}"
+		  ></d2l-insights-tree-selector-node>`;
+	}
+
+	get selected() {
+		return this.shadowRoot.getElementById('tree-selector-root-node').selected;
+	}
+
+	_onChange() {
+		this.dispatchEvent(new CustomEvent(
+			'change',
+			{bubbles: true, composed: false}
+		));
+	}
+}
+customElements.define('d2l-insights-tree-selector', TreeSelector);

--- a/components/tree-selector.js
+++ b/components/tree-selector.js
@@ -9,7 +9,7 @@ import {css, html, LitElement} from 'lit-element/lit-element.js';
  * tree - an array of the same form
  * getTree - is async callback which should return the tree (provide either tree or getTree for each node)
  * selectedState - may be "explicit", "implicit", "indeterminate", or "none"
- * @fires change - value of this.selected has changed
+ * @fires d2l-insights-tree-selector-change - value of this.selected has changed
  */
 class TreeSelector extends LitElement {
 
@@ -48,14 +48,13 @@ class TreeSelector extends LitElement {
 	render() {
 		return html`
 			<d2l-dropdown>
-				<button class="d2l-dropdown-opener d2l-input-select" aria-label="Open ${this.name} filter">
-					${this.name}
-				</button>
+				<button class="d2l-dropdown-opener d2l-input-select" aria-label="Open ${this.name} filter">${this.name}</button>
 				<d2l-dropdown-content align="start">
 					<d2l-insights-tree-selector-node
 						id="tree-selector-root-node"
 						.tree="${this.tree}"
-						@change="${this._onChange}"
+						root
+						@d2l-insights-tree-selector-change="${this._onChange}"
 					></d2l-insights-tree-selector-node>
 				</d2l-dropdown-content>
 			</d2l-dropdown>
@@ -68,10 +67,10 @@ class TreeSelector extends LitElement {
 
 	_onChange() {
 		/**
-		 * @event change
+		 * @event d2l-insights-tree-selector-change
 		 */
 		this.dispatchEvent(new CustomEvent(
-			'change',
+			'd2l-insights-tree-selector-change',
 			{bubbles: true, composed: false}
 		));
 	}

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,7 +16,7 @@
 		<d2l-demo-page page-title="d2l-insights-engagement-dashboard">
 			<h2>d2l-insights-engagement-dashboard</h2>
 			<d2l-demo-snippet>
-				<d2l-insights-engagement-dashboard></d2l-insights-engagement-dashboard>
+				<d2l-insights-engagement-dashboard use-test-data></d2l-insights-engagement-dashboard>
 			</d2l-demo-snippet>
 		</d2l-demo-page>
 	</body>

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -62,12 +62,14 @@ class EngagementDashboard extends LocalizeMixin(LitElement) {
 						orgUnits: [
 							[1, 'Course 1', 3, [3, 4]],
 							[2, 'Course 2', 3, [3, 4]],
-							[3, 'Department', 2, [5]],
+							[6, 'Course 3', 3, [7, 4]],
+							[3, 'Department 1', 2, [5]],
+							[7, 'Department 2', 2, [5]],
 							[4, 'Semester', 5, [6606]],
 							[5, 'Faculty', 7, [6606]],
 							[6606, 'Dev', 1, [0]]
 						],
-						selectedOrgUnits: [2]
+						selectedOrgUnitIds: [2]
 					}),
 					100
 				)

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -1,8 +1,9 @@
 import './components/histogram-card.js';
 import './components/summary-card.js';
+import './components/ou-filter.js';
 
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { Data, Histogram } from './model/data.js';
+import { Data } from './model/data.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 
 class EngagementDashboard extends LocalizeMixin(LitElement) {
@@ -53,21 +54,33 @@ class EngagementDashboard extends LocalizeMixin(LitElement) {
 
 		// just some demo data with a delay to simulate an API call
 		this._data = new Data({
+			// TODO: call API
 			recordProvider: () => new Promise(resolve =>
 				setTimeout(
-					() => resolve([{n: 1, dn: 1, u: 1}, {n: 2, dn: 5, u: 2}, {n: 4, dn: 3, u: 3}, {n: 4, dn: 4, u: 3}]),
-					1000
+					() => resolve({
+						records: [{UserId: 1, OrgUnitId: 1}, {UserId: 2, OrgUnitId: 1}, {UserId: 2, OrgUnitId: 2}],
+						orgUnits: [
+							[1, 'Course 1', 3, [3, 4]],
+							[2, 'Course 2', 3, [3, 4]],
+							[3, 'Department', 2, [5]],
+							[4, 'Semester', 5, [6606]],
+							[5, 'Faculty', 7, [6606]],
+							[6606, 'Dev', 1, [0]]
+						],
+						selectedOrgUnits: [2]
+					}),
+					100
 				)
 			),
 			filters: [
-				{id: 'engagement-demo-summary', field: 'n', deltaField: 'dn', threshold: 3, countUniqueField: 'u',
-					title: 'too few n', messageProvider: data => `users with n < ${data.threshold}`},
-				{id: 'engagement-other-demo-summary', field: 'dn', deltaField: 'n', threshold: 1, countUniqueField: 'u',
-					title: 'fewer matches', messageProvider: data => `notice the cross-filtering because threshold is ${data.threshold}`}
+				{
+					id: 'd2l-insights-engagement-summary',
+					title: 'Summary',
+					countUniqueField: 'UserId',
+					messageProvider: () => 'users'
+				}
 			]
 		});
-
-		this.histogram = new Histogram({id: 'engagement-demo-chart', field: 'n', title: 'distribution of n'}, this._data);
 	}
 
 	render() {
@@ -75,11 +88,17 @@ class EngagementDashboard extends LocalizeMixin(LitElement) {
 		return html`
 				<h2>Hello ${this.prop1}!</h2>
 				<div>Localization Example: ${this.localize('myLangTerm')}</div>
+				<div class="view-filters-container">
+					<d2l-insights-ou-filter .data="${this._data}" @change="${this._onOuFilterChange}"></d2l-insights-ou-filter>
+				</div>
 				<div class="summary-container">
 					${Object.values(this._data.filters).map(f => html`<d2l-labs-summary-card id="${f.id}" .data="${f}"></d2l-labs-summary-card>`)}
-					<d2l-labs-histogram-card id="${this.histogram.id}" .data="${this.histogram}"></d2l-labs-histogram-card>
 				</div>
 		`;
+	}
+
+	_onOuFilterChange(e) {
+		console.log(`got ou filter change with selected nodes ${JSON.stringify(e.target.selected.map(x => x.name))}`);
 	}
 }
 customElements.define('d2l-insights-engagement-dashboard', EngagementDashboard);

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -1,15 +1,47 @@
 import './components/histogram-card.js';
-import './components/summary-card.js';
 import './components/ou-filter.js';
+import './components/summary-card.js';
 
-import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { Data } from './model/data.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import {css, html, LitElement} from 'lit-element/lit-element.js';
+import {Data} from './model/data.js';
+import {LocalizeMixin} from '@brightspace-ui/core/mixins/localize-mixin.js';
 
+async function fetchData() {
+	const response = await fetch('/d2l/api/ap/unstable/insights/data/engagement');
+	return await response.json();
+}
+
+async function testData() {
+	return new Promise(resolve =>
+		setTimeout(
+			() => resolve({
+				records: [{UserId: 1, OrgUnitId: 1}, {UserId: 2, OrgUnitId: 1}, {UserId: 2, OrgUnitId: 2}],
+				orgUnits: [
+					[1, 'Course 1', 3, [3, 4]],
+					[2, 'Course 2', 3, [3, 4]],
+					[6, 'Course 3', 3, [7, 4]],
+					[8, 'Course 4', 3, [5]],
+					[3, 'Department 1', 2, [5]],
+					[7, 'Department 2', 2, [5]],
+					[4, 'Semester', 5, [6606]],
+					[5, 'Faculty', 7, [6606]],
+					[6606, 'Dev', 1, [0]]
+				],
+				selectedOrgUnitIds: [2]
+			}),
+			100
+		)
+	);
+}
+
+/**
+ * @property {Boolean} useTestData - if true, use canned data; otherwise call the LMS
+ */
 class EngagementDashboard extends LocalizeMixin(LitElement) {
 
 	static get properties() {
 		return {
+			useTestData: { type: Boolean, attribute: 'use-test-data' }
 		};
 	}
 
@@ -49,31 +81,9 @@ class EngagementDashboard extends LocalizeMixin(LitElement) {
 		return null;
 	}
 
-	constructor() {
-		super();
-
-		// just some demo data with a delay to simulate an API call
+	render() {
 		this._data = new Data({
-			// TODO: call API
-			recordProvider: () => new Promise(resolve =>
-				setTimeout(
-					() => resolve({
-						records: [{UserId: 1, OrgUnitId: 1}, {UserId: 2, OrgUnitId: 1}, {UserId: 2, OrgUnitId: 2}],
-						orgUnits: [
-							[1, 'Course 1', 3, [3, 4]],
-							[2, 'Course 2', 3, [3, 4]],
-							[6, 'Course 3', 3, [7, 4]],
-							[3, 'Department 1', 2, [5]],
-							[7, 'Department 2', 2, [5]],
-							[4, 'Semester', 5, [6606]],
-							[5, 'Faculty', 7, [6606]],
-							[6606, 'Dev', 1, [0]]
-						],
-						selectedOrgUnitIds: [2]
-					}),
-					100
-				)
-			),
+			recordProvider: this.useTestData ? testData : fetchData,
 			filters: [
 				{
 					id: 'd2l-insights-engagement-summary',
@@ -83,12 +93,8 @@ class EngagementDashboard extends LocalizeMixin(LitElement) {
 				}
 			]
 		});
-	}
 
-	render() {
-		console.log('engagement-dashboard render');
 		return html`
-				<h2>Hello ${this.prop1}!</h2>
 				<div>Localization Example: ${this.localize('myLangTerm')}</div>
 				<div class="view-filters-container">
 					<d2l-insights-ou-filter .data="${this._data}" @change="${this._onOuFilterChange}"></d2l-insights-ou-filter>

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -104,9 +104,8 @@ class EngagementDashboard extends LocalizeMixin(LitElement) {
 
 				<div>Localization Example: ${this.localize('myLangTerm')}</div>
 				<div class="view-filters-container">
-					<d2l-insights-ou-filter .data="${this._data}" @d2l-insights-ou-filter-change="${this._onOuFilterChange}"></d2l-insights-ou-filter>
-					
-				<d2l-insights-role-filter @d2l-insights-role-filter-change="${this._handleRoleSelectionsUpdated}"></d2l-insights-role-filter>
+					<d2l-insights-ou-filter .data="${this._data}" @d2l-insights-ou-filter-change="${this._onOuFilterChange}"></d2l-insights-ou-filter>					
+					<d2l-insights-role-filter @d2l-insights-role-filter-change="${this._handleRoleSelectionsUpdated}" ?demo="${this.useTestData}"></d2l-insights-role-filter>
 				</div>
 				<div class="summary-container">
 					${Object.values(this._data.filters).map(f => html`<d2l-labs-summary-card id="${f.id}" .data="${f}"></d2l-labs-summary-card>`)}

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -24,10 +24,11 @@ async function testData() {
 					[3, 'Department 1', 2, [5]],
 					[7, 'Department 2', 2, [5]],
 					[4, 'Semester', 5, [6606]],
-					[5, 'Faculty', 7, [6606]],
+					[5, 'Faculty 1', 7, [6606]],
+					[9, 'Faculty 2', 7, [6606]],
 					[6606, 'Dev', 1, [0]]
 				],
-				selectedOrgUnitIds: [2]
+				selectedOrgUnitIds: [1, 2]
 			}),
 			100
 		)
@@ -85,19 +86,19 @@ class EngagementDashboard extends LocalizeMixin(LitElement) {
 		this._data = new Data({
 			recordProvider: this.useTestData ? testData : fetchData,
 			filters: [
-				{
-					id: 'd2l-insights-engagement-summary',
-					title: 'Summary',
-					countUniqueField: 'UserId',
-					messageProvider: () => 'users'
-				}
+				// {
+				// 	id: 'd2l-insights-engagement-summary',
+				// 	title: 'Summary',
+				// 	countUniqueField: 'UserId',
+				// 	messageProvider: () => 'users'
+				// }
 			]
 		});
 
 		return html`
 				<div>Localization Example: ${this.localize('myLangTerm')}</div>
 				<div class="view-filters-container">
-					<d2l-insights-ou-filter .data="${this._data}" @change="${this._onOuFilterChange}"></d2l-insights-ou-filter>
+					<d2l-insights-ou-filter .data="${this._data}" @d2l-insights-ou-filter-change="${this._onOuFilterChange}"></d2l-insights-ou-filter>
 				</div>
 				<div class="summary-container">
 					${Object.values(this._data.filters).map(f => html`<d2l-labs-summary-card id="${f.id}" .data="${f}"></d2l-labs-summary-card>`)}

--- a/model/data.js
+++ b/model/data.js
@@ -57,7 +57,8 @@ export class Data {
 		this.serverData = {
 			records: [],
 			orgUnits: [],
-			users: []
+			users: [],
+			selectedOrgUnitIds: []
 		};
 		filters
 			.map(params => new Filter(params, this))
@@ -72,16 +73,6 @@ export class Data {
 			this.serverData = data;
 			this.isLoading = false;
 		});
-	}
-
-	getChildren(orgUnitId) {
-		if (!orgUnitId) {
-			const rootOrgUnit = this.serverData.orgUnits.filter(x => x[3].includes(0))[0];
-			orgUnitId = rootOrgUnit && rootOrgUnit[0]; // todo: constants for indices
-		}
-		// TODO: filter out semesters
-		// TODO: consider moving this logic to OuFilter
-		return this.serverData.orgUnits.filter(x => x[3].includes(orgUnitId));
 	}
 
 	getRecordsInView(id) {
@@ -117,7 +108,6 @@ export class Data {
 	}
 
 	_persist() {
-		console.log('persist');
 		localStorage.setItem('d2l-insights-engagement-dashboard.state', JSON.stringify(
 			Object.keys(this.filters)
 				.map(f => ({id: f, applied: this.filters[f].isApplied}))

--- a/model/data.js
+++ b/model/data.js
@@ -13,14 +13,14 @@ export class Histogram {
 		this.data = data;
 	}
 
+	get isLoading() {
+		return this.data.isLoading;
+	}
+
 	get series() {
 		const dataByU = {};
 		this.data.getRecordsInView(this.id).forEach(r => dataByU[r[this.field]] = [...dataByU[r[this.field]] || [], r]);
 		return Object.keys(dataByU).sort().map(k => dataByU[k].length);
-	}
-
-	get isLoading() {
-		return this.data.isLoading;
 	}
 }
 
@@ -37,6 +37,10 @@ export class Filter {
 		this.isApplied = isApplied;
 	}
 
+	get isLoading() {
+		return this.data.isLoading;
+	}
+
 	get message() {
 		return this.messageProvider(this);
 	}
@@ -44,17 +48,17 @@ export class Filter {
 	get stats() {
 		return this.data.getStats(this.id);
 	}
-
-	get isLoading() {
-		return this.data.isLoading;
-	}
 }
 
 export class Data {
 	constructor({recordProvider, filters}) {
 		this.isLoading = true;
-		this.records = [];
 		this.filters = {};
+		this.serverData = {
+			records: [],
+			orgUnits: [],
+			users: []
+		};
 		filters
 			.map(params => new Filter(params, this))
 			.forEach(f => this.filters[f.id] = f);
@@ -64,14 +68,26 @@ export class Data {
 		// mobx will run _persist() whenever relevant state changes
 		autorun(() => this._persist());
 
-		recordProvider().then(records => {
-			this.records = records;
+		recordProvider().then(data => {
+			this.serverData = data;
 			this.isLoading = false;
 		});
 	}
 
-	setApplied(id, isApplied) {
-		if (this.filters[id]) this.filters[id].isApplied = isApplied;
+	getChildren(orgUnitId) {
+		if (!orgUnitId) {
+			const rootOrgUnit = this.serverData.orgUnits.filter(x => x[3].includes(0))[0];
+			orgUnitId = rootOrgUnit && rootOrgUnit[0]; // todo: constants for indices
+		}
+		// TODO: filter out semesters
+		// TODO: consider moving this logic to OuFilter
+		return this.serverData.orgUnits.filter(x => x[3].includes(orgUnitId));
+	}
+
+	getRecordsInView(id) {
+		// if id is omitted, all applied filters will be used
+		const otherFilters = Object.values(this.filters).filter(f => f.isApplied && f.id !== id);
+		return this.serverData.records.filter(r => otherFilters.every(f => r[f.field] < f.threshold));
 	}
 
 	getStats(id) {
@@ -79,28 +95,25 @@ export class Data {
 
 		const filter = this.filters[id];
 
-		const matchingRecords = recordsInView.filter(r => r[filter.field] < filter.threshold);
+		// NB: due to compact API response, we'll need to map field names to array indices
+		const matchingRecords = recordsInView.filter(r => !filter.field || (r[filter.field] < filter.threshold));
 		const value = countUnique(matchingRecords, filter.countUniqueField);
 
-		const deltaMatchingRecords = recordsInView.filter(r => r[filter.deltaField] < filter.threshold);
-		const oldValue = countUnique(deltaMatchingRecords, filter.countUniqueField);
+		let delta = null;
+		if (filter.deltaField) {
+			const deltaMatchingRecords = recordsInView.filter(r => r[filter.deltaField] < filter.threshold);
+			const oldValue = countUnique(deltaMatchingRecords, filter.countUniqueField);
+			delta = value - oldValue;
+		}
 
 		return {
 			value,
-			delta: value - oldValue
+			delta
 		};
 	}
 
-	getRecordsInView(id) {
-		// if id is omitted, all applied filters will be used
-		const otherFilters = Object.values(this.filters).filter(f => f.isApplied && f.id !== id);
-		return this.records.filter(r => otherFilters.every(f => r[f.field] < f.threshold));
-	}
-
-	_restore() {
-		// this might be better handled by url-rewriting
-		const state = JSON.parse(localStorage.getItem('d2l-insights-engagement-dashboard.state') || '[]');
-		state.forEach(filterState => this.setApplied(filterState.id, filterState.applied));
+	setApplied(id, isApplied) {
+		if (this.filters[id]) this.filters[id].isApplied = isApplied;
 	}
 
 	_persist() {
@@ -109,6 +122,12 @@ export class Data {
 			Object.keys(this.filters)
 				.map(f => ({id: f, applied: this.filters[f].isApplied}))
 		));
+	}
+
+	_restore() {
+		// this might be better handled by url-rewriting
+		const state = JSON.parse(localStorage.getItem('d2l-insights-engagement-dashboard.state') || '[]');
+		state.forEach(filterState => this.setApplied(filterState.id, filterState.applied));
 	}
 }
 
@@ -133,7 +152,7 @@ decorate(Filter, {
 });
 
 decorate(Data, {
-	records: observable,
+	serverData: observable,
 	filters: observable,
 	isLoading: observable,
 	setApplied: action

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@brightspace/d2l-engagement-dashboard",
+  "name": "d2l-engagement-dashboard",
   "version": "0.0.2",
   "description": "D2L Insights Engagement Dashboard",
   "repository": "https://github.com/Brightspace/insights-engagement-dashboard.git",

--- a/test/components/ou-filter.test.js
+++ b/test/components/ou-filter.test.js
@@ -66,7 +66,8 @@ describe('d2l-insights-ou-filter', () => {
 	describe('selection', () => {
 		it('should return selected nodes', async() => {
 			const el = await fixture(html`<d2l-insights-ou-filter .data="${data}"></d2l-insights-ou-filter>`);
-			await el.updateComplete;
+			// on Safari only, the children don't finish rendering during the above await
+			await el.shadowRoot.querySelector('d2l-insights-tree-selector').updateComplete;
 			expect(el.selected.map(x => x.name)).to.deep.equal(['Course 2 (Id: 2)', 'Department 2 (Id: 7)']);
 		});
 	});
@@ -74,7 +75,7 @@ describe('d2l-insights-ou-filter', () => {
 	describe('events', () => {
 		it('should fire d2l-insights-ou-filter-change on selection change', async() => {
 			const el = await fixture(html`<d2l-insights-ou-filter .data="${data}"></d2l-insights-ou-filter>`);
-			await el.updateComplete;
+			await el.shadowRoot.querySelector('d2l-insights-tree-selector').updateComplete;
 			const listener = oneEvent(el, 'd2l-insights-ou-filter-change');
 			const childCheckbox = el.shadowRoot.querySelector('d2l-insights-tree-selector')
 				.shadowRoot.querySelector('d2l-insights-tree-selector-node') // hidden root node

--- a/test/components/ou-filter.test.js
+++ b/test/components/ou-filter.test.js
@@ -1,0 +1,87 @@
+import '../../components/ou-filter.js';
+
+import {expect, fixture, html, oneEvent} from '@open-wc/testing';
+import {runConstructor} from '@brightspace-ui/core/tools/constructor-test-helper.js';
+
+describe('d2l-insights-ou-filter', () => {
+	const data = {
+		serverData: {
+			records: [],
+			orgUnits: [
+				[3, 'Department 1', 2, [5]],
+				[2, 'Course 2', 3, [3, 4]],
+				[1, 'Course 1', 3, [3, 4]],
+				[6, 'Course 3', 3, [7, 4]],
+				[9, 'Faculty 2', 7, [6607]],
+				[8, 'Course 4', 3, [5]],
+				[7, 'Department 2', 2, [5]],
+				[4, 'Semester', 5, [6607]],
+				[5, 'Faculty 1', 7, [6607]],
+				[6607, 'Dev', 1, [0]]
+			],
+			users: [],
+			selectedOrgUnitIds: [2, 7]
+		}
+	};
+
+	describe('constructor', () => {
+		it('should construct', () => {
+			runConstructor('d2l-insights-ou-filter');
+		});
+	});
+
+	describe('accessibility', () => {
+		it('should pass all axe tests', async() => {
+			const el = await fixture(html`<d2l-insights-ou-filter .data="${data}"></d2l-insights-ou-filter>`);
+			await expect(el).to.be.accessible();
+		});
+	});
+
+	describe('render', () => {
+		it('should render a tree-selector with the correct data including lazy-loading', async() => {
+			const el = await fixture(html`<d2l-insights-ou-filter .data="${data}"></d2l-insights-ou-filter>`);
+			const selector = el.shadowRoot.querySelector('d2l-insights-tree-selector');
+			expect(selector.tree).to.have.length(2);
+
+			expect(selector.tree[1]).to.include({ name: 'Faculty 2 (Id: 9)', selectedState: 'none', tree: null });
+			expect(selector.tree[1]).to.have.property('getTree');
+			expect(await selector.tree[1].getTree()).to.deep.equal([]);
+
+			expect(selector.tree[0]).to.include({ name: 'Faculty 1 (Id: 5)', selectedState: 'indeterminate', getTree: null });
+			const subtree = selector.tree[0].tree;
+			expect(subtree).to.exist;
+			expect(subtree).to.have.length(3);
+			expect(subtree[0]).to.deep.equal({ name: 'Course 4 (Id: 8)', selectedState: 'none', tree: null, getTree: null });
+			expect(subtree[2]).to.include({ name: 'Department 2 (Id: 7)', selectedState: 'explicit', tree: null });
+			expect(subtree[2]).to.have.property('getTree');
+			expect(await subtree[2].getTree()).to.deep.equal([{ name: 'Course 3 (Id: 6)', selectedState: 'none', tree: null, getTree: null }]);
+
+			expect(subtree[1]).to.deep.equal({ name: 'Department 1 (Id: 3)', selectedState: 'indeterminate', getTree: null, tree: [
+				{ name: 'Course 1 (Id: 1)', selectedState: 'none', tree: null, getTree: null },
+				{ name: 'Course 2 (Id: 2)', selectedState: 'explicit', tree: null, getTree: null }]
+			});
+		});
+	});
+
+	describe('selection', () => {
+		it('should return selected nodes', async() => {
+			const el = await fixture(html`<d2l-insights-ou-filter .data="${data}"></d2l-insights-ou-filter>`);
+			expect(el.selected.map(x => x.name)).to.deep.equal(['Course 2 (Id: 2)', 'Department 2 (Id: 7)']);
+		});
+	});
+
+	describe('events', () => {
+		it('should fire d2l-insights-ou-filter-change on selection change', async() => {
+			const el = await fixture(html`<d2l-insights-ou-filter .data="${data}"></d2l-insights-ou-filter>`);
+			const listener = oneEvent(el, 'd2l-insights-ou-filter-change');
+			const childCheckbox = el.shadowRoot.querySelector('d2l-insights-tree-selector')
+				.shadowRoot.querySelector('d2l-insights-tree-selector-node')
+				.shadowRoot.querySelector('d2l-insights-tree-selector-node')
+				.shadowRoot.querySelector('d2l-input-checkbox');
+			childCheckbox.simulateClick();
+			const event = await listener;
+			expect(event.type).to.equal('d2l-insights-ou-filter-change');
+			expect(event.target).to.equal(el);
+		});
+	});
+});

--- a/test/components/ou-filter.test.js
+++ b/test/components/ou-filter.test.js
@@ -67,7 +67,7 @@ describe('d2l-insights-ou-filter', () => {
 		it('should return selected nodes', async() => {
 			const el = await fixture(html`<d2l-insights-ou-filter .data="${data}"></d2l-insights-ou-filter>`);
 			// on Safari only, the children don't finish rendering during the above await
-			await el.shadowRoot.querySelector('d2l-insights-tree-selector').updateComplete;
+			await new Promise(resolve => setTimeout(resolve, 500));
 			expect(el.selected.map(x => x.name)).to.deep.equal(['Course 2 (Id: 2)', 'Department 2 (Id: 7)']);
 		});
 	});
@@ -75,7 +75,8 @@ describe('d2l-insights-ou-filter', () => {
 	describe('events', () => {
 		it('should fire d2l-insights-ou-filter-change on selection change', async() => {
 			const el = await fixture(html`<d2l-insights-ou-filter .data="${data}"></d2l-insights-ou-filter>`);
-			await el.shadowRoot.querySelector('d2l-insights-tree-selector').updateComplete;
+			// on Safari only, the children don't finish rendering during the above await
+			await new Promise(resolve => setTimeout(resolve, 500));
 			const listener = oneEvent(el, 'd2l-insights-ou-filter-change');
 			const childCheckbox = el.shadowRoot.querySelector('d2l-insights-tree-selector')
 				.shadowRoot.querySelector('d2l-insights-tree-selector-node') // hidden root node

--- a/test/components/ou-filter.test.js
+++ b/test/components/ou-filter.test.js
@@ -66,6 +66,7 @@ describe('d2l-insights-ou-filter', () => {
 	describe('selection', () => {
 		it('should return selected nodes', async() => {
 			const el = await fixture(html`<d2l-insights-ou-filter .data="${data}"></d2l-insights-ou-filter>`);
+			await el.updateComplete;
 			expect(el.selected.map(x => x.name)).to.deep.equal(['Course 2 (Id: 2)', 'Department 2 (Id: 7)']);
 		});
 	});
@@ -73,10 +74,11 @@ describe('d2l-insights-ou-filter', () => {
 	describe('events', () => {
 		it('should fire d2l-insights-ou-filter-change on selection change', async() => {
 			const el = await fixture(html`<d2l-insights-ou-filter .data="${data}"></d2l-insights-ou-filter>`);
+			await el.updateComplete;
 			const listener = oneEvent(el, 'd2l-insights-ou-filter-change');
 			const childCheckbox = el.shadowRoot.querySelector('d2l-insights-tree-selector')
-				.shadowRoot.querySelector('d2l-insights-tree-selector-node')
-				.shadowRoot.querySelector('d2l-insights-tree-selector-node')
+				.shadowRoot.querySelector('d2l-insights-tree-selector-node') // hidden root node
+				.shadowRoot.querySelector('d2l-insights-tree-selector-node') // first child
 				.shadowRoot.querySelector('d2l-input-checkbox');
 			childCheckbox.simulateClick();
 			const event = await listener;

--- a/test/components/tree-selector-node.test.js
+++ b/test/components/tree-selector-node.test.js
@@ -1,0 +1,270 @@
+import '../../components/tree-selector-node.js';
+
+import {expect, fixture, html, oneEvent} from '@open-wc/testing';
+import {runConstructor} from '@brightspace-ui/core/tools/constructor-test-helper.js';
+
+const tree = [
+	{ name: 'child1' },
+	{ name: 'child2', tree:[{ name: 'c2child1' }], selectedState: 'explicit' },
+	{ name: 'child3', getTree: async() => [], isOpen: true }
+];
+
+function getOpenControl(el) {
+	return el.shadowRoot.querySelector('.open-control');
+}
+
+function getCheckbox(el) {
+	return el.shadowRoot.querySelector('d2l-input-checkbox');
+}
+
+function getSubtree(el) {
+	return el.shadowRoot.querySelector('.subtree');
+}
+
+describe('d2l-insights-tree-selector-node', () => {
+	describe('constructor', () => {
+		it('should construct', () => {
+			runConstructor('d2l-insights-tree-selector-node');
+		});
+	});
+
+	describe('accessibility', () => {
+		it('should pass all axe tests', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="some node"></d2l-insights-tree-selector-node>`);
+			await expect(el).to.be.accessible();
+		});
+	});
+
+	describe('render', () => {
+		it('should not render top-level node if root', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node root></d2l-insights-tree-selector-node>`);
+			expect(getCheckbox(el)).to.not.exist;
+		});
+
+		it('should render a childless node without a dropdown control', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="leaf"></d2l-insights-tree-selector-node>`);
+			expect(getOpenControl(el)).to.not.exist;
+		});
+
+		it('should render with a dropdown control given a subtree', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" .tree="${tree}"></d2l-insights-tree-selector-node>`);
+			expect(getOpenControl(el)).to.exist;
+		});
+
+		it('should render with a dropdown control given a tree provider', async() => {
+			const getTree = async() => tree;
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" .getTree="${getTree}"></d2l-insights-tree-selector-node>`);
+			expect(getOpenControl(el)).to.exist;
+		});
+
+		it('should render as not selected', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" selected-state="none"></d2l-insights-tree-selector-node>`);
+			expect(getCheckbox(el).checked).to.be.false;
+			expect(getCheckbox(el).indeterminate).to.be.false;
+		});
+
+		it('should render as indeterminate', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" selected-state="indeterminate"></d2l-insights-tree-selector-node>`);
+			expect(getCheckbox(el).checked).to.be.false;
+			expect(getCheckbox(el).indeterminate).to.be.true;
+		});
+
+		it('should render as checked if explicit', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" selected-state="explicit"></d2l-insights-tree-selector-node>`);
+			expect(getCheckbox(el).checked).to.be.true;
+			expect(getCheckbox(el).indeterminate).to.be.false;
+		});
+
+		it('should render as checked if implicit', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" selected-state="implicit"></d2l-insights-tree-selector-node>`);
+			expect(getCheckbox(el).checked).to.be.true;
+			expect(getCheckbox(el).indeterminate).to.be.false;
+		});
+
+		it('should render as closed by default', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" .tree="${tree}"></d2l-insights-tree-selector-node>`);
+			expect(getSubtree(el).hidden).to.be.true;
+		});
+
+		it('should render as open if specified', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" .tree="${tree}" open></d2l-insights-tree-selector-node>`);
+			expect(getSubtree(el).hidden).to.be.false;
+		});
+
+		[true, false].forEach(isRoot =>
+			it(`should render children as specified (isRoot = ${isRoot})`, async() => {
+				const el = await fixture(html`<d2l-insights-tree-selector-node name="node" .tree="${tree}" ?root="${isRoot}">
+					</d2l-insights-tree-selector-node>`);
+				const renderedChildren = el.shadowRoot.querySelectorAll('d2l-insights-tree-selector-node');
+				expect(renderedChildren).to.have.length(3);
+				expect(renderedChildren.item(0).name).to.equal('child1');
+				expect(renderedChildren.item(0).selectedState).to.equal('none');
+				expect(renderedChildren.item(0).tree).to.not.exist;
+				expect(renderedChildren.item(0).getTree).to.not.exist;
+				expect(renderedChildren.item(0).isOpen).to.be.false;
+				expect(renderedChildren.item(1).name).to.equal('child2');
+				expect(renderedChildren.item(1).selectedState).to.equal('explicit');
+				expect(renderedChildren.item(1).tree).to.exist;
+				expect(renderedChildren.item(1).getTree).to.not.exist;
+				expect(renderedChildren.item(2).name).to.equal('child3');
+				expect(renderedChildren.item(2).tree).to.not.exist;
+				expect(renderedChildren.item(2).getTree).to.exist;
+				expect(renderedChildren.item(2).isOpen).to.be.true;
+			})
+		);
+
+		it('should mark children implicitly selected if selected (even if they are explicit in the data)', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" .tree="${tree}" selected-state="explicit"></d2l-insights-tree-selector-node>`);
+			const [...renderedChildren] = el.shadowRoot.querySelectorAll('d2l-insights-tree-selector-node');
+			renderedChildren.forEach(x => expect(x.selectedState).to.equal('implicit'));
+		});
+
+		it('should mark children implicitly selected if implicitly selected (even if they are explicit in the data)', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" .tree="${tree}" selected-state="implicit"></d2l-insights-tree-selector-node>`);
+			const [...renderedChildren] = el.shadowRoot.querySelectorAll('d2l-insights-tree-selector-node');
+			renderedChildren.forEach(x => expect(x.selectedState).to.equal('implicit'));
+		});
+	});
+
+	describe('open and close', () => {
+		it('should open on click', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" .tree="${tree}"></d2l-insights-tree-selector-node>`);
+			getOpenControl(el).click();
+			await el.updateComplete;
+			expect(el.isOpen).to.be.true;
+			expect(getSubtree(el).hidden).to.be.false;
+		});
+
+		it('should close on click', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" .tree="${tree}" open></d2l-insights-tree-selector-node>`);
+			getOpenControl(el).click();
+			await el.updateComplete;
+			expect(el.isOpen).to.be.false;
+			expect(getSubtree(el).hidden).to.be.true;
+		});
+
+		it('should maintain open state of children', async() => {
+			// child3 is open to start, and we'll open child2; close this node then open again; child2&3 should still be open
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" .tree="${tree}" open></d2l-insights-tree-selector-node>`);
+			const [...renderedChildren] = el.shadowRoot.querySelectorAll('d2l-insights-tree-selector-node');
+			renderedChildren[1].isOpen = true;
+			await renderedChildren[1].updateComplete;
+			getOpenControl(el).click();
+			await el.updateComplete;
+			getOpenControl(el).click();
+			await el.updateComplete;
+			expect(el.isOpen).to.be.true;
+			expect(renderedChildren[0].isOpen).to.be.false;
+			expect(renderedChildren[1].isOpen).to.be.true;
+			expect(renderedChildren[2].isOpen).to.be.true;
+		});
+	});
+
+	describe('selection', () => {
+		it('should select', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node"></d2l-insights-tree-selector-node>`);
+			getCheckbox(el).simulateClick();
+			await el.updateComplete;
+			expect(el.selected.map(x => x.name)).to.deep.equal(['node']);
+		});
+
+		it('should select if it was indeterminate', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" selected-state="indeterminate"></d2l-insights-tree-selector-node>`);
+			getCheckbox(el).simulateClick();
+			await el.updateComplete;
+			expect(el.selected.map(x => x.name)).to.deep.equal(['node']);
+		});
+
+		it('should deselect', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" selected-state="explicit"></d2l-insights-tree-selector-node>`);
+			getCheckbox(el).simulateClick();
+			await el.updateComplete;
+			expect(el.selected.map(x => x.name)).to.deep.equal([]);
+		});
+
+		it('should mark children implicitly selected when selected', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" .tree="${tree}"></d2l-insights-tree-selector-node>`);
+			getCheckbox(el).simulateClick();
+			await el.updateComplete;
+			const [...renderedChildren] = el.shadowRoot.querySelectorAll('d2l-insights-tree-selector-node');
+			renderedChildren.forEach(x => expect(x.selectedState).to.equal('implicit'));
+			expect(el.selected.map(x => x.name)).to.deep.equal(['node']);
+		});
+
+		it('should mark children not selected when deselected', async() => {
+			// Note that this includes child2, which was explicitly selected to begin with: that state should be discarded
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" .tree="${tree}"></d2l-insights-tree-selector-node>`);
+			getCheckbox(el).simulateClick();
+			await el.updateComplete;
+			getCheckbox(el).simulateClick();
+			await el.updateComplete;
+			const [...renderedChildren] = el.shadowRoot.querySelectorAll('d2l-insights-tree-selector-node');
+			renderedChildren.forEach(x => expect(x.selectedState).to.equal('none'));
+			expect(el.selected.map(x => x.name)).to.deep.equal([]);
+		});
+
+		it('should be marked indeterminate if some children are selected', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" .tree="${tree}"></d2l-insights-tree-selector-node>`);
+			const [...renderedChildren] = el.shadowRoot.querySelectorAll('d2l-insights-tree-selector-node');
+			getCheckbox(renderedChildren[0]).simulateClick();
+			await el.updateComplete;
+			expect(getCheckbox(el).checked).to.be.false;
+			expect(getCheckbox(el).indeterminate).to.be.true;
+			expect(el.selected.map(x => x.name)).to.deep.equal(['child1', 'child2']);
+		});
+
+		it('should select just this node if all children are selected', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" .tree="${tree}"></d2l-insights-tree-selector-node>`);
+			const [...renderedChildren] = el.shadowRoot.querySelectorAll('d2l-insights-tree-selector-node');
+			getCheckbox(renderedChildren[0]).simulateClick();
+			getCheckbox(renderedChildren[2]).simulateClick();
+			await el.updateComplete;
+			expect(getCheckbox(el).checked).to.be.true;
+			expect(getCheckbox(el).indeterminate).to.be.false;
+			expect(el.selected.map(x => x.name)).to.deep.equal(['node']);
+		});
+
+		it('should select all other children if this node was selected and one child is deselected', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" .tree="${tree}" selected-state="explicit"></d2l-insights-tree-selector-node>`);
+			const [...renderedChildren] = el.shadowRoot.querySelectorAll('d2l-insights-tree-selector-node');
+			getCheckbox(renderedChildren[0]).simulateClick();
+			await el.updateComplete;
+			expect(renderedChildren[0].selectedState).to.equal('none');
+			expect(renderedChildren[1].selectedState).to.equal('explicit');
+			expect(renderedChildren[2].selectedState).to.equal('explicit');
+			expect(el.selected.map(x => x.name)).to.deep.equal(['child2', 'child3']);
+		});
+	});
+
+	describe('events', () => {
+		async function expectEvent(el, clickTarget = el) {
+			const listener = oneEvent(el, 'd2l-insights-tree-selector-change');
+			getCheckbox(clickTarget).simulateClick();
+			const event = await listener;
+			expect(event.type).to.equal('d2l-insights-tree-selector-change');
+			expect(event.target).to.equal(el);
+		}
+
+		it('should fire d2l-insights-tree-selector-change on selection', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node"></d2l-insights-tree-selector-node>`);
+			await expectEvent(el);
+		});
+
+		it('should fire d2l-insights-tree-selector-change on deselection', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" selected-state="explicit"></d2l-insights-tree-selector-node>`);
+			await expectEvent(el);
+		});
+
+		it('should fire d2l-insights-tree-selector-change on child selection', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" selected-state="explicit"></d2l-insights-tree-selector-node>`);
+			const [...renderedChildren] = el.shadowRoot.querySelectorAll('d2l-insights-tree-selector-node');
+			await expectEvent(el, renderedChildren[0]);
+		});
+
+		it('should fire d2l-insights-tree-selector-change on child deselection', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector-node name="node" selected-state="explicit"></d2l-insights-tree-selector-node>`);
+			const [...renderedChildren] = el.shadowRoot.querySelectorAll('d2l-insights-tree-selector-node');
+			await expectEvent(el, renderedChildren[1]);
+		});
+	});
+});

--- a/test/components/tree-selector.test.js
+++ b/test/components/tree-selector.test.js
@@ -1,0 +1,60 @@
+import '../../components/tree-selector.js';
+
+import {expect, fixture, html, oneEvent} from '@open-wc/testing';
+import {runConstructor} from '@brightspace-ui/core/tools/constructor-test-helper.js';
+
+const tree = [
+	{ name: 'child1' },
+	{ name: 'child2', tree:[{ name: 'c2child1' }], selectedState: 'explicit' },
+	{ name: 'child3', getTree: async() => [], isOpen: true }
+];
+
+describe('d2l-insights-tree-selector', () => {
+	describe('constructor', () => {
+		it('should construct', () => {
+			runConstructor('d2l-insights-tree-selector');
+		});
+	});
+
+	describe('accessibility', () => {
+		it('should pass all axe tests', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector name="choose!" .tree="${tree}"></d2l-insights-tree-selector>`);
+			await expect(el).to.be.accessible();
+		});
+	});
+
+	describe('render', () => {
+		it('should render a node with the given tree', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector name="choose!" .tree="${tree}"></d2l-insights-tree-selector>`);
+			const node = el.shadowRoot.querySelector('d2l-insights-tree-selector-node');
+			expect(node.tree).to.deep.equal(tree);
+			expect(node.isRoot).to.be.true;
+		});
+
+		it('should render a dropbdown with the given name', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector name="choose!" .tree="${tree}"></d2l-insights-tree-selector>`);
+			expect(el.shadowRoot.querySelector('.d2l-dropdown-opener').textContent).to.equal('choose!');
+		});
+	});
+
+	describe('selection', () => {
+		it('should return selected nodes', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector name="choose!" .tree="${tree}"></d2l-insights-tree-selector>`);
+			expect(el.selected.map(x => x.name)).to.deep.equal(['child2']);
+		});
+	});
+
+	describe('events', () => {
+		it('should fire d2l-insights-tree-selector-change on selection change', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector name="choose!" .tree="${tree}"></d2l-insights-tree-selector>`);
+			const listener = oneEvent(el, 'd2l-insights-tree-selector-change');
+			const childCheckbox = el.shadowRoot.querySelector('d2l-insights-tree-selector-node')
+				.shadowRoot.querySelector('d2l-insights-tree-selector-node')
+				.shadowRoot.querySelector('d2l-input-checkbox');
+			childCheckbox.simulateClick();
+			const event = await listener;
+			expect(event.type).to.equal('d2l-insights-tree-selector-change');
+			expect(event.target).to.equal(el);
+		});
+	});
+});


### PR DESCRIPTION
First look: needs more css, but most of the functionality is there for the no-truncation case, where we get a full tree of org units back from the main query.

Future PRs: styling; show selected in the drop-down button; call the LMS as needed for children if the main query was truncated.
Not in this story: cross-filtering by semester, using this filter on the summary cards and table.

Quality Notes
* functional
  * using test data, many variations of opening, closing, selecting, and deselecting, checking resulting selection in the console
    * open and close a node, and open it again (with and without opening another in between)
    * open node and child, close, and reopen (with and without opening another in between) and confirm child's open state is preserved
    * select a leaf node and check that node is selected and parent is indeterminate; select all siblings and confirm that parent is selected instead
    * select a leaf node; select then deselect the parent, and confirm the leaf node is no longer selected
    * select all children of a node, including leafs and nodes with children; confirm parent is selected instead, and implicit when a child is deselected
    * select a node, then deselect one child; confirm that all siblings are selected and the parent is indeterminate
  * using local BSI and LMS, tested with real API data; similar coverage
* security: n/a
* performance: not tested explicitly, but no lag noticed
* devops: demo app works using canned data
* ux/docs: UI appearance to be tweaked in follow-up PRs

![image](https://user-images.githubusercontent.com/11181217/88975410-2072c880-d288-11ea-87bd-50ee96ee054d.png)

FYI @anhill-D2L @Vitalii-Misechko 