### PR TITLE
Us117429/l10n and a11y

### DIFF
--- a/components/insights-role-filter.js
+++ b/components/insights-role-filter.js
@@ -2,12 +2,13 @@ import './simple-filter';
 
 import {html, LitElement} from 'lit-element';
 import Lms from '../model/lms';
+import {Localizer} from '../locales/localizer';
 
 /**
  * @property {{id: string, displayName: string}[]} _filterData
  * @fires d2l-insights-role-filter-change - detail includes the list of selected role ids
  */
-class InsightsRoleFilter extends LitElement {
+class InsightsRoleFilter extends Localizer(LitElement) {
 
 	static get properties() {
 		return {
@@ -18,7 +19,6 @@ class InsightsRoleFilter extends LitElement {
 	constructor() {
 		super();
 
-		this._name = 'Roles';
 		this._roleData = [];
 
 		const lms = new Lms();
@@ -60,7 +60,7 @@ class InsightsRoleFilter extends LitElement {
 		return html`
 			<d2l-simple-filter
 				@d2l-simple-filter-selected="${this._updateFilterSelections}"
-				name="${this._name}"
+				name="${this.localize('components.insights-role-filter.name')}"
 				.data="${this._filterData}">
 			</d2l-simple-filter>
 		`;

--- a/components/insights-role-filter.js
+++ b/components/insights-role-filter.js
@@ -5,9 +5,9 @@ import Lms from '../model/lms';
 import {Localizer} from '../locales/localizer';
 
 const demoData = [
-	{ id: '500', displayName: 'Administrator' },
-	{ id: '600', displayName: 'Instructor' },
-	{ id: '700', displayName: 'Student' }
+	{ Identifier: '500', DisplayName: 'Administrator' },
+	{ Identifier: '600', DisplayName: 'Instructor' },
+	{ Identifier: '700', DisplayName: 'Student' }
 ];
 
 /**
@@ -26,7 +26,9 @@ class InsightsRoleFilter extends Localizer(LitElement) {
 	constructor() {
 		super();
 
+		this.isDemo = false;
 		this._roleData = [];
+		this._filterData = [];
 
 		const lms = new Lms();
 		lms.fetchRoles().then(data => this._setRoleData(data));
@@ -63,13 +65,18 @@ class InsightsRoleFilter extends Localizer(LitElement) {
 		this._roleData.find(role => role.Identifier === roleId).selected = selected;
 	}
 
+	firstUpdated() {
+		if (this.isDemo) {
+			this._setRoleData(demoData);
+		}
+	}
+
 	render() {
-		const filterData = this.isDemo ? demoData : this._filterData;
 		return html`
 			<d2l-simple-filter
 				@d2l-simple-filter-selected="${this._updateFilterSelections}"
 				name="${this.localize('components.insights-role-filter.name')}"
-				.data="${filterData}">
+				.data="${this._filterData}">
 			</d2l-simple-filter>
 		`;
 	}

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -83,8 +83,6 @@ class EngagementDashboard extends LitElement {
 		return html`
 				<h2>Hello ${this.prop1}!</h2>
 
-				<d2l-insights-role-filter @d2l-insights-role-filter-change="${this._handleRoleSelectionsUpdated}"></d2l-insights-role-filter>
-
 				<div class="view-filters-container">
 					<d2l-insights-ou-filter .data="${this._data}" @d2l-insights-ou-filter-change="${this._onOuFilterChange}"></d2l-insights-ou-filter>
 					<d2l-insights-role-filter @d2l-insights-role-filter-change="${this._handleRoleSelectionsUpdated}" ?demo="${this.useTestData}"></d2l-insights-role-filter>

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -4,9 +4,8 @@ import './components/insights-role-filter.js';
 
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { Data, Histogram } from './model/data.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 
-class EngagementDashboard extends LocalizeMixin(LitElement) {
+class EngagementDashboard extends LitElement {
 
 	static get properties() {
 		return {
@@ -32,23 +31,6 @@ class EngagementDashboard extends LocalizeMixin(LitElement) {
 				}
 			`
 		];
-	}
-
-	static async getLocalizeResources(langs) {
-		const langResources = {
-			'en': { 'myLangTerm': 'I am a localized string!' }
-		};
-
-		for (let i = 0; i < langs.length; i++) {
-			if (langResources[langs[i]]) {
-				return {
-					language: langs[i],
-					resources: langResources[langs[i]]
-				};
-			}
-		}
-
-		return null;
 	}
 
 	constructor() {
@@ -86,7 +68,6 @@ class EngagementDashboard extends LocalizeMixin(LitElement) {
 
 				<d2l-insights-role-filter @d2l-insights-role-filter-change="${this._handleRoleSelectionsUpdated}"></d2l-insights-role-filter>
 
-				<div>Localization Example: ${this.localize('myLangTerm')}</div>
 				<div class="summary-container">
 					${Object.values(this._data.filters).map(f => html`<d2l-labs-summary-card id="${f.id}" .data="${f}"></d2l-labs-summary-card>`)}
 					<d2l-labs-histogram-card id="${this.histogram.id}" .data="${this.histogram}"></d2l-labs-histogram-card>

--- a/insights-engagement-dashboard.serge.json
+++ b/insights-engagement-dashboard.serge.json
@@ -1,0 +1,24 @@
+{
+  "name": "insights-engagement-dashboard",
+  "parser_plugin": {
+    "plugin": "parse_js"
+  },
+  "source_match": "en\\.js$",
+  "source_dir": "locales",
+  "output_file_path": "locales/%LANG%.js",
+  "output_lang_rewrite": [
+    "ar-sa ar",
+    "da-dk da",
+    "de-de de",
+    "es-mx es",
+    "fr-ca fr",
+    "ja-jp ja",
+    "ko-kr ko",
+    "nl-nl nl",
+    "pt-br pt",
+    "sv-se sv",
+    "tr-tr tr",
+    "zh-cn zh",
+    "zh-tw zh-tw"
+  ]
+}

--- a/locales/en.js
+++ b/locales/en.js
@@ -1,0 +1,5 @@
+/* eslint quotes: 0 */
+
+export default {
+	"components.insights-role-filter.name": "Roles"
+};

--- a/locales/localizer.js
+++ b/locales/localizer.js
@@ -3,9 +3,18 @@ import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin';
 
 export const Localizer = superclass => class extends LocalizeMixin(superclass) {
 
+	/**
+	 * @param {string[]} langs - contains locales and languages in order of preference
+	 * e.g. ['fr-fr', 'fr', 'en-us', 'en']
+	 */
 	static async getLocalizeResources(langs) {
 		let translations;
+		// always load in English translations, so we have something to default to
+		const enTranslations = await import('./en.js');
+
 		try {
+			// not sure why for await..of syntax is required here.
+			// In debugger langs looks like a regular array, but maybe it's really an async iterable under the hood
 			for await (const lang of langs) {
 				switch (lang) {
 					case 'ar':
@@ -54,16 +63,21 @@ export const Localizer = superclass => class extends LocalizeMixin(superclass) {
 				if (translations && translations.default) {
 					return {
 						language: lang,
-						resources: translations.default
+						resources: Object.assign(enTranslations.default, translations.default)
 					};
 				}
 			}
-		} catch (err) {
-			// can happen if the langterms file for a language doesn't exist
-			translations = await import('./en.js');
+
 			return {
 				language: 'en',
-				resources: translations.default
+				resources: enTranslations.default
+			};
+
+		} catch (err) {
+			// can happen if the langterms file for a language doesn't exist
+			return {
+				language: 'en',
+				resources: enTranslations.default
 			};
 		}
 	}

--- a/locales/localizer.js
+++ b/locales/localizer.js
@@ -1,66 +1,70 @@
-// a copy of BrightspaceUI/core's LocalizeCoreElement
+// copied from BrightspaceUI/core's LocalizeCoreElement, with modifications
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin';
 
 export const Localizer = superclass => class extends LocalizeMixin(superclass) {
 
 	static async getLocalizeResources(langs) {
 		let translations;
-		for await (const lang of langs) {
-			switch (lang) {
-				case 'ar':
-					translations = await import('./ar.js');
-					break;
-				case 'da':
-					translations = await import('./da.js');
-					break;
-				case 'de':
-					translations = await import('./de.js');
-					break;
-				case 'en':
-					translations = await import('./en.js');
-					break;
-				case 'es':
-					translations = await import('./es.js');
-					break;
-				case 'fr':
-					translations = await import('./fr.js');
-					break;
-				case 'ja':
-					translations = await import('./ja.js');
-					break;
-				case 'ko':
-					translations = await import('./ko.js');
-					break;
-				case 'nl':
-					translations = await import('./nl.js');
-					break;
-				case 'pt':
-					translations = await import('./pt.js');
-					break;
-				case 'sv':
-					translations = await import('./sv.js');
-					break;
-				case 'tr':
-					translations = await import('./tr.js');
-					break;
-				case 'zh-tw':
-					translations = await import('./zh-tw.js');
-					break;
-				case 'zh':
-					translations = await import('./zh.js');
-					break;
+		try {
+			for await (const lang of langs) {
+				switch (lang) {
+					case 'ar':
+						translations = await import('./ar.js');
+						break;
+					case 'da':
+						translations = await import('./da.js');
+						break;
+					case 'de':
+						translations = await import('./de.js');
+						break;
+					case 'en':
+						translations = await import('./en.js');
+						break;
+					case 'es':
+						translations = await import('./es.js');
+						break;
+					case 'fr':
+						translations = await import('./fr.js');
+						break;
+					case 'ja':
+						translations = await import('./ja.js');
+						break;
+					case 'ko':
+						translations = await import('./ko.js');
+						break;
+					case 'nl':
+						translations = await import('./nl.js');
+						break;
+					case 'pt':
+						translations = await import('./pt.js');
+						break;
+					case 'sv':
+						translations = await import('./sv.js');
+						break;
+					case 'tr':
+						translations = await import('./tr.js');
+						break;
+					case 'zh-tw':
+						translations = await import('./zh-tw.js');
+						break;
+					case 'zh':
+						translations = await import('./zh.js');
+						break;
+				}
+				if (translations && translations.default) {
+					return {
+						language: lang,
+						resources: translations.default
+					};
+				}
 			}
-			if (translations && translations.default) {
-				return {
-					language: lang,
-					resources: translations.default
-				};
-			}
+		} catch (err) {
+			// can happen if the langterms file for a language doesn't exist
+			translations = await import('./en.js');
+			return {
+				language: 'en',
+				resources: translations.default
+			};
 		}
-		translations = await import('./en.js');
-		return {
-			language: 'en',
-			resources: translations.default
-		};
 	}
 };

--- a/locales/localizer.js
+++ b/locales/localizer.js
@@ -1,0 +1,66 @@
+// a copy of BrightspaceUI/core's LocalizeCoreElement
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin';
+
+export const Localizer = superclass => class extends LocalizeMixin(superclass) {
+
+	static async getLocalizeResources(langs) {
+		let translations;
+		for await (const lang of langs) {
+			switch (lang) {
+				case 'ar':
+					translations = await import('./ar.js');
+					break;
+				case 'da':
+					translations = await import('./da.js');
+					break;
+				case 'de':
+					translations = await import('./de.js');
+					break;
+				case 'en':
+					translations = await import('./en.js');
+					break;
+				case 'es':
+					translations = await import('./es.js');
+					break;
+				case 'fr':
+					translations = await import('./fr.js');
+					break;
+				case 'ja':
+					translations = await import('./ja.js');
+					break;
+				case 'ko':
+					translations = await import('./ko.js');
+					break;
+				case 'nl':
+					translations = await import('./nl.js');
+					break;
+				case 'pt':
+					translations = await import('./pt.js');
+					break;
+				case 'sv':
+					translations = await import('./sv.js');
+					break;
+				case 'tr':
+					translations = await import('./tr.js');
+					break;
+				case 'zh-tw':
+					translations = await import('./zh-tw.js');
+					break;
+				case 'zh':
+					translations = await import('./zh.js');
+					break;
+			}
+			if (translations && translations.default) {
+				return {
+					language: lang,
+					resources: translations.default
+				};
+			}
+		}
+		translations = await import('./en.js');
+		return {
+			language: 'en',
+			resources: translations.default
+		};
+	}
+};

--- a/test/components/insights-role-filter.test.js
+++ b/test/components/insights-role-filter.test.js
@@ -92,7 +92,7 @@ describe('d2l-insights-role-filter', () => {
 
 		beforeEach(async() => {
 			el = await fixture(html`<d2l-insights-role-filter></d2l-insights-role-filter>`);
-			await new Promise(resolve => setTimeout(resolve, 0)); // allow fetch to run
+			await new Promise(resolve => setTimeout(resolve, 200)); // allow fetch to run. Add 200 ms for Firefox on OSX
 			await el.updateComplete;
 		});
 

--- a/test/locales/localizer.test.js
+++ b/test/locales/localizer.test.js
@@ -1,0 +1,15 @@
+import {expect} from '@open-wc/testing';
+import {Localizer} from '../../locales/localizer';
+
+class MockLocalizedObjectSuperclass {}
+class MockLocalizedObject extends Localizer(MockLocalizedObjectSuperclass) {}
+
+describe('Localizer', () => {
+	it('should default to English if the lang file is not found', async() => {
+		const langTerms = await MockLocalizedObject.getLocalizeResources(['not a supported language']);
+
+		expect(langTerms.language).to.equal('en');
+	});
+
+	// whenever we get actual langterms files: add a test that makes sure the correct langterms are loaded in
+});


### PR DESCRIPTION
Sets up serge to translate our repo, and adds localization for the role filter. (More localization will be required once we shift to `facet-filter-sort`.) 

This is basically a copy of how BrightspaceUI/core does localization.

Quality notes
* Testing
  * Localization
    * English renders in English
    * Other languages
      * Setup: I created a temporary `fr.js` file (which I later deleted) and put a French langterm in there. Then I set my local LMS to French
      * If `fr.js` exists and contains the langterm, then it uses the term in `fr.js`
      * If `fr.js` doesn't exist, then it defaults to English
      * ~~If `fr.js` exists but doesn't contain the langterm, then it defaults to empty string. I think this case could happen if we add a new langterm but the file isn't updated until _after_ cert, so (TODO) we want to handle this case in a smarter way.~~
      * **UPDATE** If `fr.js` exists but doesn't contain the langterm, it defaults to English
  * [x] screen reader testing (leftover from previous PR)
* Security: N/A
* Perf:
  * We always load in the English langterms file, even if the LMS is in a different language
* Devops
  * [x] add this repo to https://git.dev.d2l/projects/RE/repos/serge-localize
    * PR here: https://git.dev.d2l/projects/RE/repos/serge-localize/pull-requests/132/diff
* UX/Docs: N/A

FYI @anhill-D2L @rohitvinnakota @hyehayes @MykolaGalian 