### PR TITLE
Us118254/user table paging

### DIFF
--- a/components/table.js
+++ b/components/table.js
@@ -20,6 +20,13 @@ class Table extends Localizer(RtlMixin(LitElement)) {
 
 	static get styles() {
 		return css`
+			:host {
+				display: block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+
 			:host([dir="rtl"]) .d2l-insights-table-table {
 				text-align: right;
 			}

--- a/components/users-table.js
+++ b/components/users-table.js
@@ -2,11 +2,9 @@ import '@brightspace-ui/core/components/inputs/input-text';
 import '@brightspace-ui-labs/pagination/pagination';
 import './table.js';
 
-import {css, html} from 'lit-element';
-import {inputStyles} from '@brightspace-ui/core/components/inputs/input-styles';
-import {Localizer} from '../locales/localizer';
-import {MobxLitElement} from '@adobe/lit-mobx';
-import {selectStyles} from '@brightspace-ui/core/components/inputs/input-select-styles';
+import { css, html } from 'lit-element';
+import { Localizer } from '../locales/localizer';
+import { MobxLitElement } from '@adobe/lit-mobx';
 
 /**
  * At the moment the mobx data object is doing sorting / filtering logic
@@ -19,16 +17,14 @@ class UsersTable extends Localizer(MobxLitElement) {
 
 	static get properties() {
 		return {
-			data: {type: Object, attribute: false},
-			_currentPage: {type: Number, attribute: false},
-			_pageSize: {type: Number, attribute: false}
+			data: { type: Object, attribute: false },
+			_currentPage: { type: Number, attribute: false },
+			_pageSize: { type: Number, attribute: false }
 		};
 	}
 
 	static get styles() {
 		return [
-			inputStyles,
-			selectStyles,
 			css`
 				:host {
 					display: block;
@@ -38,22 +34,12 @@ class UsersTable extends Localizer(MobxLitElement) {
 				}
 
 				d2l-labs-pagination {
-					margin: 30px 0;
+					margin: 15px 0;
 				}
 
-				.d2l-insights-users-table-controls {
-					display: flex;
-					margin: 30px 0;
-					width: 100%;
-				}
-
-				.d2l-insights-users-table-controls-item {
-					flex: 1 1 33%;
-				}
-
-				.table-total-users {
-					width: 100%;
+				.d2l-insights-users-table-total-users {
 					margin-bottom: 30px;
+					width: 100%;
 				}
 			`
 		];
@@ -69,7 +55,6 @@ class UsersTable extends Localizer(MobxLitElement) {
 	}
 
 	get _itemsCount() {
-		// this might recalculate userDataForDisplay every time it's accessed, which could make perf bad
 		return this.data.userDataForDisplay.length;
 	}
 
@@ -103,17 +88,17 @@ class UsersTable extends Localizer(MobxLitElement) {
 				.data="${this._displayData}"></d2l-insights-table>
 
 			<d2l-labs-pagination
-				showItemCountSelect="true"
-				itemCountOptions="[10,20,50,100]"
-				pageNumber="${this._currentPage}"
-				maxPageNumber="${this._maxPages}"
-				selectedCountOption="${this._pageSize}"
+				show-item-count-select
+				item-count-options="[10,20,50,100]"
+				page-number="${this._currentPage}"
+				max-page-number="${this._maxPages}"
+				selected-count-option="${this._pageSize}"
 				@pagination-page-change="${this._handlePageChange}"
 				@pagination-item-counter-change="${this._handlePageSizeChange}"
 			></d2l-labs-pagination>
 
-			<div class="table-total-users">
-				${this.localize('components.insights-users-table.totalUsers', {num: this._itemsCount})}
+			<div class="d2l-insights-users-table-total-users">
+				${this.localize('components.insights-users-table.totalUsers', { num: this._itemsCount })}
 			</div>
 		`;
 	}

--- a/components/users-table.js
+++ b/components/users-table.js
@@ -1,26 +1,42 @@
+import '@brightspace-ui/core/components/inputs/input-text';
+import '@brightspace-ui-labs/pagination/pagination';
 import './table.js';
 
-import { css, html } from 'lit-element';
-import { Localizer } from '../locales/localizer';
-import { MobxLitElement } from '@adobe/lit-mobx';
+import {css, html} from 'lit-element';
+import {inputStyles} from '@brightspace-ui/core/components/inputs/input-styles';
+import {Localizer} from '../locales/localizer';
+import {MobxLitElement} from '@adobe/lit-mobx';
+import {selectStyles} from '@brightspace-ui/core/components/inputs/input-select-styles';
 
 /**
- * At the moment the mobx data object is doing all the display logic,
- * including sorting / filtering (and eventually paging, probably)
+ * At the moment the mobx data object is doing sorting / filtering logic
  *
  * @property {Object} data - an instance of Data from model/data.js
+ * @property {Number} _currentPage
+ * @property {Number} _pageSize
  */
 class UsersTable extends Localizer(MobxLitElement) {
 
 	static get properties() {
 		return {
-			data: { type: Object, attribute: false }
+			data: {type: Object, attribute: false},
+			_currentPage: {type: Number, attribute: false},
+			_pageSize: {type: Number, attribute: false}
 		};
 	}
 
 	static get styles() {
 		return [
+			inputStyles,
+			selectStyles,
 			css`
+				:host {
+					display: block;
+				}
+				:host([hidden]) {
+					display: none;
+				}
+
 				.d2l-insights-users-table-controls {
 					display: flex;
 					margin: 30px 0;
@@ -30,13 +46,46 @@ class UsersTable extends Localizer(MobxLitElement) {
 				.d2l-insights-users-table-controls-item {
 					flex: 1 1 33%;
 				}
+
+				.table-total-users {
+					flex: 0 1 33%;
+				}
+
+				.table-page-controls {
+					flex: 0 1 67%;
+				}
 			`
 		];
 	}
 
 	constructor() {
 		super();
-		this.data = {};
+		this.data = {
+			userDataForDisplay: []
+		};
+		this._currentPage = 1;
+		this._pageSize = 20;
+	}
+
+	get _itemsCount() {
+		// this might recalculate userDataForDisplay every time it's accessed, which could make perf bad
+		return this.data.userDataForDisplay.length;
+	}
+
+	get _maxPages() {
+		const itemsCount = this._itemsCount;
+		return itemsCount ? Math.ceil(itemsCount / this._pageSize) : 0;
+	}
+
+	get _displayData() {
+		if (this._itemsCount) {
+			const start = this._pageSize * (this._currentPage - 1);
+			const end = this._pageSize * (this._currentPage); // it's ok if this is larger than the size of the array
+
+			return this.data.userDataForDisplay.slice(start, end);
+		}
+
+		return [];
 	}
 
 	get columns() {
@@ -46,24 +95,47 @@ class UsersTable extends Localizer(MobxLitElement) {
 	}
 
 	render() {
-		const _displayData = this.data.userDataForDisplay;
-		// not sure how _itemsCount has the correct initial value of 0, since _displayData should initially be undefined
-		// behind-the-scenes mobx magic, I guess
-		const _itemsCount = _displayData.length;
-
 		return html`
 			<d2l-insights-table
 				title="${this.localize('components.insights-users-table.title')}"
 				.columns=${this.columns}
-				.data="${_displayData}"></d2l-insights-table>
+				.data="${this._displayData}"></d2l-insights-table>
 
 			<div class="d2l-insights-users-table-controls">
 				<div class="d2l-insights-users-table-controls-item">
-					${this.localize('components.insights-users-table.totalUsers', { num: _itemsCount })}
+					${this.localize('components.insights-users-table.totalUsers', { num: this._itemsCount })}
 				</div>
-				<!-- other columns in the flex box are for paging controls -->
+
+				<div class="table-page-controls">
+					<d2l-labs-pagination
+						showItemCountSelect="true"
+						itemCountOptions="[10,20,50,100]"
+						pageNumber="${this._currentPage}"
+						maxPageNumber="${this._maxPages}"
+						selectedCountOption="${this._pageSize}"
+						@pagination-page-change="${this._handlePageChange}"
+						@pagination-item-counter-change="${this._handlePageSizeChange}"
+					></d2l-labs-pagination>
+				</div>
 			</div>
 		`;
+	}
+
+	updated() {
+		if (this._itemsCount === 0) {
+			this._currentPage = 0;
+		} else if (this._currentPage === 0) {
+			this._currentPage = 1;
+		}
+	}
+
+	_handlePageChange(event) {
+		this._currentPage = event.detail.page;
+	}
+
+	_handlePageSizeChange(event) {
+		this._currentPage = 1;
+		this._pageSize = Number(event.detail.itemCount); // itemCount comes back as a string
 	}
 }
 customElements.define('d2l-insights-users-table', UsersTable);

--- a/components/users-table.js
+++ b/components/users-table.js
@@ -37,6 +37,10 @@ class UsersTable extends Localizer(MobxLitElement) {
 					display: none;
 				}
 
+				d2l-labs-pagination {
+					margin: 30px 0;
+				}
+
 				.d2l-insights-users-table-controls {
 					display: flex;
 					margin: 30px 0;
@@ -48,11 +52,8 @@ class UsersTable extends Localizer(MobxLitElement) {
 				}
 
 				.table-total-users {
-					flex: 0 1 33%;
-				}
-
-				.table-page-controls {
-					flex: 0 1 67%;
+					width: 100%;
+					margin-bottom: 30px;
 				}
 			`
 		];
@@ -101,22 +102,18 @@ class UsersTable extends Localizer(MobxLitElement) {
 				.columns=${this.columns}
 				.data="${this._displayData}"></d2l-insights-table>
 
-			<div class="d2l-insights-users-table-controls">
-				<div class="d2l-insights-users-table-controls-item">
-					${this.localize('components.insights-users-table.totalUsers', { num: this._itemsCount })}
-				</div>
+			<d2l-labs-pagination
+				showItemCountSelect="true"
+				itemCountOptions="[10,20,50,100]"
+				pageNumber="${this._currentPage}"
+				maxPageNumber="${this._maxPages}"
+				selectedCountOption="${this._pageSize}"
+				@pagination-page-change="${this._handlePageChange}"
+				@pagination-item-counter-change="${this._handlePageSizeChange}"
+			></d2l-labs-pagination>
 
-				<div class="table-page-controls">
-					<d2l-labs-pagination
-						showItemCountSelect="true"
-						itemCountOptions="[10,20,50,100]"
-						pageNumber="${this._currentPage}"
-						maxPageNumber="${this._maxPages}"
-						selectedCountOption="${this._pageSize}"
-						@pagination-page-change="${this._handlePageChange}"
-						@pagination-item-counter-change="${this._handlePageSizeChange}"
-					></d2l-labs-pagination>
-				</div>
+			<div class="table-total-users">
+				${this.localize('components.insights-users-table.totalUsers', {num: this._itemsCount})}
 			</div>
 		`;
 	}

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -34,8 +34,17 @@ async function demoData() {
 					[6606, 'Dev', 1, [0]]
 				],
 				users: [
-					[100, 'First', 'Last'],
-					[200, 'Test', 'Student']
+					[100, '1First', 'Last'],
+					[200, 'ATest', 'Student'],
+					[300, 'BTest', 'Student'],
+					[400, 'CTest', 'Student'],
+					[500, 'DTest', 'Student'],
+					[600, 'ETest', 'Student'],
+					[700, 'FTest', 'Student'],
+					[800, 'GTest', 'Student'],
+					[900, 'HTest', 'Student'],
+					[1000, 'ITest', 'Student'],
+					[1100, 'JTest', 'Student']
 				],
 				semesterTypeId: 25,
 				selectedOrgUnitIds: [1, 2]

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -33,18 +33,18 @@ async function demoData() {
 					[9, 'Faculty 2', 7, [6606]],
 					[6606, 'Dev', 1, [0]]
 				],
-				users: [
-					[100, '1First', 'Last'],
-					[200, 'ATest', 'Student'],
-					[300, 'BTest', 'Student'],
-					[400, 'CTest', 'Student'],
-					[500, 'DTest', 'Student'],
-					[600, 'ETest', 'Student'],
-					[700, 'FTest', 'Student'],
-					[800, 'GTest', 'Student'],
-					[900, 'HTest', 'Student'],
-					[1000, 'ITest', 'Student'],
-					[1100, 'JTest', 'Student']
+				users: [ // some of which are out of order
+					[100,  'ATest', 'AStudent'],
+					[300,  'CTest', 'CStudent'],
+					[200,  'BTest', 'BStudent'],
+					[400,  'DTest', 'DStudent'],
+					[500,  'ETest', 'EStudent'],
+					[600,  'GTest', 'GStudent'],
+					[700,  'FTest', 'FStudent'],
+					[800,  'HTest', 'HStudent'],
+					[900,  'ITest', 'IStudent'],
+					[1000, 'KTest', 'KStudent'],
+					[1100, 'JTest', 'JStudent']
 				],
 				semesterTypeId: 25,
 				selectedOrgUnitIds: [1, 2]

--- a/locales/localizer.js
+++ b/locales/localizer.js
@@ -17,47 +17,8 @@ export const Localizer = superclass => class extends LocalizeMixin(superclass) {
 			// In debugger langs looks like a regular array, but maybe it's really an async iterable under the hood
 			for await (const lang of langs) {
 				switch (lang) {
-					case 'ar':
-						translations = await import('./ar.js');
-						break;
-					case 'da':
-						translations = await import('./da.js');
-						break;
-					case 'de':
-						translations = await import('./de.js');
-						break;
 					case 'en':
 						translations = await import('./en.js');
-						break;
-					case 'es':
-						translations = await import('./es.js');
-						break;
-					case 'fr':
-						translations = await import('./fr.js');
-						break;
-					case 'ja':
-						translations = await import('./ja.js');
-						break;
-					case 'ko':
-						translations = await import('./ko.js');
-						break;
-					case 'nl':
-						translations = await import('./nl.js');
-						break;
-					case 'pt':
-						translations = await import('./pt.js');
-						break;
-					case 'sv':
-						translations = await import('./sv.js');
-						break;
-					case 'tr':
-						translations = await import('./tr.js');
-						break;
-					case 'zh-tw':
-						translations = await import('./zh-tw.js');
-						break;
-					case 'zh':
-						translations = await import('./zh.js');
 						break;
 				}
 				if (translations && translations.default) {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@adobe/lit-mobx": "0.0.4",
     "@brightspace-ui/core": "^1.69.0",
+    "@brightspace-ui-labs/pagination": "^0",
     "@webcomponents/webcomponentsjs": "^2",
     "d2l-facet-filter-sort": "BrightspaceUI/facet-filter-sort#semver:^3",
     "highcharts": "^8.1.2",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   },
   "dependencies": {
     "@adobe/lit-mobx": "0.0.4",
+    "@brightspace-ui-labs/pagination": "^0.0.8",
     "@brightspace-ui/core": "^1.69.0",
-    "@brightspace-ui-labs/pagination": "^0",
     "@webcomponents/webcomponentsjs": "^2",
     "d2l-facet-filter-sort": "BrightspaceUI/facet-filter-sort#semver:^3",
     "highcharts": "^8.1.2",

--- a/test/components/users-table.test.js
+++ b/test/components/users-table.test.js
@@ -5,31 +5,8 @@ import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-help
 
 describe('d2l-insights-users-table', () => {
 	const data = {
-		userDataForDisplay: [
-			['01Last, 01First'],
-			['02Last, 02First'],
-			['03Last, 03First'],
-			['04Last, 04First'],
-			['05Last, 05First'],
-			['06Last, 06First'],
-			['07Last, 07First'],
-			['08Last, 08First'],
-			['09Last, 09First'],
-			['10Last, 10First'],
-			['11Last, 11First'],
-			['12Last, 12First'],
-			['13Last, 13First'],
-			['14Last, 14First'],
-			['15Last, 15First'],
-			['16Last, 16First'],
-			['17Last, 17First'],
-			['18Last, 18First'],
-			['19Last, 19First'],
-			['20Last, 20First'],
-			['21Last, 21First'],
-			['22Last, 22First'],
-			['23Last, 23First']
-		]
+		// returns [ ['0First', '0Last'], ['1First', '1Last'], ..., ['22First', '22Last'] ]
+		userDataForDisplay: Array.from({ length: 23 }, (val, idx) => [`${idx}First`, `${idx}Last`])
 	};
 
 	describe('constructor', () => {
@@ -52,7 +29,7 @@ describe('d2l-insights-users-table', () => {
 	describe('render', () => {
 		it('should display the correct total users count', async() => {
 			const el = await fixture(html`<d2l-insights-users-table .data="${data}"></d2l-insights-users-table>`);
-			const totalUsersText = el.shadowRoot.querySelectorAll('.table-total-users')[0];
+			const totalUsersText = el.shadowRoot.querySelectorAll('.d2l-insights-users-table-total-users')[0];
 			expect(totalUsersText.innerText).to.equal('Total Users: 23');
 		});
 	});

--- a/test/components/users-table.test.js
+++ b/test/components/users-table.test.js
@@ -64,8 +64,12 @@ describe('d2l-insights-users-table', () => {
 			});
 
 			it('should show the correct number of users on the last page', async() => {
-				pageSelector.shadowRoot.querySelector('d2l-button-icon[text="Next page"]').click();
+				pageSelector
+					.shadowRoot.querySelector('d2l-button-icon[text="Next page"]')
+					.shadowRoot.querySelector('button')
+					.click();
 				await innerTable.updateComplete;
+				await pageSelector.updateComplete;
 
 				expect(pageSelector.pageNumber).to.equal(2);
 
@@ -80,6 +84,7 @@ describe('d2l-insights-users-table', () => {
 				pageSizeSelector.value = '10';
 				pageSizeSelector.dispatchEvent(new Event('change'));
 				await innerTable.updateComplete;
+				await pageSelector.updateComplete;
 
 				expect(pageSelector.selectedCountOption).to.equal(10);
 				expect(pageSelector.maxPageNumber).to.equal(3);
@@ -91,8 +96,12 @@ describe('d2l-insights-users-table', () => {
 					expect(user.innerText).to.equal(data.userDataForDisplay[idx][0]);
 				});
 
-				pageSelector.shadowRoot.querySelector('d2l-button-icon[text="Next page"]').click();
+				pageSelector
+					.shadowRoot.querySelector('d2l-button-icon[text="Next page"]')
+					.shadowRoot.querySelector('button')
+					.click();
 				await innerTable.updateComplete;
+				await pageSelector.updateComplete;
 
 				expect(pageSelector.pageNumber).to.equal(2);
 
@@ -102,8 +111,12 @@ describe('d2l-insights-users-table', () => {
 					expect(user.innerText).to.equal(data.userDataForDisplay[idx + 10][0]);
 				});
 
-				pageSelector.shadowRoot.querySelector('d2l-button-icon[text="Next page"]').click();
+				pageSelector
+					.shadowRoot.querySelector('d2l-button-icon[text="Next page"]')
+					.shadowRoot.querySelector('button')
+					.click();
 				await innerTable.updateComplete;
+				await pageSelector.updateComplete;
 
 				expect(pageSelector.pageNumber).to.equal(3);
 
@@ -118,6 +131,7 @@ describe('d2l-insights-users-table', () => {
 				pageSizeSelector.value = '50';
 				pageSizeSelector.dispatchEvent(new Event('change'));
 				await innerTable.updateComplete;
+				await pageSelector.updateComplete;
 
 				expect(pageSelector.selectedCountOption).to.equal(50);
 				expect(pageSelector.maxPageNumber).to.equal(1);
@@ -134,6 +148,7 @@ describe('d2l-insights-users-table', () => {
 			it('should show zero pages if there are no users to display', async() => {
 				el.data = { userDataForDisplay: [] };
 				await innerTable.updateComplete;
+				await pageSelector.updateComplete;
 
 				expect(pageSelector.selectedCountOption).to.equal(50);
 				expect(pageSelector.maxPageNumber).to.equal(0);

--- a/test/components/users-table.test.js
+++ b/test/components/users-table.test.js
@@ -6,10 +6,29 @@ import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-help
 describe('d2l-insights-users-table', () => {
 	const data = {
 		userDataForDisplay: [
-			'Lennon, John',
-			'McCartney, Paul',
-			'Harrison, George',
-			'Starr, Ringo'
+			['01Last, 01First'],
+			['02Last, 02First'],
+			['03Last, 03First'],
+			['04Last, 04First'],
+			['05Last, 05First'],
+			['06Last, 06First'],
+			['07Last, 07First'],
+			['08Last, 08First'],
+			['09Last, 09First'],
+			['10Last, 10First'],
+			['11Last, 11First'],
+			['12Last, 12First'],
+			['13Last, 13First'],
+			['14Last, 14First'],
+			['15Last, 15First'],
+			['16Last, 16First'],
+			['17Last, 17First'],
+			['18Last, 18First'],
+			['19Last, 19First'],
+			['20Last, 20First'],
+			['21Last, 21First'],
+			['22Last, 22First'],
+			['23Last, 23First']
 		]
 	};
 
@@ -22,15 +41,131 @@ describe('d2l-insights-users-table', () => {
 	describe('accessibility', () => {
 		it('should pass all axe tests', async() => {
 			const el = await fixture(html`<d2l-insights-users-table .data="${data}"></d2l-insights-users-table>`);
+			// give it a second to make sure inner table and paging controls load in
+			await new Promise(resolve => setTimeout(resolve, 200));
+			await el.updateComplete;
+
 			await expect(el).to.be.accessible();
 		});
 	});
 
 	describe('render', () => {
-		it('should calculate and display the correct number of users', async() => {
+		it('should display the correct total users count', async() => {
 			const el = await fixture(html`<d2l-insights-users-table .data="${data}"></d2l-insights-users-table>`);
-			const totalUsersText = el.shadowRoot.querySelectorAll('.d2l-insights-users-table-controls-item')[0];
-			expect(totalUsersText.innerText).to.equal('Total Users: 4');
+			const totalUsersText = el.shadowRoot.querySelectorAll('.table-total-users')[0];
+			expect(totalUsersText.innerText).to.equal('Total Users: 23');
 		});
+	});
+
+	describe('pagination', () => {
+		describe('when there are users in the table', () => {
+			let el;
+			let pageSizeSelector;
+			let pageSelector;
+			let innerTable;
+
+			before(async() => {
+				el = await fixture(html`<d2l-insights-users-table .data="${data}"></d2l-insights-users-table>`);
+				innerTable = el.shadowRoot.querySelector('d2l-insights-table');
+				await innerTable.updateComplete;
+				pageSelector = el.shadowRoot.querySelector('d2l-labs-pagination');
+				pageSizeSelector = pageSelector.shadowRoot.querySelector('select');
+			});
+
+			it('should show the first 20 users in order on the first page, if there are more than 20 users', () => {
+				// the default page size is 20
+				expect(pageSelector.selectedCountOption).to.equal(20);
+				expect(pageSelector.maxPageNumber).to.equal(2);
+				expect(pageSelector.pageNumber).to.equal(1);
+
+				// since there are 23 users, the first (default) page should show the first 20 users, in order, on it
+				const displayedUsers = Array.from(innerTable.shadowRoot.querySelectorAll('tbody > tr > td:first-child'));
+				expect(displayedUsers.length).to.equal(20);
+				displayedUsers.forEach((user, idx) => {
+					expect(user.innerText).to.equal(data.userDataForDisplay[idx][0]);
+				});
+			});
+
+			it('should show the correct number of users on the last page', async() => {
+				pageSelector.shadowRoot.querySelector('d2l-button-icon[text="Next page"]').click();
+				await innerTable.updateComplete;
+
+				expect(pageSelector.pageNumber).to.equal(2);
+
+				const displayedUsers = Array.from(innerTable.shadowRoot.querySelectorAll('tbody > tr > td:first-child'));
+				expect(displayedUsers.length).to.equal(3);
+				displayedUsers.forEach((user, idx) => {
+					expect(user.innerText).to.equal(data.userDataForDisplay[idx + 20][0]);
+				});
+			});
+
+			it('should change number of users shown and total number of pages if the page size changes', async() => {
+				pageSizeSelector.value = '10';
+				pageSizeSelector.dispatchEvent(new Event('change'));
+				await innerTable.updateComplete;
+
+				expect(pageSelector.selectedCountOption).to.equal(10);
+				expect(pageSelector.maxPageNumber).to.equal(3);
+				expect(pageSelector.pageNumber).to.equal(1);
+
+				let displayedUsers = Array.from(innerTable.shadowRoot.querySelectorAll('tbody > tr > td:first-child'));
+				expect(displayedUsers.length).to.equal(10);
+				displayedUsers.forEach((user, idx) => {
+					expect(user.innerText).to.equal(data.userDataForDisplay[idx][0]);
+				});
+
+				pageSelector.shadowRoot.querySelector('d2l-button-icon[text="Next page"]').click();
+				await innerTable.updateComplete;
+
+				expect(pageSelector.pageNumber).to.equal(2);
+
+				displayedUsers = Array.from(innerTable.shadowRoot.querySelectorAll('tbody > tr > td:first-child'));
+				expect(displayedUsers.length).to.equal(10);
+				displayedUsers.forEach((user, idx) => {
+					expect(user.innerText).to.equal(data.userDataForDisplay[idx + 10][0]);
+				});
+
+				pageSelector.shadowRoot.querySelector('d2l-button-icon[text="Next page"]').click();
+				await innerTable.updateComplete;
+
+				expect(pageSelector.pageNumber).to.equal(3);
+
+				displayedUsers = Array.from(innerTable.shadowRoot.querySelectorAll('tbody > tr > td:first-child'));
+				expect(displayedUsers.length).to.equal(3);
+				displayedUsers.forEach((user, idx) => {
+					expect(user.innerText).to.equal(data.userDataForDisplay[idx + 20][0]);
+				});
+			});
+
+			it('should show all users on a single page if there are fewer users than the page size', async() => {
+				pageSizeSelector.value = '50';
+				pageSizeSelector.dispatchEvent(new Event('change'));
+				await innerTable.updateComplete;
+
+				expect(pageSelector.selectedCountOption).to.equal(50);
+				expect(pageSelector.maxPageNumber).to.equal(1);
+				expect(pageSelector.pageNumber).to.equal(1);
+
+				const displayedUsers = Array.from(innerTable.shadowRoot.querySelectorAll('tbody > tr > td:first-child'));
+				expect(displayedUsers.length).to.equal(23);
+				displayedUsers.forEach((user, idx) => {
+					expect(user.innerText).to.equal(data.userDataForDisplay[idx][0]);
+				});
+
+			});
+
+			it('should show zero pages if there are no users to display', async() => {
+				el.data = { userDataForDisplay: [] };
+				await innerTable.updateComplete;
+
+				expect(pageSelector.selectedCountOption).to.equal(50);
+				expect(pageSelector.maxPageNumber).to.equal(0);
+				expect(pageSelector.pageNumber).to.equal(0);
+
+				const displayedUsers = Array.from(innerTable.shadowRoot.querySelectorAll('tbody > tr > td:first-child'));
+				expect(displayedUsers.length).to.equal(0);
+			});
+		});
+
 	});
 });


### PR DESCRIPTION
Brightspace UI Labs have synthesized a new component: pagination. Made from a piece of LitElement exposed to waaaaay too many edge-legacy-frustration radiation.

I guess you could call those problems I had... "edge cases" *ba-dum-tss*

Quality notes
* Testing (Chrome, FF, Edgium, Edge Legacy)
  * It changes which page of users are displayed when the page number changes
  * It changes how many users are displayed, and goes back to the first page, when the page size is changed
  * "Total users" still shows the total length, not the page size
  * NOT tested: what happens if the underlying data changes (e.g. if we do a server-side filter). I'm hoping we can defer this until the "Apply" story.
* Perf:
  * The list of users to display is stored as a calculated mobx property. It doesn't seem to be recalculated if I just access the property, which is good because the recalculation (which re-sorts the list) will probably be slow for a large list. 
  * I tested this by console.logging every time `get userDataForDisplay() ` was called.
* UX:
  * The pagination element is almost localized, except for the a11y label on the input box
  * It RTL's properly - except for a small glitch with the division symbol in Edge.
![image](https://user-images.githubusercontent.com/11587338/90679902-e49ba500-e22e-11ea-9da5-6938536312ed.png)
  * It is responsive (tested Chrome, FF, Edgium, Edge Legacy)
![image](https://user-images.githubusercontent.com/11587338/90680991-b15a1580-e230-11ea-9974-5869be323e28.png)
  * Screen reader and keyboard nav is ok (tested Chrome, Edge Legacy)
* Devops: 
  * https://github.com/Brightspace/brightspace-integration/pull/2398 needs to be merged as well
* Cost: N/A
* Security: N/A
* Docs: N/A

TODO list
- [x] Safari tests failing
- [x] Responsive notes
- [x] RTL notes
- [x] a11y "integration" testing

@Vitalii-Misechko @rohitvinnakota @MykolaGalian @hyehayes 