### PR TITLE
Stylelint

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@brightspace-ui/stylelint-config"
+}

--- a/components/dropdown-filter.js
+++ b/components/dropdown-filter.js
@@ -39,12 +39,12 @@ class DropdownFilter extends Localizer(LitElement) {
 				display: none;
 			}
 			d2l-button-subtle {
-				margin: 0.25rem;
 				display: grid;
+				margin: 0.25rem;
 			}
 
 			d2l-filter-dropdown-category[disable-search] {
-				padding-top: 0px;
+				padding-top: 0;
 			}
 		`];
 	}

--- a/components/histogram-card.js
+++ b/components/histogram-card.js
@@ -109,50 +109,50 @@ class HistogramCard extends MobxLitElement {
 			:host([hidden]) {
 				display: none;
 			}
-			
-			.summary-card {
-				width: fit-content;
-				border-width: 4px;
+
+			.d2l-insights-summary-card {
 				border-color: aliceblue;
-				border-style: solid;
-				padding: 10px;
 				border-radius: 15px;
+				border-style: solid;
+				border-width: 4px;
 				display: inline-block;
 				margin-right: 10px;
 				margin-top: 10px;
+				padding: 10px;
+				width: fit-content;
 			}
-			.summary-card[applied] {
+			.d2l-insights-summary-card[applied] {
 				border-color: darkseagreen;
 			}
-			.summary-card[loading] {
+			.d2l-insights-summary-card[loading] {
 				opacity: 30%;
 			}
-			
-			.summary-card-body {
+
+			.d2l-insights-summary-card-body {
+				align-items: center;
 				display: flex;
 				flex-wrap: wrap;
 				height: 100%;
-				align-items: center;
 				margin-top: -15px;
-				width: 80px
+				width: 80px;
 			}
-			
-			.summary-card-title {
+
+			.d2l-insights-summary-card-title {
 				font-size: smaller;
 			}
-			
-			.summary-card-field {
+
+			.d2l-insights-summary-card-field {
 				display: inline-block;
 				margin: 10px;
 				vertical-align: middle;
 			}
-			
-			.summary-card-value {
-				font-size: 40px;
+
+			.d2l-insights-summary-card-value {
 				color: lightsteelblue;
+				font-size: 40px;
 			}
-			
-			.summary-card-message {
+
+			.d2l-insights-summary-card-message {
 				max-width: 120px;
 			}
 		`;
