### PR TITLE
US119136  [Engagement][Filters] Replace simple-filter with facet-filter-sort component. New app level filter component

### DIFF
--- a/components/dropdown-filter.js
+++ b/components/dropdown-filter.js
@@ -32,6 +32,12 @@ class DropdownFilter extends Localizer(LitElement) {
 
 	static get styles() {
 		return [css`
+			:host {
+				display: inline-block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
 			d2l-button-subtle {
 				margin: 0.25rem;
 				display: grid;

--- a/components/dropdown-filter.js
+++ b/components/dropdown-filter.js
@@ -68,12 +68,14 @@ class DropdownFilter extends Localizer(LitElement) {
 	}
 
 	render() {
+		const openerSelectedText = this.localize('components.dropdown-filter.opener-text-multiple', {filterName: this.name, selectedCount: this._selectedCount});
+
 		return html`
 			<d2l-filter-dropdown
 				total-selected-option-count="${this._selectedCount}"
 				opener-text="${this.name}"
-				opener-text-single="${this.localize('components.dropdown-filter.opener-text-multiple', {filterName: this.name, selectedCount: this._selectedCount})}"
-				opener-text-multiple="${this.localize('components.dropdown-filter.opener-text-multiple', {filterName: this.name, selectedCount: this._selectedCount})}"
+				opener-text-single="${openerSelectedText}"
+				opener-text-multiple="${openerSelectedText}"
 				@d2l-filter-dropdown-cleared="${this._clearSelectionClick}"
 				@d2l-dropdown-close="${this._filterClose}"
 				>

--- a/components/dropdown-filter.js
+++ b/components/dropdown-filter.js
@@ -1,0 +1,164 @@
+import '@brightspace-ui/core/components/button/button-subtle.js';
+import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown.js';
+import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js';
+import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown-option.js';
+
+import {css, html, LitElement} from 'lit-element';
+import {Localizer} from '../locales/localizer';
+import {repeat} from 'lit-html/directives/repeat.js';
+
+/**
+ * @property {string} name
+ * @property {{id: string, displayName: string, _selected: boolean}[]} data
+ * @property {boolean} more - shows Load More button if true
+ * @property {string[]} selected - returns list of ids for selected items
+ * @property {boolean} disable-search
+ * @fires d2l-insights-dropdown-filter-selected - event.detail contains {string} filterName, {string} id, and {boolean} selected
+ * @fires d2l-insights-dropdown-filter-load-more-click
+ * @fires d2l-insights-dropdown-filter-searched
+ * @fires d2l-insights-dropdown-filter-selection-cleared
+ * @fires d2l-insights-dropdown-filter-close
+ */
+class DropdownFilter extends Localizer(LitElement) {
+
+	static get properties() {
+		return {
+			name: {type: String, attribute: true},
+			data: {type: Array, attribute: false},
+			hasMore: {type: Boolean, attribute: 'more'},
+			disableSearch: {type: Boolean, attribute: 'disable-search'},
+			_selectedCount: {type: Number, attribute: true}
+		};
+	}
+
+	static get styles() {
+		return [css`
+			d2l-button-subtle {
+				margin: 0.25rem;
+				display: grid;
+			}
+
+			d2l-filter-dropdown-category[disable-search] {
+				padding-top: 0px;
+			}
+		`];
+	}
+
+	get selected() {
+		return this.data
+			.filter(item => item._selected)
+			.map(item => item.id);
+	}
+
+	constructor() {
+		super();
+
+		/** {{id: string, displayName: string, _selected: boolean}[]} */
+		this.data = [];
+		this.name = '';
+		this.hasMore = false;
+		this._selectedCount = 0;
+		// is used in repeat-directive to tell Lit-framework that we want full refresh of a list of elements
+		this._searchIteration = 0;
+	}
+
+	render() {
+		return html`
+			<d2l-filter-dropdown
+				total-selected-option-count="${this._selectedCount}"
+				opener-text="${this.name}"
+				opener-text-single="${this.localize('components.dropdown-filter.opener-text-multiple', {filterName: this.name, selectedCount: this._selectedCount})}"
+				opener-text-multiple="${this.localize('components.dropdown-filter.opener-text-multiple', {filterName: this.name, selectedCount: this._selectedCount})}"
+				@d2l-filter-dropdown-cleared="${this._clearSelectionClick}"
+				@d2l-dropdown-close="${this._filterClose}"
+				>
+				<d2l-filter-dropdown-category
+					?disable-search="${this.disableSearch}"
+					category-text="${this.name}"
+					@d2l-filter-dropdown-option-change="${this._handleElementSelected}"
+					@d2l-filter-dropdown-category-searched="${this._handleSearchedClick}" >
+
+					${repeat(this.data, (item) => item.id + this._searchIteration, (item) => html`
+						<d2l-filter-dropdown-option text="${item.displayName}" value="${item.id}"></d2l-filter-dropdown-option>
+					`)}
+
+				</d2l-filter-dropdown-category>
+
+				${this._renderLoadMore()}
+
+			</d2l-filter-dropdown>
+		`;
+	}
+
+	async updated() {
+		if (!this.hasMore && this._loadMoreClickFlag) {
+			this._loadMoreClickFlag = false;
+
+			// move focus to the first filter item/option when the last page is loaded and Load More button is removed
+			await this.updateComplete;
+			this.shadowRoot.querySelector('d2l-filter-dropdown-option').focus();
+		}
+	}
+
+	_setSelectedState(id, selected) {
+		this.data.find(item => item.id === id)._selected = selected;
+		this._updateSelectedCount();
+	}
+
+	_updateSelectedCount() {
+		this._selectedCount = this.data.filter(item => item._selected).length;
+	}
+
+	_renderLoadMore() {
+		if (!this.hasMore) {
+			return html``;
+		}
+
+		return html`
+			<d2l-button-subtle
+				text="${this.localize('components.dropdown-filter.load-more')}"
+				@click="${this._handleLoadMoreClick}">
+			</d2l-button-subtle>`;
+	}
+
+	_handleElementSelected(event) {
+		this._setSelectedState(event.detail.menuItemKey, event.detail.selected);
+
+		// propagate the event one level up, since it can't cross the shadow DOM boundary
+		this.dispatchEvent(new CustomEvent('d2l-insights-dropdown-filter-selected', {
+			detail: {
+				itemId: event.detail.menuItemKey,
+				selected: event.detail.selected
+			}
+		}));
+	}
+
+	_handleLoadMoreClick() {
+		this._loadMoreClickFlag = true;
+		this.dispatchEvent(new CustomEvent('d2l-insights-dropdown-filter-load-more-click'));
+	}
+
+	_handleSearchedClick(event) {
+		this._searchIteration++;
+		this._selectedCount = 0;
+
+		this.dispatchEvent(new CustomEvent('d2l-insights-dropdown-filter-searched', {
+			detail: { value: event.detail.value }
+		}));
+	}
+
+	_clearSelectionClick() {
+		this._searchIteration++;
+		this._selectedCount = 0;
+
+		this.data.forEach(item => item._selected = false);
+
+		this.dispatchEvent(new CustomEvent('d2l-insights-dropdown-filter-selection-cleared'));
+	}
+
+	_filterClose() {
+		this.dispatchEvent(new CustomEvent('d2l-insights-dropdown-filter-close'));
+	}
+}
+
+customElements.define('d2l-insights-dropdown-filter', DropdownFilter);

--- a/components/dropdown-filter.js
+++ b/components/dropdown-filter.js
@@ -32,12 +32,6 @@ class DropdownFilter extends Localizer(LitElement) {
 
 	static get styles() {
 		return [css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
 			d2l-button-subtle {
 				margin: 0.25rem;
 				display: grid;

--- a/components/dropdown-filter.js
+++ b/components/dropdown-filter.js
@@ -91,7 +91,7 @@ class DropdownFilter extends Localizer(LitElement) {
 		`;
 	}
 
-	async updated() {
+	updated() {
 		if (!this.hasMore && this._loadMoreClickFlag) {
 			this._loadMoreClickFlag = false;
 

--- a/components/dropdown-filter.js
+++ b/components/dropdown-filter.js
@@ -1,4 +1,3 @@
-import '@brightspace-ui/core/components/button/button-subtle.js';
 import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown.js';
 import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js';
 import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown-option.js';
@@ -33,6 +32,12 @@ class DropdownFilter extends Localizer(LitElement) {
 
 	static get styles() {
 		return [css`
+			:host {
+				display: block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
 			d2l-button-subtle {
 				margin: 0.25rem;
 				display: grid;

--- a/components/dropdown-filter.js
+++ b/components/dropdown-filter.js
@@ -95,8 +95,6 @@ class DropdownFilter extends Localizer(LitElement) {
 		if (!this.hasMore && this._loadMoreClickFlag) {
 			this._loadMoreClickFlag = false;
 
-			// move focus to the first filter item/option when the last page is loaded and Load More button is removed
-			await this.updateComplete;
 			this.shadowRoot.querySelector('d2l-filter-dropdown-option').focus();
 		}
 	}

--- a/components/dropdown-filter.js
+++ b/components/dropdown-filter.js
@@ -26,7 +26,7 @@ class DropdownFilter extends Localizer(LitElement) {
 			data: {type: Array, attribute: false},
 			hasMore: {type: Boolean, attribute: 'more'},
 			disableSearch: {type: Boolean, attribute: 'disable-search'},
-			_selectedCount: {type: Number, attribute: true}
+			_selectedCount: {type: Number, attribute: false}
 		};
 	}
 

--- a/locales/en.js
+++ b/locales/en.js
@@ -8,12 +8,14 @@ export default {
 	"components.insights-role-filter.name": "Roles",
 
 	"components.semester-filter.name": "Semesters",
-	"components.semester-filter.loadMore": "Load More",
 	"components.semester-filter.semester-name": "{orgUnitName} (Id: {id})",
 
 	"components.simple-filter.search-label": "Search",
 	"components.simple-filter.search-placeholder": "Search...",
 	"components.simple-filter.dropdown-action": "Open {name} filter",
+
+	"components.dropdown-filter.load-more": "Load More",
+	"components.dropdown-filter.opener-text-multiple": "{filterName}: {selectedCount} selected",
 
 	"components.insights-users-table.title": "User Details",
 	"components.insights-users-table.lastFirstName": "Last Name, First Name",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@adobe/lit-mobx": "0.0.4",
     "@brightspace-ui/core": "^1.55.1",
     "@webcomponents/webcomponentsjs": "^2",
+    "d2l-facet-filter-sort": "BrightspaceUI/facet-filter-sort#semver:^3",
     "highcharts": "^8.1.2",
     "lit-element": "^2",
     "mobx": "^5.15.4"

--- a/test/components/dropdown-filter.test.js
+++ b/test/components/dropdown-filter.test.js
@@ -1,0 +1,164 @@
+import '../../components/dropdown-filter';
+
+import {expect, fixture, html, oneEvent} from '@open-wc/testing';
+import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
+
+describe('d2l-insights-dropdown-filter', () => {
+	let el;
+	const name = 'test';
+	const testData = [
+		{
+			id: '1',
+			displayName: 'name 1'
+		},
+		{
+			id: '2',
+			displayName: 'name 2'
+		},
+	];
+
+	beforeEach(async() => {
+		el = await fixture(html`<d2l-insights-dropdown-filter name="${name}" more .data="${testData}"></d2l-insights-dropdown-filter>`);
+		await new Promise(resolve => setTimeout(resolve, 0)); // allow fetch to run
+		await el.updateComplete;
+	});
+
+	describe('accessibility', () => {
+		it('should pass all axe tests', async() => {
+			await expect(el).to.be.accessible();
+		});
+	});
+
+	describe('constructor', () => {
+		it('should construct', () => {
+			runConstructor('d2l-insights-dropdown-filter');
+		});
+	});
+
+	describe('render', () => {
+		it('should render the dropdown opener with the correct name', async() => {
+			const filter = el.shadowRoot.querySelector('d2l-filter-dropdown');
+			expect(filter.openerText).to.equal(name);
+			expect(filter.openerTextSingle).to.equal(`${name}: 0 selected`);
+			expect(filter.openerTextMultiple).to.equal(`${name}: 0 selected`);
+		});
+
+		it('should render with the correct checkbox elements', () => {
+			const checkboxList = Array.from(el.shadowRoot.querySelectorAll('d2l-filter-dropdown-option'));
+			expect(checkboxList.length).to.equal(2);
+			checkboxList.forEach((checkbox, idx) => {
+				expect(checkbox.value).to.equal(testData[idx].id);
+				expect(checkbox.text).to.equal(testData[idx].displayName);
+				expect(checkbox.selected).to.be.false;
+			});
+		});
+
+		it('should render Load More button when `more`-attribute is specified', () => {
+			const button = el.shadowRoot.querySelector('d2l-button-subtle');
+			expect(button.text).to.equal('Load More');
+		});
+
+		it('should not render Load More button when no `more`-attribute', async() => {
+			el = await fixture(html`<d2l-insights-dropdown-filter name="${name}" .data="${testData}"></d2l-insights-dropdown-filter>`);
+			await new Promise(resolve => setTimeout(resolve, 0)); // allow fetch to run
+			await el.updateComplete;
+
+			const button = el.shadowRoot.querySelector('d2l-button-subtle');
+			expect(button).to.be.null;
+		});
+
+		it('should render search pannel', () => {
+			const category = el.shadowRoot.querySelector('d2l-filter-dropdown-category');
+			expect(category.disableSearch).to.be.false;
+		});
+
+		it('should hide search if `disable-search` is specified', async() => {
+			el = await fixture(html`<d2l-insights-dropdown-filter name="${name}" .data="${testData}" disable-search></d2l-insights-dropdown-filter>`);
+			await new Promise(resolve => setTimeout(resolve, 0)); // allow fetch to run
+			await el.updateComplete;
+
+			const category = el.shadowRoot.querySelector('d2l-filter-dropdown-category');
+			expect(category.disableSearch).to.be.true;
+		});
+	});
+
+	describe('eventing', () => {
+		it('should fire a `selected` event whenever one of the checkboxes is clicked', async() => {
+			let listener = oneEvent(el, 'd2l-insights-dropdown-filter-selected');
+			const checkboxList = Array.from(el.shadowRoot.querySelectorAll('d2l-filter-dropdown-option'));
+
+			checkboxList[0].click();
+
+			let event = await listener;
+			expect(event.type).to.equal('d2l-insights-dropdown-filter-selected');
+			expect(event.detail).to.deep.equal({ itemId: '1', selected: true });
+
+			// verify `selected` property changed
+			expect(el.selected.length).to.equal(1);
+			expect(el.selected[0]).to.equal('1');
+
+			//  verify opener textes are changed
+			let filter = el.shadowRoot.querySelector('d2l-filter-dropdown');
+			expect(filter.openerText).to.equal(name);
+			expect(filter.openerTextSingle).to.equal(`${name}: 1 selected`);
+			expect(filter.openerTextMultiple).to.equal(`${name}: 1 selected`);
+
+			listener = oneEvent(el, 'd2l-insights-dropdown-filter-selected');
+
+			checkboxList[0].click();
+
+			event = await listener;
+			expect(event.type).to.equal('d2l-insights-dropdown-filter-selected');
+			expect(event.detail).to.deep.equal({ itemId: '1', selected: false });
+
+			// verify `selected` property changed
+			expect(el.selected.length).to.equal(0);
+
+			// verify opener textes are changed
+			filter = el.shadowRoot.querySelector('d2l-filter-dropdown');
+			expect(filter.openerText).to.equal(name);
+			expect(filter.openerTextSingle).to.equal(`${name}: 0 selected`);
+			expect(filter.openerTextMultiple).to.equal(`${name}: 0 selected`);
+		});
+
+		it('should fire a `load-more-click` event when `Load More`-button is clicked', async() => {
+			const listener = oneEvent(el, 'd2l-insights-dropdown-filter-load-more-click');
+			const button = el.shadowRoot.querySelector('d2l-button-subtle');
+
+			button.click();
+			const event = await listener;
+			expect(event.type).to.equal('d2l-insights-dropdown-filter-load-more-click');
+		});
+
+		it('should fire a `searched` event when d2l-filter-dropdown-category-searched is handled', async() => {
+			const listener = oneEvent(el, 'd2l-insights-dropdown-filter-searched');
+			const dropdownCategorySearchedEvent = {detail: {value: 'search string'}};
+
+			el._handleSearchedClick(dropdownCategorySearchedEvent);
+
+			const event = await listener;
+			expect(event.type).to.equal('d2l-insights-dropdown-filter-searched');
+			expect(event.detail).to.deep.equal({ value: 'search string' });
+		});
+
+		it('should fire a `cleared` event when d2l-insights-dropdown-filter-selection-cleared is handled', async() => {
+			const listener = oneEvent(el, 'd2l-insights-dropdown-filter-selection-cleared');
+
+			el._clearSelectionClick();
+
+			const event = await listener;
+			expect(event.type).to.equal('d2l-insights-dropdown-filter-selection-cleared');
+			expect(event.detail).to.be.null;
+		});
+
+		it('should fire a `close` event when d2l-insights-dropdown-filter-close is handled', async() => {
+			const listener = oneEvent(el, 'd2l-insights-dropdown-filter-close');
+
+			el._filterClose();
+
+			const event = await listener;
+			expect(event.type).to.equal('d2l-insights-dropdown-filter-close');
+			expect(event.detail).to.be.null;
+		});
+	});
+});


### PR DESCRIPTION
[US119136](https://rally1.rallydev.com/#/detail/userstory/410073841016?fdp=true): [Engagement][Filters] Replace simple-filter with facet-filter-sort component

This PR introduces `d2l-insights-dropdown-filter` component that I'm going to use instead of `d2l-simple-filter` to achieve all AC in the story. `d2l-insights-dropdown-filter` uses Gaudi's `d2l-filter-dropdown` component under the hood

PR Draft with changes to existing Semester and Role filters: https://github.com/Brightspace/insights-engagement-dashboard/pull/26 


### Functional Testing

-  Tests
   - [x] The search actions clear selected items
   - [x] When load more disappears input focus stays on filter element
   - [x] Filter opener text is correct for 1 and many selected items
   - [x] Load more preserves selected items
   - [x] Closing filter sends an event 
   - [x] Accessibility
   - [x] Keyboard navigation (without a screen reader filter does not open a list of items. I'll report it to Gaudi)
   - [x] Unit tests
- Browsers
   - [x]  Chrome
   - [x] Firefox
   - [x] Edge
   - [x] ~Edge Legacy (Edge HTML) - it hungs on my laptop~
### Security Testing - N/A
### Performance Testing - N/A
### Devops - N/A
### UX and docs
 - [x] Demo to Kevin

NB. This PR does not change `Semesters` and `Roles` filter
![image](https://user-images.githubusercontent.com/9429561/90258262-f527d600-de50-11ea-84a9-311e7477cf0d.png)
