### PR TITLE
Minor cosmetic changes

### DIFF
--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -5,6 +5,7 @@ import './components/insights-role-filter.js';
 
 import {css, html, LitElement} from 'lit-element/lit-element.js';
 import {Data} from './model/data.js';
+import {Localizer} from './locales/localizer';
 
 async function fetchData() {
 	const response = await fetch('/d2l/api/ap/unstable/insights/data/engagement');
@@ -38,7 +39,7 @@ async function testData() {
 /**
  * @property {Boolean} useTestData - if true, use canned data; otherwise call the LMS
  */
-class EngagementDashboard extends LitElement {
+class EngagementDashboard extends Localizer(LitElement) {
 
 	static get properties() {
 		return {
@@ -51,6 +52,7 @@ class EngagementDashboard extends LitElement {
 			css`
 				:host {
 					display: block;
+					padding: 0 30px;
 				}
 				:host([hidden]) {
 					display: none;
@@ -62,6 +64,21 @@ class EngagementDashboard extends LitElement {
 					margin-bottom: 25px;
 					display: flex;
 					flex-wrap: wrap;
+				}
+
+				h1 {
+					font-weight: normal; /* default is bold */
+				}
+
+				@media screen and (max-width: 615px) {
+					h1 {
+						line-height: 1.2em;
+					}
+
+					:host {
+						display: block;
+						padding: 0 18px;
+					}
 				}
 			`
 		];
@@ -81,7 +98,7 @@ class EngagementDashboard extends LitElement {
 		});
 
 		return html`
-				<h2>Hello ${this.prop1}!</h2>
+				<h1>${this.localize('components.insights-engagement-dashboard.title')}</h1>
 
 				<div class="view-filters-container">
 					<d2l-insights-ou-filter .data="${this._data}" @d2l-insights-ou-filter-change="${this._onOuFilterChange}"></d2l-insights-ou-filter>

--- a/locales/en.js
+++ b/locales/en.js
@@ -1,5 +1,6 @@
 /* eslint quotes: 0 */
 
 export default {
+	"components.insights-engagement-dashboard.title": "Engagement Dashboard",
 	"components.insights-role-filter.name": "Roles"
 };


### PR DESCRIPTION
Change title to "Engagement Dashboard" (localized), put title in a `h1`, add L/R padding

Quality notes
* UX/Docs: see screenshots
  * [x] approval from design
* other: N/A

Larger than 615px: L/R padding = 30px
![image](https://user-images.githubusercontent.com/11587338/89315934-6d202000-d649-11ea-8960-efff7571761d.png)

Smaller than 615px: L/R padding = 18px
![image](https://user-images.githubusercontent.com/11587338/89316035-904acf80-d649-11ea-8ea9-63b19a1ff125.png)

Really small: title text isn't overlapping (which was the default)
![image](https://user-images.githubusercontent.com/11587338/89316131-b1abbb80-d649-11ea-9c3e-b4a983b461a9.png)

@johngwilkinson @hyehayes @MykolaGalian @rohitvinnakota 