@@ -163,9 +163,9 @@ class HistogramCard extends MobxLitElement {
 
 		// NB: relying on mobx rather than lit-element properties to handle update detection: it will trigger a redraw for
 		// any change to a relevant observed property of the Data object
-		return html`<div class="summary-card" ?applied="${this.data.isApplied}" ?loading="${this.data.isLoading}">
-			<div class="summary-card-title">${this.data.title}</div>
-			<d2l-labs-chart class="summary-card-body" .options="${this.chartOptions}"></d2l-labs-chart>
+		return html`<div class="d2l-insights-summary-card" ?applied="${this.data.isApplied}" ?loading="${this.data.isLoading}">
+			<div class="d2l-insights-summary-card-title">${this.data.title}</div>
+			<d2l-labs-chart class="d2l-insights-summary-card-body" .options="${this.chartOptions}"></d2l-labs-chart>
 		</div>`;
 	}
 

--- a/components/summary-card.js
+++ b/components/summary-card.js
@@ -17,49 +17,49 @@ class SummaryCard extends MobxLitElement {
 			:host([hidden]) {
 				display: none;
 			}
-			
-			.summary-card {
-				width: fit-content;
-				border-width: 4px;
+
+			.d2l-insights-summary-card {
 				border-color: aliceblue;
-				border-style: solid;
-				padding: 10px;
 				border-radius: 15px;
+				border-style: solid;
+				border-width: 4px;
 				display: inline-block;
 				margin-right: 10px;
 				margin-top: 10px;
+				padding: 10px;
+				width: fit-content;
 			}
-			.summary-card[applied] {
+			.d2l-insights-summary-card[applied] {
 				border-color: darkseagreen;
 			}
-			.summary-card[loading] {
+			.d2l-insights-summary-card[loading] {
 				opacity: 30%;
 			}
-			
-			.summary-card-body {
+
+			.d2l-insights-summary-card-body {
+				align-items: center;
 				display: flex;
 				flex-wrap: wrap;
 				height: 100%;
-				align-items: center;
 				margin-top: -15px;
 			}
-			
-			.summary-card-title {
+
+			.d2l-insights-summary-card-title {
 				font-size: smaller;
 			}
-			
-			.summary-card-field {
+
+			.d2l-insights-summary-card-field {
 				display: inline-block;
 				margin: 10px;
 				vertical-align: middle;
 			}
-			
-			.summary-card-value {
-				font-size: 40px;
+
+			.d2l-insights-summary-card-value {
 				color: lightsteelblue;
+				font-size: 40px;
 			}
-			
-			.summary-card-message {
+
+			.d2l-insights-summary-card-message {
 				max-width: 120px;
 			}
 		`;
@@ -70,12 +70,12 @@ class SummaryCard extends MobxLitElement {
 
 		// NB: relying on mobx rather than lit-element properties to handle update detection: it will trigger a redraw for
 		// any change to a relevant observed property of the Data object
-		return html`<div class="summary-card" ?applied="${this.data.isApplied}" ?loading="${this.data.isLoading}">
-			<div class="summary-card-title">${this.data.title}</div>
-			<div class="summary-card-body">
-				${(this.data.stats.delta !== undefined) ? html`<span class="summary-card-delta summary-card-field">${this.data.stats.delta}</span>` : ''}
-				<span class="summary-card-value summary-card-field">${this.data.stats.value}</span>
-				<span class="summary-card-message summary-card-field">${html`${this.data.message}`}</span>
+		return html`<div class="d2l-insights-summary-card" ?applied="${this.data.isApplied}" ?loading="${this.data.isLoading}">
+			<div class="d2l-insights-summary-card-title">${this.data.title}</div>
+			<div class="d2l-insights-summary-card-body">
+				${(this.data.stats.delta !== undefined) ? html`<span class="d2l-insights-summary-card-delta d2l-insights-summary-card-field">${this.data.stats.delta}</span>` : ''}
+				<span class="d2l-insights-summary-card-value d2l-insights-summary-card-field">${this.data.stats.value}</span>
+				<span class="d2l-insights-summary-card-message d2l-insights-summary-card-field">${html`${this.data.message}`}</span>
 			</div>
 		</div>`;
 	}

--- a/components/table.js
+++ b/components/table.js
@@ -20,11 +20,11 @@ class Table extends Localizer(RtlMixin(LitElement)) {
 
 	static get styles() {
 		return css`
-			:host([dir="rtl"]) .d2l-insights-table {
+			:host([dir="rtl"]) .d2l-insights-table-table {
 				text-align: right;
 			}
 
-			.d2l-insights-table {
+			.d2l-insights-table-table {
 				background-color: #ffffff;
 				border-collapse: separate;
 				border-spacing: 0;
@@ -51,65 +51,65 @@ class Table extends Localizer(RtlMixin(LitElement)) {
 			}
 
 			/* Table cell borders - to get exactly 1px inner borders in all cells */
-			.d2l-insights-table .d2l-insights-table-row-first > th {
+			.d2l-insights-table-table .d2l-insights-table-row-first > th {
 				border-top: 1px solid var(--d2l-color-mica);
 			}
 
-			.d2l-insights-table .d2l-insights-table-cell {
+			.d2l-insights-table-table .d2l-insights-table-cell {
 				border-right: 1px solid var(--d2l-color-mica);
 			}
 
-			.d2l-insights-table .d2l-insights-table-cell-first,
-			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-cell-last {
+			.d2l-insights-table-table .d2l-insights-table-cell-first,
+			:host([dir="rtl"]) .d2l-insights-table-table .d2l-insights-table-cell-last {
 				border-left: 1px solid var(--d2l-color-mica);
 			}
 
-			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-cell-first:not(.d2l-insights-table-cell-last) {
+			:host([dir="rtl"]) .d2l-insights-table-table .d2l-insights-table-cell-first:not(.d2l-insights-table-cell-last) {
 				border-left: 0;
 			}
 
 			/* Table cell radii - to round all 4 corners */
 			/* top row, first child */
-			.d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-first {
+			.d2l-insights-table-table .d2l-insights-table-row-first > .d2l-insights-table-cell-first {
 				border-top-left-radius: 8px;
 			}
-			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-first:not(.d2l-insights-table-cell-last) {
+			:host([dir="rtl"]) .d2l-insights-table-table .d2l-insights-table-row-first > .d2l-insights-table-cell-first:not(.d2l-insights-table-cell-last) {
 				border-top-left-radius: 0;
 			}
-			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-first {
+			:host([dir="rtl"]) .d2l-insights-table-table .d2l-insights-table-row-first > .d2l-insights-table-cell-first {
 				border-top-right-radius: 8px;
 			}
 
 			/* top row, last child */
-			.d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-last {
+			.d2l-insights-table-table .d2l-insights-table-row-first > .d2l-insights-table-cell-last {
 				border-top-right-radius: 8px;
 			}
-			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-last:not(.d2l-insights-table-cell-first) {
+			:host([dir="rtl"]) .d2l-insights-table-table .d2l-insights-table-row-first > .d2l-insights-table-cell-last:not(.d2l-insights-table-cell-first) {
 				border-top-right-radius: 0;
 			}
-			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-last {
+			:host([dir="rtl"]) .d2l-insights-table-table .d2l-insights-table-row-first > .d2l-insights-table-cell-last {
 				border-top-left-radius: 8px;
 			}
 
 			/* bottom row, first child */
-			.d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-first {
+			.d2l-insights-table-table .d2l-insights-table-row-last > .d2l-insights-table-cell-first {
 				border-bottom-left-radius: 8px;
 			}
-			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-first:not(.d2l-insights-table-cell-last) {
+			:host([dir="rtl"]) .d2l-insights-table-table .d2l-insights-table-row-last > .d2l-insights-table-cell-first:not(.d2l-insights-table-cell-last) {
 				border-bottom-left-radius: 0;
 			}
-			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-first {
+			:host([dir="rtl"]) .d2l-insights-table-table .d2l-insights-table-row-last > .d2l-insights-table-cell-first {
 				border-bottom-right-radius: 8px;
 			}
 
 			/* bottom row, last child */
-			.d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-last {
+			.d2l-insights-table-table .d2l-insights-table-row-last > .d2l-insights-table-cell-last {
 				border-bottom-right-radius: 8px;
 			}
-			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-last:not(.d2l-insights-table-cell-first) {
+			:host([dir="rtl"]) .d2l-insights-table-table .d2l-insights-table-row-last > .d2l-insights-table-cell-last:not(.d2l-insights-table-cell-first) {
 				border-bottom-right-radius: 0;
 			}
-			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-last {
+			:host([dir="rtl"]) .d2l-insights-table-table .d2l-insights-table-row-last > .d2l-insights-table-cell-last {
 				border-bottom-left-radius: 8px;
 			}
 		`;
@@ -124,7 +124,7 @@ class Table extends Localizer(RtlMixin(LitElement)) {
 
 	render() {
 		return html`
-			<table class="d2l-insights-table" aria-label="${this.title}">
+			<table class="d2l-insights-table-table" aria-label="${this.title}">
 				${this._renderThead()}
 				${this._renderTbody()}
 			</table>

--- a/components/table.js
+++ b/components/table.js
@@ -25,29 +25,29 @@ class Table extends Localizer(RtlMixin(LitElement)) {
 			}
 
 			.d2l-insights-table {
-				background-color: #fff;
+				background-color: #ffffff;
 				border-collapse: separate;
 				border-spacing: 0;
-				width: 100%;
-				text-align: left;
 				font-weight: normal;
+				text-align: left;
+				width: 100%;
 			}
 
 			.d2l-insights-table-header {
-				color: var(--d2l-color-ferrite);
 				background-color: var(--d2l-color-regolith);
+				color: var(--d2l-color-ferrite);
+				height: 27px; /* min-height to be 48px including border */
 				line-height: 1.4rem;
 				padding: 10px 20px;
-				height: 27px; /* min-height to be 48px including border */
 			}
 
 			.d2l-insights-table-cell {
-				font-weight: normal;
-				display: table-cell;
-				vertical-align: middle;
-				padding: 10px 20px;
-				height: 41px; /* min-height to be 62px including border */
 				border-bottom: 1px solid var(--d2l-color-mica);
+				display: table-cell;
+				font-weight: normal;
+				height: 41px; /* min-height to be 62px including border */
+				padding: 10px 20px;
+				vertical-align: middle;
 			}
 
 			/* Table cell borders - to get exactly 1px inner borders in all cells */
@@ -70,48 +70,48 @@ class Table extends Localizer(RtlMixin(LitElement)) {
 
 			/* Table cell radii - to round all 4 corners */
 			/* top row, first child */
-            .d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-first {
-                border-top-left-radius: 8px;
-            }
-            :host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-first:not(.d2l-insights-table-cell-last) {
-                border-top-left-radius: 0;
-            }
-            :host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-first {
-                border-top-right-radius: 8px;
-            }
+			.d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-first {
+				border-top-left-radius: 8px;
+			}
+			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-first:not(.d2l-insights-table-cell-last) {
+				border-top-left-radius: 0;
+			}
+			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-first {
+				border-top-right-radius: 8px;
+			}
 
-   			/* top row, last child */
-            .d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-last {
-                border-top-right-radius: 8px;
-            }
-            :host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-last:not(.d2l-insights-table-cell-first) {
-                border-top-right-radius: 0;
-            }
-            :host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-last {
-                border-top-left-radius: 8px;
-            }
+			/* top row, last child */
+			.d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-last {
+				border-top-right-radius: 8px;
+			}
+			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-last:not(.d2l-insights-table-cell-first) {
+				border-top-right-radius: 0;
+			}
+			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-first > .d2l-insights-table-cell-last {
+				border-top-left-radius: 8px;
+			}
 
 			/* bottom row, first child */
-            .d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-first {
-                border-bottom-left-radius: 8px;
-            }
-            :host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-first:not(.d2l-insights-table-cell-last) {
-                border-bottom-left-radius: 0;
-            }
-            :host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-first {
-                border-bottom-right-radius: 8px;
-            }
+			.d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-first {
+				border-bottom-left-radius: 8px;
+			}
+			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-first:not(.d2l-insights-table-cell-last) {
+				border-bottom-left-radius: 0;
+			}
+			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-first {
+				border-bottom-right-radius: 8px;
+			}
 
 			/* bottom row, last child */
-            .d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-last {
-                border-bottom-right-radius: 8px;
-            }
-            :host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-last:not(.d2l-insights-table-cell-first) {
-                border-bottom-right-radius: 0;
-            }
-            :host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-last {
-                border-bottom-left-radius: 8px;
-            }
+			.d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-last {
+				border-bottom-right-radius: 8px;
+			}
+			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-last:not(.d2l-insights-table-cell-first) {
+				border-bottom-right-radius: 0;
+			}
+			:host([dir="rtl"]) .d2l-insights-table .d2l-insights-table-row-last > .d2l-insights-table-cell-last {
+				border-bottom-left-radius: 8px;
+			}
 		`;
 	}
 

--- a/components/tree-selector-node.js
+++ b/components/tree-selector-node.js
@@ -50,7 +50,7 @@ class TreeSelectorNode extends Localizer(RtlMixin(LitElement)) {
 				display: none;
 			}
 
-			.node {
+			.d2l-insights-tree-selector-node {
 				display: flex;
 				flex-wrap: nowrap;
 				margin-bottom: 16px;
@@ -60,44 +60,44 @@ class TreeSelectorNode extends Localizer(RtlMixin(LitElement)) {
 				display: inline-block;
 			}
 
-			.open-control {
+			.d2l-insights-tree-selector-node-open-control {
 				cursor: default;
 				margin-top: -3px;
 			}
-			.open-control .open {
+			.d2l-insights-tree-selector-node-open-control .d2l-insights-tree-selector-node-open {
 				display: none;
 			}
-			.open-control[open] .open {
+			.d2l-insights-tree-selector-node-open-control[open] .d2l-insights-tree-selector-node-open {
 				display: inline-block;
 			}
-			.open-control[open] .closed {
+			.d2l-insights-tree-selector-node-open-control[open] .d2l-insights-tree-selector-node-closed {
 				display: none;
 			}
 
-			.subtree {
+			.d2l-insights-tree-selector-node-subtree {
 				margin-left: 34px;
-				margin-right: 0px;
+				margin-right: 0;
 			}
-			:host([dir="rtl"]) .subtree {
-				margin-left: 0px;
+			:host([dir="rtl"]) .d2l-insights-tree-selector-node-subtree {
+				margin-left: 0;
 				margin-right: 34px;
 			}
-			.subtree[root] {
-				margin-left: 0px;
+			.d2l-insights-tree-selector-node-subtree[root] {
+				margin-left: 0;
 			}
-			:host([dir="rtl"]) .subtree[root] {
-				margin-right: 0px;
+			:host([dir="rtl"]) .d2l-insights-tree-selector-node-subtree[root] {
+				margin-right: 0;
 			}
-			.subtree[hidden] {
+			.d2l-insights-tree-selector-node-subtree[hidden] {
 				display: none;
 			}
 
-			.node-text {
-				display: inline-block;
+			.d2l-insights-tree-selector-node-text {
 				cursor: default;
-				width: 100%;
+				display: inline-block;
 				margin-left: 0.5rem;
 				margin-right: 0.5rem;
+				width: 100%;
 			}
 		`;
 	}
@@ -131,14 +131,14 @@ class TreeSelectorNode extends Localizer(RtlMixin(LitElement)) {
 		}
 
 		return html`
-			<div class="node">
+			<div class="d2l-insights-tree-selector-node">
 				<d2l-input-checkbox
 					?checked="${this._showSelected}"
 					?indeterminate="${this._showIndeterminate}"
 					aria-label="${this.localize('components.tree-selector.node.aria-label', { name: this.name, parentName: this.parentName })}"
 					@change="${this._onChange}"
 				></d2l-input-checkbox>
-				<span class="node-text" @click="${this._onArrowClick}" aria-hidden="true">${this.name}</span>
+				<span class="d2l-insights-tree-selector-node-text" @click="${this._onArrowClick}" aria-hidden="true">${this.name}</span>
 				${this._renderOpenControl()}
 			</div>
 		`;
@@ -148,14 +148,14 @@ class TreeSelectorNode extends Localizer(RtlMixin(LitElement)) {
 		// show the open/close arrow if this is not a leaf
 		if (this._isOpenable) {
 			return html`
-				<a href="#" class="open-control"
+				<a href="#" class="d2l-insights-tree-selector-node-open-control"
 					?open="${this.isOpen}"
 				 	@click="${this._onArrowClick}"
 				 	aria-label="${this._arrowLabel}"
 				 	aria-expanded="${this.isOpen}"
 				 >
-					<d2l-icon class="closed" icon="tier1:arrow-expand"></d2l-icon>
-					<d2l-icon class="open" icon="tier1:arrow-collapse"></d2l-icon>
+					<d2l-icon class="d2l-insights-tree-selector-node-closed" icon="tier1:arrow-expand"></d2l-icon>
+					<d2l-icon class="d2l-insights-tree-selector-node-open" icon="tier1:arrow-collapse"></d2l-icon>
 				</a>
 			`;
 		} else {
@@ -165,7 +165,7 @@ class TreeSelectorNode extends Localizer(RtlMixin(LitElement)) {
 
 	_renderSubtree() {
 		if (this.tree) {
-			return html`<div class="subtree" ?hidden="${!this.isRoot && !this.isOpen}" id="subtree" ?root="${this.isRoot}">${this.tree.map((x, i) => {
+			return html`<div class="d2l-insights-tree-selector-node-subtree" ?hidden="${!this.isRoot && !this.isOpen}" id="subtree" ?root="${this.isRoot}">${this.tree.map((x, i) => {
 				const childState = this._getChildState(x, i);
 				return html`<d2l-insights-tree-selector-node
 					name="${x.name}"

--- a/components/tree-selector-node.js
+++ b/components/tree-selector-node.js
@@ -50,7 +50,7 @@ class TreeSelectorNode extends Localizer(RtlMixin(LitElement)) {
 				display: none;
 			}
 
-			.d2l-insights-tree-selector-node {
+			.d2l-insights-tree-selector-node-node {
 				display: flex;
 				flex-wrap: nowrap;
 				margin-bottom: 16px;
@@ -131,7 +131,7 @@ class TreeSelectorNode extends Localizer(RtlMixin(LitElement)) {
 		}
 
 		return html`
-			<div class="d2l-insights-tree-selector-node">
+			<div class="d2l-insights-tree-selector-node-node">
 				<d2l-input-checkbox
 					?checked="${this._showSelected}"
 					?indeterminate="${this._showIndeterminate}"

--- a/components/tree-selector.js
+++ b/components/tree-selector.js
@@ -36,7 +36,7 @@ class TreeSelector extends Localizer(LitElement) {
 					display: none;
 				}
 
-				.search {
+				.d2l-insights-tree-selector-search {
 					display: flex;
 					flex-wrap: nowrap;
 					width: 334px;
@@ -52,7 +52,7 @@ class TreeSelector extends Localizer(LitElement) {
 					aria-label="${this.localize('components.tree-selector.dropdown-action', { name: this.name })}"
 				>${this.name}</button>
 					<d2l-dropdown-content align="start">
-						<div class="search" slot="header">
+						<div class="d2l-insights-tree-selector-search" slot="header">
 							<d2l-input-search
 								label="${this.localize('components.tree-selector.search-label')}"
 								placeholder="${this.localize('components.tree-selector.search-placeholder')}"

--- a/components/users-table.js
+++ b/components/users-table.js
@@ -21,13 +21,13 @@ class UsersTable extends Localizer(MobxLitElement) {
 	static get styles() {
 		return [
 			css`
-				.table-controls {
-					margin: 30px 0;
+				.d2l-insights-users-table-controls {
 					display: flex;
+					margin: 30px 0;
 					width: 100%;
 				}
 
-				.table-controls-item {
+				.d2l-insights-users-table-controls-item {
 					flex: 1 1 33%;
 				}
 			`
@@ -57,8 +57,8 @@ class UsersTable extends Localizer(MobxLitElement) {
 				.columns=${this.columns}
 				.data="${_displayData}"></d2l-insights-table>
 
-			<div class="table-controls">
-				<div class="table-controls-item">
+			<div class="d2l-insights-users-table-controls">
+				<div class="d2l-insights-users-table-controls-item">
 					${this.localize('components.insights-users-table.totalUsers', { num: _itemsCount })}
 				</div>
 				<!-- other columns in the flex box are for paging controls -->

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -69,11 +69,11 @@ class EngagementDashboard extends Localizer(LitElement) {
 				}
 
 				/* NB: this layout css doesn't quite work; do not ship */
-				.summary-container {
-					margin-top: 10px;
-					margin-bottom: 25px;
+				.d2l-insights-summary-container {
 					display: flex;
 					flex-wrap: wrap;
+					margin-bottom: 25px;
+					margin-top: 10px;
 				}
 
 				h1.d2l-heading-1 {
@@ -123,7 +123,7 @@ class EngagementDashboard extends Localizer(LitElement) {
 				</div>
 
 				<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.summaryHeading')}</h2>
-				<div class="summary-container">
+				<div class="d2l-insights-summary-container">
 					${Object.values(this._data.filters).map(f => html`<d2l-labs-summary-card id="${f.id}" .data="${f}"></d2l-labs-summary-card>`)}
 				</div>
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "repository": "https://github.com/Brightspace/insights-engagement-dashboard.git",
   "private": true,
   "scripts": {
-    "lint": "npm run lint:eslint && npm run lint:lit",
+    "lint": "npm run lint:eslint && npm run lint:lit && npm run lint:style",
     "lint:eslint": "eslint . --ext .js,.html",
     "lint:lit": "lit-analyzer engagement-dashboard.js demo test components",
+    "lint:style": "stylelint \"**/*.js\"",
     "start": "es-dev-server --app-index demo/index.html --node-resolve --dedupe --open --watch",
     "test": "npm run lint && npm run test:headless && npm run test:diff",
     "test:diff": "mocha ./**/*.visual-diff.js -t 40000",
@@ -20,6 +21,7 @@
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@brightspace-ui/stylelint-config": "0.0.1",
     "@brightspace-ui/visual-diff": "^1.4.1",
     "@open-wc/testing": "^2",
     "@open-wc/testing-karma": "^4.0.1",
@@ -36,7 +38,8 @@
     "frau-ci": "^1",
     "karma-sauce-launcher": "^4",
     "lit-analyzer": "^1.2.0",
-    "puppeteer": "^5"
+    "puppeteer": "^5",
+    "stylelint": "^13.6.1"
   },
   "dependencies": {
     "@adobe/lit-mobx": "0.0.4",

--- a/test/components/tree-selector-node.test.js
+++ b/test/components/tree-selector-node.test.js
@@ -10,7 +10,7 @@ const tree = [
 ];
 
 function getOpenControl(el) {
-	return el.shadowRoot.querySelector('.open-control');
+	return el.shadowRoot.querySelector('.d2l-insights-tree-selector-node-open-control');
 }
 
 function getCheckbox(el) {
@@ -18,7 +18,7 @@ function getCheckbox(el) {
 }
 
 function getSubtree(el) {
-	return el.shadowRoot.querySelector('.subtree');
+	return el.shadowRoot.querySelector('.d2l-insights-tree-selector-node-subtree');
 }
 
 describe('d2l-insights-tree-selector-node', () => {

--- a/test/components/users-table.test.js
+++ b/test/components/users-table.test.js
@@ -29,7 +29,7 @@ describe('d2l-insights-users-table', () => {
 	describe('render', () => {
 		it('should calculate and display the correct number of users', async() => {
 			const el = await fixture(html`<d2l-insights-users-table .data="${data}"></d2l-insights-users-table>`);
-			const totalUsersText = el.shadowRoot.querySelectorAll('.table-controls-item')[0];
+			const totalUsersText = el.shadowRoot.querySelectorAll('.d2l-insights-users-table-controls-item')[0];
 			expect(totalUsersText.innerText).to.equal('Total Users: 4');
 		});
 	});


### PR DESCRIPTION
Applies style linting as described in https://blog.d2l.dev/2020/08/04/style-linting/

Quality notes
* Testing
  * Demo page looks the same in Chrome, FF, Edgium, Edge Legacy (including fully expanded filters)
* Devops
  * New devops step `lint:style` is required to pass tests
* UX
  * Keyboard nav on Chrome seems to work the same. I didn't test other browsers
* Perf, Cost, Security, Docs: unchanged

Additional note: some of the class names are now really long. Definitely open to change if anyone has ideas for shortening them.

FYI @rohitvinnakota @Vitalii-Misechko @MykolaGalian @hyehayes 