### PR TITLE
US118248 Refactoring, groundwork for calling server with filter params

### DIFF
--- a/components/role-filter.js
+++ b/components/role-filter.js
@@ -1,8 +1,8 @@
 import './dropdown-filter';
 
 import { html, LitElement } from 'lit-element';
-import FakeLms from '../model/fake-lms';
-import Lms from '../model/lms';
+import { fetchRoles as fetchDemoRoles } from '../model/fake-lms';
+import { fetchRoles } from '../model/lms';
 import { Localizer } from '../locales/localizer';
 
 /**
@@ -10,7 +10,7 @@ import { Localizer } from '../locales/localizer';
  * @fires d2l-insights-role-filter-change
  * @fires d2l-insights-role-filter-close
  */
-class InsightsRoleFilter extends Localizer(LitElement) {
+class RoleFilter extends Localizer(LitElement) {
 
 	static get properties() {
 		return {
@@ -28,8 +28,8 @@ class InsightsRoleFilter extends Localizer(LitElement) {
 	}
 
 	async firstUpdated() {
-		this._lms = this.isDemo ? new FakeLms() : new Lms();
-		const data = await this._lms.fetchRoles();
+		const dataProvider = this.isDemo ? fetchDemoRoles : fetchRoles;
+		const data = await dataProvider();
 		this._setRoleData(data);
 	}
 
@@ -83,4 +83,4 @@ class InsightsRoleFilter extends Localizer(LitElement) {
 	}
 
 }
-customElements.define('d2l-insights-role-filter', InsightsRoleFilter);
+customElements.define('d2l-insights-role-filter', RoleFilter);

--- a/components/semester-filter.js
+++ b/components/semester-filter.js
@@ -1,8 +1,8 @@
 import './dropdown-filter';
 
 import { html, LitElement } from 'lit-element';
-import FakeLms from '../model/fake-lms';
-import Lms from '../model/lms';
+import { fetchSemesters as fetchDemoSemesters } from '../model/fake-lms';
+import { fetchSemesters } from '../model/lms';
 import { Localizer } from '../locales/localizer';
 
 /**
@@ -38,7 +38,7 @@ class SemesterFilter extends Localizer(LitElement) {
 	}
 
 	async firstUpdated() {
-		this._lms = this.isDemo ? new FakeLms() : new Lms();
+		this.dataProvider = this.isDemo ? fetchDemoSemesters : fetchSemesters;
 		await this._loadData();
 	}
 
@@ -57,7 +57,7 @@ class SemesterFilter extends Localizer(LitElement) {
 	}
 
 	async _loadData() {
-		const data = await this._lms.fetchSemesters(this.pageSize);
+		const data = await this.dataProvider(this.pageSize);
 
 		this._filterData = data.Items.map(item => ({
 			id: item.orgUnitId.toString(),

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -2,67 +2,17 @@ import './components/histogram-card.js';
 import './components/ou-filter.js';
 import './components/results-card.js';
 import './components/debug-card.js';
-import './components/insights-role-filter.js';
+import './components/role-filter.js';
 import './components/semester-filter.js';
 import './components/users-table.js';
 import './components/table.js';
 
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { Data } from './model/data.js';
+import { fetchData } from './model/lms.js';
+import { fetchData as fetchDemoData } from './model/fake-lms.js';
 import { heading3Styles } from '@brightspace-ui/core/components/typography/styles';
 import { Localizer } from './locales/localizer';
-
-async function fetchData() {
-	const response = await fetch('/d2l/api/ap/unstable/insights/data/engagement');
-	return await response.json();
-}
-
-async function demoData() {
-	return new Promise(resolve =>
-		setTimeout(
-			() => resolve({
-				records: [
-					[1, 100, 500],
-					[1, 200, 600],
-					[2, 200, 700],
-					[2, 300, 700],
-					[2, 400, 700],
-					[2, 500, 700],
-					[8, 200, 700],
-					[6, 600, 700]
-				],
-				orgUnits: [
-					[1, 'Course 1', 3, [3, 4]],
-					[2, 'Course 2', 3, [3, 4]],
-					[6, 'Course 3 has a surprisingly long name, but nonetheless this kind of thing is bound to happen sometimes and we do need to design for it. Is that not so?', 3, [7, 4]],
-					[8, 'ZCourse 4', 3, [5]],
-					[3, 'Department 1', 2, [5]],
-					[7, 'Department 2 has a longer name', 2, [5]],
-					[4, 'Semester', 25, [6606]],
-					[5, 'Faculty 1', 7, [6606]],
-					[9, 'Faculty 2', 7, [6606]],
-					[6606, 'Dev', 1, [0]]
-				],
-				users: [ // some of which are out of order
-					[100,  'ATest', 'AStudent'],
-					[300,  'CTest', 'CStudent'],
-					[200,  'BTest', 'BStudent'],
-					[400,  'DTest', 'DStudent'],
-					[500,  'ETest', 'EStudent'],
-					[600,  'GTest', 'GStudent'],
-					[700,  'FTest', 'FStudent'],
-					[800,  'HTest', 'HStudent'],
-					[900,  'ITest', 'IStudent'],
-					[1000, 'KTest', 'KStudent'],
-					[1100, 'JTest', 'JStudent']
-				],
-				semesterTypeId: 25,
-				selectedOrgUnitIds: [1, 2]
-			}),
-			100
-		)
-	);
-}
 
 /**
  * @property {Boolean} useTestData - if true, use canned data; otherwise call the LMS
@@ -121,7 +71,7 @@ class EngagementDashboard extends Localizer(LitElement) {
 
 	render() {
 		this._data = new Data({
-			recordProvider: this.isDemo ? demoData : fetchData,
+			recordProvider: this.isDemo ? fetchDemoData : fetchData,
 			cardFilters: [
 				// {
 				// 	id: 'd2l-insights-engagement-summary',

--- a/model/data.js
+++ b/model/data.js
@@ -53,7 +53,7 @@ export class Data {
 		// mobx will run _persist() whenever relevant state changes
 		autorun(() => this._persist());
 
-		recordProvider().then(data => {
+		recordProvider(this.selectorFilters).then(data => {
 			this._orgUnitAncestors = new OrgUnitAncestors(data.orgUnits);
 			this._userDictionary = new Map(data.users.map(user => [user[USER.ID], user]));
 			this.isLoading = false;

--- a/model/fake-lms.js
+++ b/model/fake-lms.js
@@ -1,76 +1,118 @@
-class Lms {
-	/**
-	 * @returns {{Identifier: string, DisplayName: string, Code: string|null}[]}
-	 */
-	async fetchRoles() {
-		const demoData = [
-			{ Identifier: '500', DisplayName: 'Administrator' },
-			{ Identifier: '600', DisplayName: 'Instructor' },
-			{ Identifier: '700', DisplayName: 'Student' }
-		];
-
-		return new Promise(resolve =>	setTimeout(() => resolve(demoData), 100));
-	}
-
-	/**
-	 * @param pageSize
-	 * @param {string|null} bookmark - can be null
-	 * @param {string|null} search - can be null
-	 * @returns {{PagingInfo:{Bookmark: string, HasMoreItems: boolean}, Items: {orgUnitId: number, orgUnitName: string}[]}}
-	 */
-	async fetchSemesters(pageSize, bookmark, search) {
-		const response = {
-			PagingInfo: {
-				Bookmark: '0',
-				HasMoreItems: false
-			},
-			Items: [
-				{
-					orgUnitId: 10007,
-					orgUnitName: 'IPSIS Semester New'
-				},
-				{
-					orgUnitId: 121194,
-					orgUnitName: 'Fall Test Semester'
-				},
-				{
-					orgUnitId: 120127,
-					orgUnitName: 'IPSIS Test Semester 1'
-				},
-				{
-					orgUnitId: 120126,
-					orgUnitName: 'IPSIS Test Semester 12'
-				},
-				{
-					orgUnitId: 120125,
-					orgUnitName: 'IPSIS Test Semester 123'
-				},
-				{
-					orgUnitId: 120124,
-					orgUnitName: 'IPSIS Test Semester 4'
-				},
-				{
-					orgUnitId: 1201240,
-					orgUnitName: 'IPSIS Test Semester 42'
-				}
-			]
-		};
-
-		response.Items = response.Items.map((item, index) => Object.assign(item, { index }));
-
-		const index = parseInt(bookmark || '-1');
-		response.Items = response.Items.slice(index + 1);
-
-		if (search) {
-			response.Items = response.Items
-				.filter(item => item.orgUnitName.toLowerCase().includes(search.toLowerCase()));
-		}
-		response.PagingInfo.HasMoreItems = response.Items.length > pageSize;
-		response.Items = response.Items.slice(0, pageSize);
-		response.PagingInfo.Bookmark = response.Items[response.Items.length - 1].index.toString();
-
-		return new Promise(resolve =>	setTimeout(() => resolve(response), 100));
-	}
+// adding variables here to match signature of real LMS. The filters don't actually work though.
+// eslint-disable-next-line no-unused-vars
+export async function fetchData({ roleIds, semesterIds, orgUnitIds }) {
+	const demoData = {
+		records: [
+			[1, 100, 500],
+			[1, 200, 600],
+			[2, 200, 700],
+			[2, 300, 700],
+			[2, 400, 700],
+			[2, 500, 700],
+			[8, 200, 700],
+			[6, 600, 700]
+		],
+		orgUnits: [
+			[1, 'Course 1', 3, [3, 4]],
+			[2, 'Course 2', 3, [3, 4]],
+			[6, 'Course 3 has a surprisingly long name, but nonetheless this kind of thing is bound to happen sometimes and we do need to design for it. Is that not so?', 3, [7, 4]],
+			[8, 'ZCourse 4', 3, [5]],
+			[3, 'Department 1', 2, [5]],
+			[7, 'Department 2 has a longer name', 2, [5]],
+			[4, 'Semester', 25, [6606]],
+			[5, 'Faculty 1', 7, [6606]],
+			[9, 'Faculty 2', 7, [6606]],
+			[6606, 'Dev', 1, [0]]
+		],
+		users: [ // some of which are out of order
+			[100,  'ATest', 'AStudent'],
+			[300,  'CTest', 'CStudent'],
+			[200,  'BTest', 'BStudent'],
+			[400,  'DTest', 'DStudent'],
+			[500,  'ETest', 'EStudent'],
+			[600,  'GTest', 'GStudent'],
+			[700,  'FTest', 'FStudent'],
+			[800,  'HTest', 'HStudent'],
+			[900,  'ITest', 'IStudent'],
+			[1000, 'KTest', 'KStudent'],
+			[1100, 'JTest', 'JStudent']
+		],
+		semesterTypeId: 25,
+		selectedOrgUnitIds: [1, 2]
+	};
+	return new Promise(resolve => setTimeout(() => resolve(demoData), 100));
 }
 
-export default Lms;
+/**
+ * @returns {{Identifier: string, DisplayName: string, Code: string|null}[]}
+ */
+export async function fetchRoles() {
+	const demoData = [
+		{ Identifier: '500', DisplayName: 'Administrator' },
+		{ Identifier: '600', DisplayName: 'Instructor' },
+		{ Identifier: '700', DisplayName: 'Student' }
+	];
+
+	return new Promise(resolve =>	setTimeout(() => resolve(demoData), 100));
+}
+
+/**
+ * @param pageSize
+ * @param {string|null} bookmark - can be null
+ * @param {string|null} search - can be null
+ * @returns {{PagingInfo:{Bookmark: string, HasMoreItems: boolean}, Items: {orgUnitId: number, orgUnitName: string}[]}}
+ */
+export async function fetchSemesters(pageSize, bookmark, search) {
+	const response = {
+		PagingInfo: {
+			Bookmark: '0',
+			HasMoreItems: false
+		},
+		Items: [
+			{
+				orgUnitId: 10007,
+				orgUnitName: 'IPSIS Semester New'
+			},
+			{
+				orgUnitId: 121194,
+				orgUnitName: 'Fall Test Semester'
+			},
+			{
+				orgUnitId: 120127,
+				orgUnitName: 'IPSIS Test Semester 1'
+			},
+			{
+				orgUnitId: 120126,
+				orgUnitName: 'IPSIS Test Semester 12'
+			},
+			{
+				orgUnitId: 120125,
+				orgUnitName: 'IPSIS Test Semester 123'
+			},
+			{
+				orgUnitId: 120124,
+				orgUnitName: 'IPSIS Test Semester 4'
+			},
+			{
+				orgUnitId: 1201240,
+				orgUnitName: 'IPSIS Test Semester 42'
+			}
+		]
+	};
+
+	response.Items = response.Items.map((item, index) => Object.assign(item, { index }));
+
+	const index = parseInt(bookmark || '-1');
+	response.Items = response.Items.slice(index + 1);
+
+	if (search) {
+		response.Items = response.Items
+			.filter(item => item.orgUnitName.toLowerCase().includes(search.toLowerCase()));
+	}
+	response.PagingInfo.HasMoreItems = response.Items.length > pageSize;
+	response.Items = response.Items.slice(0, pageSize);
+	response.PagingInfo.Bookmark = response.Items[response.Items.length - 1].index.toString();
+
+	return new Promise(resolve =>	setTimeout(() => resolve(response), 100));
+}
+

--- a/model/lms.js
+++ b/model/lms.js
@@ -1,36 +1,55 @@
 const rolesEndpoint = '/d2l/api/lp/1.23/roles/';
+const semestersEndpoint = '/d2l/api/ap/unstable/insights/data/semesters';
+const dataEndpoint = '/d2l/api/ap/unstable/insights/data/engagement';
 
-class Lms {
-	/**
-	 * @returns {{Identifier: string, DisplayName: string, Code: string|null}[]}
-	 */
-	async fetchRoles() {
-		const response = await fetch(rolesEndpoint);
-
-		/**
-		 * Expected data format from Roles API
-		 * @type {{Identifier: string, DisplayName: string, Code: string|null}[]}
-		 */
-		return await response.json();
+/**
+ * @param {[Number]} roleIds
+ * @param {[Number]} semesterIds
+ * @param {[Number]} orgUnitIds
+ */
+export async function fetchData({ roleIds = [], semesterIds = [], orgUnitIds = [] }) {
+	const url = new URL(dataEndpoint, window.location.origin);
+	if (roleIds) {
+		url.searchParams.set('selectedRolesCsv', roleIds.join(','));
 	}
-
-	/**
-	 * @param {string|null} bookmark - can be null
-	 * @param {string|null} search - can be null
-	 * @returns {{PagingInfo:{Bookmark: string, HasMoreItems: boolean}, Items: {orgUnitId: number, orgUnitName: string}[]}}
-	 */
-	async fetchSemesters(pageSize, bookmark, search) {
-		const url = new URL('/d2l/api/ap/unstable/insights/data/semesters', location.href);
-		url.searchParams.set('pageSize', pageSize);
-		if (bookmark) {
-			url.searchParams.set('bookmark', bookmark);
-		}
-		if (search) {
-			url.searchParams.set('search', search);
-		}
-		const response = await fetch(url);
-		return await response.json();
+	if (semesterIds) {
+		url.searchParams.set('selectedSemestersCsv', semesterIds.join(','));
 	}
+	if (orgUnitIds) {
+		url.searchParams.set('selectedOrgUnitIdsCsv', orgUnitIds.join(','));
+	}
+	const response = await fetch(url.toString());
+	return await response.json();
 }
 
-export default Lms;
+/**
+ * @returns {{Identifier: string, DisplayName: string, Code: string|null}[]}
+ */
+export async function fetchRoles() {
+	const response = await fetch(rolesEndpoint);
+
+	/**
+	 * Expected data format from Roles API
+	 * @type {{Identifier: string, DisplayName: string, Code: string|null}[]}
+	 */
+	return await response.json();
+}
+
+/**
+ * @param {Number} pageSize
+ * @param {string|null} bookmark - can be null
+ * @param {string|null} search - can be null
+ * @returns {{PagingInfo:{Bookmark: string, HasMoreItems: boolean}, Items: {orgUnitId: number, orgUnitName: string}[]}}
+ */
+export async function fetchSemesters(pageSize, bookmark, search) {
+	const url = new URL(semestersEndpoint, window.location.origin);
+	url.searchParams.set('pageSize', pageSize.toString());
+	if (bookmark) {
+		url.searchParams.set('bookmark', bookmark);
+	}
+	if (search) {
+		url.searchParams.set('search', search);
+	}
+	const response = await fetch(url.toString());
+	return await response.json();
+}

--- a/test/components/role-filter.test.js
+++ b/test/components/role-filter.test.js
@@ -1,4 +1,4 @@
-import '../../components/insights-role-filter';
+import '../../components/role-filter';
 
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import fetchMock from 'fetch-mock/esm/client';

--- a/test/model/lms.test.js
+++ b/test/model/lms.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@open-wc/testing';
 import fetchMock from 'fetch-mock/esm/client';
-import Lms from '../../model/lms';
+import { fetchRoles } from '../../model/lms';
 
 const rolesEndpoint = '/d2l/api/lp/1.23/roles/';
 
@@ -28,8 +28,7 @@ describe('Lms', () => {
 			fetchMock.reset();
 			fetchMock.get(rolesEndpoint, mockLmsResponseData);
 
-			const sut = new Lms();
-			expect(await sut.fetchRoles()).to.deep.equal(mockLmsResponseData);
+			expect(await fetchRoles()).to.deep.equal(mockLmsResponseData);
 		});
 	});
 


### PR DESCRIPTION
Moving some things around and renaming others. I also "de-classed" LMS and FakeLMS because I wanted to be able to use the functions statically.

Testing: 
* Still works as before on Chrome, Edge Legacy
* Hardcoding OrgUnit ids into `lms.fetchData` fetched the correctly filtered data from the server. Tested with a Department, a Course Template and a Course Offering. OU filter is updated based on `serverData.selectedOrgUnitIds`

@MykolaGalian @rohitvinnakota @hyehayes @anhill-D2L 