### PR TITLE
US118248 Reload data from server if necessary

### DIFF
--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -88,17 +88,17 @@ class EngagementDashboard extends Localizer(LitElement) {
 				<h1 class="d2l-heading-1">${this.localize('components.insights-engagement-dashboard.title')}</h1>
 
 				<div class="view-filters-container">
-					<d2l-insights-ou-filter .data="${this._data}" @d2l-insights-ou-filter-change="${this._onOuFilterChange}"></d2l-insights-ou-filter>
+					<d2l-insights-ou-filter
+						.data="${this._data}"
+						@d2l-insights-ou-filter-change="${this._orgUnitFilterChange}"
+					></d2l-insights-ou-filter>
 					<d2l-insights-semester-filter
 						page-size="10000"
 						?demo="${this.isDemo}"
 						@d2l-insights-semester-filter-change="${this._semesterFilterChange}"
-						@d2l-insights-semester-filter-close="${this._semesterFilterChange}"
-						>
-					</d2l-insights-semester-filter>
+					></d2l-insights-semester-filter>
 					<d2l-insights-role-filter
-						@d2l-insights-role-filter-change="${this._handleRoleSelectionsUpdated}"
-						@d2l-insights-role-filter-close="${this._handleRoleSelectionsUpdated}"
+						@d2l-insights-role-filter-change="${this._roleFilterChange}"
 						?demo="${this.isDemo}"
 					></d2l-insights-role-filter>
 				</div>
@@ -116,22 +116,18 @@ class EngagementDashboard extends Localizer(LitElement) {
 		`;
 	}
 
-	_handleRoleSelectionsUpdated(event) {
+	_roleFilterChange(event) {
 		event.stopPropagation();
-
-		console.log(`List of selected role ids: ${event.target.selected}`);
 		this._data.applyRoleFilters(event.target.selected.map(roleId => Number(roleId)));
 	}
 
-	_onOuFilterChange(e) {
-		console.log(`got ou filter change with selected ids ${JSON.stringify(e.target.selected)}`);
-		this._data.applyOrgUnitFilters(e.target.selected);
+	_orgUnitFilterChange(event) {
+		event.stopPropagation();
+		this._data.applyOrgUnitFilters(event.target.selected);
 	}
 
 	_semesterFilterChange(event) {
 		event.stopPropagation();
-
-		console.log(`List of selected semesters: ${event.target.selected}`);
 		this._data.applySemesterFilters(event.target.selected.map(semesterId => Number(semesterId)));
 	}
 }

--- a/model/orgUnitAncestors.js
+++ b/model/orgUnitAncestors.js
@@ -1,9 +1,4 @@
-const ORG_UNIT = {
-	ID: 0,
-	NAME: 1,
-	TYPE: 2,
-	ANCESTORS: 3
-};
+import { ORG_UNIT } from './data';
 
 class OrgUnitAncestors {
 	/**
@@ -56,6 +51,22 @@ class OrgUnitAncestors {
 	 */
 	getAncestorsFor(orgUnitId) {
 		return this.ancestorsMap.get(orgUnitId);
+	}
+
+	/**
+	 * Checks if an orgUnit has ancestors in a given list.
+	 * NOTE: returns true if the orgUnit itself is in the list.
+	 * @param {Number} orgUnitId - the orgUnit whose ancestors we want to check
+	 * @param {[Number]} listToCheck - an array of orgUnitIds which potentially has ancestors in it
+	 * @returns {boolean}
+	 */
+	hasAncestorsInList(orgUnitId, listToCheck) {
+		const ancestorsSet = this.getAncestorsFor(orgUnitId);
+		if (!ancestorsSet) {
+			return false;
+		}
+
+		return listToCheck.some(potentialAncestor => ancestorsSet.has(potentialAncestor));
 	}
 }
 export default OrgUnitAncestors;

--- a/model/selectorFilters.js
+++ b/model/selectorFilters.js
@@ -12,12 +12,12 @@ function isFilterCleared(oldSelectedIds, newSelectedIds) {
 export class RoleSelectorFilter {
 	constructor({ selectedRolesIds, isRecordsTruncated }) {
 		this._latestServerQuery = selectedRolesIds || [];
-		this.roleIds = selectedRolesIds || [];
+		this.selected = selectedRolesIds || [];
 		this._isRecordsTruncated = isRecordsTruncated;
 	}
 
 	shouldInclude(record) {
-		return !hasSelections(this.roleIds) || this.roleIds.includes(record[RECORD.ROLE_ID]);
+		return !hasSelections(this.selected) || this.selected.includes(record[RECORD.ROLE_ID]);
 	}
 
 	shouldReloadFromServer(newRoleIds) {
@@ -33,18 +33,18 @@ export class RoleSelectorFilter {
 export class SemesterSelectorFilter {
 	constructor({ selectedSemestersIds, isRecordsTruncated, isOrgUnitsTruncated }, orgUnitAncestors) {
 		this._latestServerQuery = selectedSemestersIds || [];
-		this.semesterIds = selectedSemestersIds || [];
+		this.selected = selectedSemestersIds || [];
 		this._isRecordsTruncated = isRecordsTruncated;
 		this._isOrgUnitsTruncated = isOrgUnitsTruncated;
 		this._orgUnitAncestors = orgUnitAncestors;
 	}
 
 	shouldInclude(record) {
-		if (!hasSelections(this.semesterIds) || !this._orgUnitAncestors) {
+		if (!hasSelections(this.selected) || !this._orgUnitAncestors) {
 			return true;
 		}
 
-		return this._orgUnitAncestors.hasAncestorsInList(record[RECORD.ORG_UNIT_ID], this.semesterIds);
+		return this._orgUnitAncestors.hasAncestorsInList(record[RECORD.ORG_UNIT_ID], this.selected);
 	}
 
 	shouldReloadFromServer(newSemesterIds) {
@@ -63,17 +63,17 @@ export class SemesterSelectorFilter {
 export class OrgUnitSelectorFilter {
 	constructor({ selectedOrgUnitIds, isRecordsTruncated }, orgUnitAncestors) {
 		this._latestServerQuery = selectedOrgUnitIds || [];
-		this.orgUnitIds = selectedOrgUnitIds || [];
+		this.selected = selectedOrgUnitIds || [];
 		this._isRecordsTruncated = isRecordsTruncated;
 		this._orgUnitAncestors = orgUnitAncestors;
 	}
 
 	shouldInclude(record) {
-		if (!hasSelections(this.orgUnitIds) || !this._orgUnitAncestors) {
+		if (!hasSelections(this.selected) || !this._orgUnitAncestors) {
 			return true;
 		}
 
-		return this._orgUnitAncestors.hasAncestorsInList(record[RECORD.ORG_UNIT_ID], this.orgUnitIds);
+		return this._orgUnitAncestors.hasAncestorsInList(record[RECORD.ORG_UNIT_ID], this.selected);
 	}
 
 	shouldReloadFromServer(newOrgUnitIds) {
@@ -88,13 +88,13 @@ export class OrgUnitSelectorFilter {
 }
 
 decorate(RoleSelectorFilter, {
-	roleIds: observable
+	selected: observable
 });
 
 decorate(SemesterSelectorFilter, {
-	semesterIds: observable
+	selected: observable
 });
 
 decorate(OrgUnitSelectorFilter, {
-	orgUnitIds: observable
+	selected: observable
 });

--- a/model/selectorFilters.js
+++ b/model/selectorFilters.js
@@ -1,0 +1,87 @@
+import { decorate, observable } from 'mobx';
+import { RECORD } from './data';
+
+function isFilterApplied(selectedIds) {
+	return selectedIds.length > 0;
+}
+
+function isFilterCleared(oldSelectedIds, newSelectedIds) {
+	return isFilterApplied(oldSelectedIds) && !isFilterApplied(newSelectedIds);
+}
+
+export class RoleSelectorFilter {
+	constructor({ selectedRolesIds, isRecordsTruncated }) {
+		this.roleIds = selectedRolesIds || [];
+		this._isRecordsTruncated = isRecordsTruncated;
+	}
+
+	shouldInclude(record) {
+		return !isFilterApplied(this.roleIds) || this.roleIds.includes(record[RECORD.ROLE_ID]);
+	}
+
+	shouldReloadFromServer(newRoleIds) {
+		return this._isRecordsTruncated
+			|| isFilterCleared(this.roleIds, newRoleIds) // filter was cleared
+			|| newRoleIds.some(newRoleId => !this.roleIds.includes(newRoleId));
+	}
+}
+
+export class SemesterSelectorFilter {
+	constructor({ selectedSemestersIds, isRecordsTruncated, isOrgUnitsTruncated }, orgUnitAncestors) {
+		this.semesterIds = selectedSemestersIds || [];
+		this._isRecordsTruncated = isRecordsTruncated;
+		this._isOrgUnitsTruncated = isOrgUnitsTruncated;
+		this._orgUnitAncestors = orgUnitAncestors;
+	}
+
+	shouldInclude(record) {
+		if (!isFilterApplied(this.semesterIds) || !this._orgUnitAncestors) {
+			return true;
+		}
+
+		return this._orgUnitAncestors.hasAncestorsInList(record[RECORD.ORG_UNIT_ID], this.semesterIds);
+	}
+
+	shouldReloadFromServer(newSemesterIds) {
+		return this._isRecordsTruncated
+			|| this._isOrgUnitsTruncated
+			|| isFilterCleared(this.semesterIds, newSemesterIds)
+			|| newSemesterIds.some(newSemesterId => !this.semesterIds.includes(newSemesterId));
+	}
+}
+
+export class OrgUnitSelectorFilter {
+	constructor({ selectedOrgUnitIds, isRecordsTruncated }, orgUnitAncestors) {
+		this.orgUnitIds = selectedOrgUnitIds || [];
+		this._isRecordsTruncated = isRecordsTruncated;
+		this._orgUnitAncestors = orgUnitAncestors;
+	}
+
+	shouldInclude(record) {
+		if (!isFilterApplied(this.orgUnitIds) || !this._orgUnitAncestors) {
+			return true;
+		}
+
+		return this._orgUnitAncestors.hasAncestorsInList(record[RECORD.ORG_UNIT_ID], this.orgUnitIds);
+	}
+
+	shouldReloadFromServer(newOrgUnitIds) {
+		return this._isRecordsTruncated
+			|| isFilterCleared(this.orgUnitIds, newOrgUnitIds)
+			|| newOrgUnitIds.some(newOrgUnitId =>
+				!this._orgUnitAncestors.hasAncestorsInList(newOrgUnitId, this.orgUnitIds)
+			);
+	}
+}
+
+decorate(RoleSelectorFilter, {
+	roleIds: observable
+});
+
+decorate(SemesterSelectorFilter, {
+	semesterIds: observable
+});
+
+decorate(OrgUnitSelectorFilter, {
+	orgUnitIds: observable
+});

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "karma-sauce-launcher": "^4",
     "lit-analyzer": "^1.2.0",
     "puppeteer": "^5",
+    "sinon": "^9.0.3",
     "stylelint": "^13.6.1"
   },
   "dependencies": {

--- a/test/components/users-table.test.js
+++ b/test/components/users-table.test.js
@@ -44,8 +44,10 @@ describe('d2l-insights-users-table', () => {
 			before(async() => {
 				el = await fixture(html`<d2l-insights-users-table .data="${data}"></d2l-insights-users-table>`);
 				innerTable = el.shadowRoot.querySelector('d2l-insights-table');
+				await new Promise(resolve => setTimeout(resolve, 200));
 				await innerTable.updateComplete;
 				pageSelector = el.shadowRoot.querySelector('d2l-labs-pagination');
+				await pageSelector.updateComplete;
 				pageSizeSelector = pageSelector.shadowRoot.querySelector('select');
 			});
 
@@ -68,6 +70,7 @@ describe('d2l-insights-users-table', () => {
 					.shadowRoot.querySelector('d2l-button-icon[text="Next page"]')
 					.shadowRoot.querySelector('button')
 					.click();
+				await new Promise(resolve => setTimeout(resolve, 200));
 				await innerTable.updateComplete;
 				await pageSelector.updateComplete;
 
@@ -83,6 +86,7 @@ describe('d2l-insights-users-table', () => {
 			it('should change number of users shown and total number of pages if the page size changes', async() => {
 				pageSizeSelector.value = '10';
 				pageSizeSelector.dispatchEvent(new Event('change'));
+				await new Promise(resolve => setTimeout(resolve, 200));
 				await innerTable.updateComplete;
 				await pageSelector.updateComplete;
 
@@ -100,6 +104,7 @@ describe('d2l-insights-users-table', () => {
 					.shadowRoot.querySelector('d2l-button-icon[text="Next page"]')
 					.shadowRoot.querySelector('button')
 					.click();
+				await new Promise(resolve => setTimeout(resolve, 200));
 				await innerTable.updateComplete;
 				await pageSelector.updateComplete;
 
@@ -115,6 +120,7 @@ describe('d2l-insights-users-table', () => {
 					.shadowRoot.querySelector('d2l-button-icon[text="Next page"]')
 					.shadowRoot.querySelector('button')
 					.click();
+				await new Promise(resolve => setTimeout(resolve, 200));
 				await innerTable.updateComplete;
 				await pageSelector.updateComplete;
 
@@ -130,6 +136,7 @@ describe('d2l-insights-users-table', () => {
 			it('should show all users on a single page if there are fewer users than the page size', async() => {
 				pageSizeSelector.value = '50';
 				pageSizeSelector.dispatchEvent(new Event('change'));
+				await new Promise(resolve => setTimeout(resolve, 200));
 				await innerTable.updateComplete;
 				await pageSelector.updateComplete;
 
@@ -147,6 +154,7 @@ describe('d2l-insights-users-table', () => {
 
 			it('should show zero pages if there are no users to display', async() => {
 				el.data = { userDataForDisplay: [] };
+				await new Promise(resolve => setTimeout(resolve, 200));
 				await innerTable.updateComplete;
 				await pageSelector.updateComplete;
 
@@ -158,6 +166,5 @@ describe('d2l-insights-users-table', () => {
 				expect(displayedUsers.length).to.equal(0);
 			});
 		});
-
 	});
 });

--- a/test/model/data.test.js
+++ b/test/model/data.test.js
@@ -1,5 +1,7 @@
+import { OrgUnitSelectorFilter, RoleSelectorFilter, SemesterSelectorFilter } from '../../model/selectorFilters';
 import { Data } from '../../model/data.js';
 import { expect } from '@open-wc/testing';
+import sinon from 'sinon/pkg/sinon-esm.js';
 
 const mockOuTypes = {
 	organization: 0,
@@ -127,6 +129,102 @@ describe('Data', () => {
 		await new Promise(resolve => setTimeout(resolve, 0)); // allow recordProvider to resolve
 	});
 
+	describe('applyRoleFilter', () => {
+		it('should cause a reload from server if filter says it should reload', () => {
+			const recordProvider = sinon.stub().resolves(serverData);
+			sut.recordProvider = recordProvider;
+
+			// set isRecordsTruncated to true to force a reload
+			sut._selectorFilters.role = new RoleSelectorFilter({ selectedRolesIds: null, isRecordsTruncated: true });
+			sut.applyRoleFilters([mockRoleIds.student]);
+
+			sinon.assert.calledWithMatch(recordProvider, sinon.match({
+				roleIds: [mockRoleIds.student],
+				semesterIds: [],
+				orgUnitIds: []
+			}));
+		});
+
+		it('should not cause a reload from server if filter says it should not reload', () => {
+			const recordProvider = sinon.stub().resolves(serverData);
+			sut.recordProvider = recordProvider;
+
+			// set isRecordsTruncated to false and selectedRolesIds to null to force no reload
+			sut._selectorFilters.role = new RoleSelectorFilter({ selectedRolesIds: null, isRecordsTruncated: false });
+			sut.applyRoleFilters([mockRoleIds.student]);
+
+			sinon.assert.notCalled(recordProvider);
+		});
+	});
+
+	describe('applySemesterFilter', () => {
+		it('should cause a reload from server if filter says it should reload', () => {
+			const recordProvider = sinon.stub().resolves(serverData);
+			sut.recordProvider = recordProvider;
+
+			// set isRecordsTruncated to true to force a reload
+			sut._selectorFilters.semester = new SemesterSelectorFilter({
+				selectedSemestersIds: null,
+				isRecordsTruncated: true
+			}, null);
+			sut.applySemesterFilters([11]);
+
+			sinon.assert.calledWithMatch(recordProvider, sinon.match({
+				roleIds: [],
+				semesterIds: [11],
+				orgUnitIds: []
+			}));
+		});
+
+		it('should not cause a reload from server if filter says it should not reload', () => {
+			const recordProvider = sinon.stub().resolves(serverData);
+			sut.recordProvider = recordProvider;
+
+			// set isRecordsTruncated to false and selectedRolesIds to null to force no reload
+			sut._selectorFilters.semester = new SemesterSelectorFilter({
+				selectedSemestersIds: null,
+				isRecordsTruncated: false
+			}, null);
+			sut.applySemesterFilters([mockRoleIds.student]);
+
+			sinon.assert.notCalled(recordProvider);
+		});
+	});
+
+	describe('applyOrgUnitFilter', () => {
+		it('should cause a reload from server if filter says it should reload', () => {
+			const recordProvider = sinon.stub().resolves(serverData);
+			sut.recordProvider = recordProvider;
+
+			// set isRecordsTruncated to true to force a reload
+			sut._selectorFilters.orgUnit = new OrgUnitSelectorFilter({
+				selectedOrgUnitIds: null,
+				isRecordsTruncated: true
+			}, null);
+			sut.applyOrgUnitFilters([1001]);
+
+			sinon.assert.calledWithMatch(recordProvider, sinon.match({
+				roleIds: [],
+				semesterIds: [],
+				orgUnitIds: [1001]
+			}));
+		});
+
+		it('should not cause a reload from server if filter says it should not reload', () => {
+			const recordProvider = sinon.stub().resolves(serverData);
+			sut.recordProvider = recordProvider;
+
+			// set isRecordsTruncated to false and selectedRolesIds to null to force no reload
+			sut._selectorFilters.orgUnit = new OrgUnitSelectorFilter({
+				selectedSemestersIds: null,
+				isRecordsTruncated: false
+			}, null);
+			sut.applyOrgUnitFilters([1001]);
+
+			sinon.assert.notCalled(recordProvider);
+		});
+	});
+
 	describe('get records', () => {
 		it('should return all records when no filters are applied', async() => {
 			expect(sut.records).to.deep.equal(serverData.records);
@@ -140,7 +238,6 @@ describe('Data', () => {
 			});
 
 			sut.applyOrgUnitFilters(orgUnitFilters);
-			await new Promise(resolve => setTimeout(resolve, 0)); // wait for it to "reload data from server"
 
 			expect(sut.records).to.deep.equal(expectedRecords);
 		});
@@ -153,7 +250,6 @@ describe('Data', () => {
 			});
 
 			sut.applySemesterFilters(semesterFilters);
-			await new Promise(resolve => setTimeout(resolve, 0)); // wait for it to "reload data from server"
 
 			expect(sut.records).to.deep.equal(expectedRecords);
 		});
@@ -165,7 +261,6 @@ describe('Data', () => {
 			});
 
 			sut.applyRoleFilters(roleFilters);
-			await new Promise(resolve => setTimeout(resolve, 0)); // wait for it to "reload data from server"
 
 			expect(sut.records).to.deep.equal(expectedRecords);
 		});
@@ -179,11 +274,8 @@ describe('Data', () => {
 			);
 
 			sut.applyOrgUnitFilters(orgUnitFilters);
-			await new Promise(resolve => setTimeout(resolve, 0)); // wait for it to "reload data from server"
 			sut.applySemesterFilters(semesterFilters);
-			await new Promise(resolve => setTimeout(resolve, 0)); // wait for it to "reload data from server"
 			sut.applyRoleFilters(roleFilters);
-			await new Promise(resolve => setTimeout(resolve, 0)); // wait for it to "reload data from server"
 
 			expect(sut.records).to.deep.equal(expectedRecords);
 		});
@@ -202,7 +294,6 @@ describe('Data', () => {
 			});
 
 			sut.applyOrgUnitFilters(orgUnitFilters);
-			await new Promise(resolve => setTimeout(resolve, 0)); // wait for it to "reload data from server"
 
 			expect(sut.users).to.deep.equal(expectedUsers);
 		});
@@ -215,7 +306,6 @@ describe('Data', () => {
 			});
 
 			sut.applySemesterFilters(semesterFilters);
-			await new Promise(resolve => setTimeout(resolve, 0)); // wait for it to "reload data from server"
 
 			expect(sut.users).to.deep.equal(expectedUsers);
 		});
@@ -228,7 +318,6 @@ describe('Data', () => {
 			});
 
 			sut.applyRoleFilters(roleFilters);
-			await new Promise(resolve => setTimeout(resolve, 0)); // wait for it to "reload data from server"
 
 			expect(sut.users).to.deep.equal(expectedUsers);
 		});
@@ -243,11 +332,8 @@ describe('Data', () => {
 			});
 
 			sut.applyOrgUnitFilters(orgUnitFilters);
-			await new Promise(resolve => setTimeout(resolve, 0)); // wait for it to "reload data from server"
 			sut.applySemesterFilters(semesterFilters);
-			await new Promise(resolve => setTimeout(resolve, 0)); // wait for it to "reload data from server"
 			sut.applyRoleFilters(roleFilters);
-			await new Promise(resolve => setTimeout(resolve, 0)); // wait for it to "reload data from server"
 
 			expect(sut.users).to.deep.equal(expectedUsers);
 		});
@@ -273,7 +359,6 @@ describe('Data', () => {
 			];
 
 			sut.applyRoleFilters(roleFilters);
-			await new Promise(resolve => setTimeout(resolve, 0)); // wait for it to "reload data from server"
 
 			expect(sut.userDataForDisplay).to.deep.equal(expectedUsers);
 		});

--- a/test/model/orgUnitAncestors.test.js
+++ b/test/model/orgUnitAncestors.test.js
@@ -82,4 +82,26 @@ describe('orgUnitAncestors', () => {
 			expect(sut.getAncestorsFor(12345)).to.be.undefined;
 		});
 	});
+
+	describe('hasAncestorsInList', () => {
+		it('returns false if passed in orgUnit is not in the ancestors list', () => {
+			expect(sut.hasAncestorsInList(12345, [6606])).to.be.false;
+		});
+
+		it('returns false if orgUnit is not in the list to check', () => {
+			expect(sut.hasAncestorsInList(1001, [1002, 1003])).to.be.false;
+		});
+
+		it('returns false if orgUnit has no ancestors in the list to check', () => {
+			expect(sut.hasAncestorsInList(1, [1002, 1003])).to.be.false;
+		});
+
+		it('returns true if orgUnit is in the list to check', () => {
+			expect(sut.hasAncestorsInList(1001, [1001, 1002])).to.be.true;
+		});
+
+		it('returns true if orgUnit has ancestors in the list to check', () => {
+			expect(sut.hasAncestorsInList(1, [1001, 1002])).to.be.true;
+		});
+	});
 });

--- a/test/model/selectorFilters.test.js
+++ b/test/model/selectorFilters.test.js
@@ -49,7 +49,7 @@ describe('selectorFilters', () => {
 				expect(sut.shouldReloadFromServer(newRoleIds)).to.be.false;
 
 				// apply local changes - make sure it won't reload from server if it doesn't need to
-				sut.roleIds = [1, 3, 5];
+				sut.selected = [1, 3, 5];
 				expect(sut.shouldReloadFromServer([1, 3, 5])).to.be.false;
 				expect(sut.shouldReloadFromServer([1, 3, 5, 7])).to.be.false;
 				expect(sut.shouldReloadFromServer([])).to.be.false;
@@ -72,7 +72,7 @@ describe('selectorFilters', () => {
 				const sut = new RoleSelectorFilter({ selectedRolesIds: [1, 3, 5], isRecordsTruncated: false });
 
 				// apply local changes
-				sut.roleIds = [1, 3];
+				sut.selected = [1, 3];
 				expect(sut.shouldReloadFromServer([1, 3])).to.be.false;
 				// if it were using the newly applied local selection, this next line would be true
 				expect(sut.shouldReloadFromServer([1, 3, 5])).to.be.false;
@@ -174,7 +174,7 @@ describe('selectorFilters', () => {
 				expect(sut.shouldReloadFromServer(newSemesterIds)).to.be.false;
 
 				// apply local changes - make sure it won't reload from server if it doesn't need to
-				sut.semesterIds = [1, 3, 5];
+				sut.selected = [1, 3, 5];
 				expect(sut.shouldReloadFromServer([1, 3, 5])).to.be.false;
 				expect(sut.shouldReloadFromServer([1, 3, 5, 7])).to.be.false;
 				expect(sut.shouldReloadFromServer([])).to.be.false;
@@ -209,7 +209,7 @@ describe('selectorFilters', () => {
 				}, null);
 
 				// apply local changes
-				sut.semesterIds = [1, 3];
+				sut.selected = [1, 3];
 				expect(sut.shouldReloadFromServer([1, 3])).to.be.false;
 				// if it were using the newly applied local selection, this next line would be true
 				expect(sut.shouldReloadFromServer([1, 3, 5])).to.be.false;
@@ -299,7 +299,7 @@ describe('selectorFilters', () => {
 				expect(sut.shouldReloadFromServer(newOrgUnitIds)).to.be.false;
 
 				// apply local changes - make sure it won't reload from server if it doesn't need to
-				sut.orgUnitIds = [1, 3, 5];
+				sut.selected = [1, 3, 5];
 				expect(sut.shouldReloadFromServer([1, 3, 5])).to.be.false;
 				expect(sut.shouldReloadFromServer([1, 3, 5, 7])).to.be.false;
 				expect(sut.shouldReloadFromServer([])).to.be.false;
@@ -329,7 +329,7 @@ describe('selectorFilters', () => {
 				}, mockOrgUnitAncestors);
 
 				// apply local changes
-				sut.orgUnitIds = [1, 3];
+				sut.selected = [1, 3];
 				expect(sut.shouldReloadFromServer([1, 3])).to.be.false;
 				// if it were using the newly applied local selection, this next line would be true
 				expect(sut.shouldReloadFromServer([1, 3, 5])).to.be.false;

--- a/test/model/selectorFilters.test.js
+++ b/test/model/selectorFilters.test.js
@@ -1,0 +1,253 @@
+import { OrgUnitSelectorFilter, RoleSelectorFilter, SemesterSelectorFilter } from '../../model/selectorFilters';
+import { expect } from '@open-wc/testing';
+
+describe('selectorFilters', () => {
+	describe('RoleSelectorFilter', () => {
+		describe('shouldInclude', () => {
+			it('should return true if the filter has no selected ids', () => {
+				const record = [1, 1, 1]; // doesn't matter what the ids are here
+				const sut = new RoleSelectorFilter({ selectedRolesIds: [], isRecordsTruncated: false });
+				expect(sut.shouldInclude(record)).to.be.true;
+			});
+
+			it('should return true if the record role id is in the selected ids', () => {
+				const record = [1, 1, 1];
+				const sut = new RoleSelectorFilter({ selectedRolesIds: [1, 3, 5], isRecordsTruncated: false });
+				expect(sut.shouldInclude(record)).to.be.true;
+			});
+
+			it('should return false if the record role id is not in the selected ids', () => {
+				const record = [1, 1, 2];
+				const sut = new RoleSelectorFilter({ selectedRolesIds: [1, 3, 5], isRecordsTruncated: false });
+				expect(sut.shouldInclude(record)).to.be.false;
+			});
+		});
+
+		describe('shouldReloadFromServer', () => {
+			it('should return true if records are truncated', () => {
+				const newRoleIds = [1, 3]; // a list that otherwise wouldn't trigger a server reload
+				const sut = new RoleSelectorFilter({ selectedRolesIds: [1, 3, 5], isRecordsTruncated: true });
+				expect(sut.shouldReloadFromServer(newRoleIds)).to.be.true;
+			});
+
+			it('should return true if the existing selected list has items and the new list has no items', () => {
+				// i.e. the filter was cleared
+				const newRoleIds = [ /* empty */ ];
+				const sut = new RoleSelectorFilter({ selectedRolesIds: [1, 3, 5], isRecordsTruncated: false });
+				expect(sut.shouldReloadFromServer(newRoleIds)).to.be.true;
+			});
+
+			it('should return true if the new role ids list has an id that is not in the existing list', () => {
+				const newRoleIds = [1, 2, 5];
+				const sut = new RoleSelectorFilter({ selectedRolesIds: [1, 3, 5], isRecordsTruncated: false });
+				expect(sut.shouldReloadFromServer(newRoleIds)).to.be.true;
+			});
+
+			it('should return false if the new list is the same as the old list', () => {
+				// added an explicit test for this because it could potentially happen often
+				const newRoleIds = [1, 3, 5];
+				const sut = new RoleSelectorFilter({ selectedRolesIds: [1, 3, 5], isRecordsTruncated: false });
+				expect(sut.shouldReloadFromServer(newRoleIds)).to.be.false;
+			});
+
+			it('should return false if the new list is a subset of the old list', () => {
+				const newRoleIds = [1, 3];
+				const sut = new RoleSelectorFilter({ selectedRolesIds: [1, 3, 5], isRecordsTruncated: false });
+				expect(sut.shouldReloadFromServer(newRoleIds)).to.be.false;
+			});
+		});
+	});
+
+	describe('SemesterSelectorFilter', () => {
+		describe('shouldInclude', () => {
+			it('should return true if the filter has no selected ids', () => {
+				const record = [1, 1, 1]; // doesn't matter what the ids are here
+				const sut = new SemesterSelectorFilter({
+					selectedSemestersIds: [],
+					isRecordsTruncated: false,
+					isOrgUnitsTruncated: false
+				}, null);
+				expect(sut.shouldInclude(record)).to.be.true;
+			});
+
+			it('should return true if the record orgUnit id has a selected semester id as one of its ancestors', () => {
+				const mockOrgUnitAncestors = {
+					hasAncestorsInList: (/* any */) => true
+				};
+				const record = [1, 1, 1]; // doesn't matter what the ids are here
+				const sut = new SemesterSelectorFilter({
+					selectedSemestersIds: [11, 12],
+					isRecordsTruncated: false,
+					isOrgUnitsTruncated: false
+				}, mockOrgUnitAncestors);
+
+				expect(sut.shouldInclude(record)).to.be.true;
+			});
+
+			it('should return false if the record orgUnitId has no ancestors in the selected ids', () => {
+				const mockOrgUnitAncestors = {
+					hasAncestorsInList: (/* any */) => false
+				};
+				const record = [1, 1, 1]; // doesn't matter what the ids are here
+				const sut = new SemesterSelectorFilter({
+					selectedSemestersIds: [12, 13],
+					isRecordsTruncated: false,
+					isOrgUnitsTruncated: false
+				}, mockOrgUnitAncestors);
+
+				expect(sut.shouldInclude(record)).to.be.false;
+			});
+		});
+
+		describe('shouldReloadFromServer', () => {
+			it('should return true if records are truncated', () => {
+				const newSemesterIds = [1, 3]; // a list that otherwise wouldn't trigger a server reload
+				const sut = new SemesterSelectorFilter({
+					selectedSemestersIds: [1, 3, 5],
+					isRecordsTruncated: true,
+					isOrgUnitsTruncated: false
+				}, null);
+				expect(sut.shouldReloadFromServer(newSemesterIds)).to.be.true;
+			});
+
+			it('should return true if orgUnits are truncated', () => {
+				const newSemesterIds = [1, 3]; // a list that otherwise wouldn't trigger a server reload
+				const sut = new SemesterSelectorFilter({
+					selectedOrgUnitIds: [1, 3, 5],
+					isRecordsTruncated: false,
+					isOrgUnitsTruncated: true
+				}, null);
+				expect(sut.shouldReloadFromServer(newSemesterIds)).to.be.true;
+			});
+
+			it('should return true if the existing selected list has items and the new list has no items', () => {
+				// i.e. the filter was cleared
+				const newSemesterIds = [ /* empty */ ];
+				const sut = new SemesterSelectorFilter({
+					selectedSemestersIds: [1, 3, 5],
+					isRecordsTruncated: false,
+					isOrgUnitsTruncated: false
+				}, null);
+				expect(sut.shouldReloadFromServer(newSemesterIds)).to.be.true;
+			});
+
+			it('should return true if the new semester ids list has an id that is not in the existing list', () => {
+				const newSemesterIds = [1, 2, 5];
+				const sut = new SemesterSelectorFilter({
+					selectedSemestersIds: [1, 3, 5],
+					isRecordsTruncated: false,
+					isOrgUnitsTruncated: false
+				}, null);
+				expect(sut.shouldReloadFromServer(newSemesterIds)).to.be.true;
+			});
+
+			it('should return false if the new list is the same as the old list', () => {
+				// added an explicit test for this because it could potentially happen often
+				const newSemesterIds = [1, 3, 5];
+				const sut = new SemesterSelectorFilter({
+					selectedSemestersIds: [1, 3, 5],
+					isRecordsTruncated: false,
+					isOrgUnitsTruncated: false
+				}, null);
+				expect(sut.shouldReloadFromServer(newSemesterIds)).to.be.false;
+			});
+
+			it('should return false if the new list is a subset of the old list', () => {
+				const newSemesterIds = [1, 3];
+				const sut = new SemesterSelectorFilter({
+					selectedSemestersIds: [1, 3, 5],
+					isRecordsTruncated: false,
+					isOrgUnitsTruncated: false
+				}, null);
+				expect(sut.shouldReloadFromServer(newSemesterIds)).to.be.false;
+			});
+		});
+	});
+
+	describe('OrgUnitSelectorFilter', () => {
+		describe('shouldInclude', () => {
+			it('should return true if the filter has no selected ids', () => {
+				const record = [1, 1, 1]; // doesn't matter what the ids are here
+				const sut = new OrgUnitSelectorFilter({
+					selectedOrgUnitIds: [],
+					isRecordsTruncated: false
+				}, null);
+				expect(sut.shouldInclude(record)).to.be.true;
+			});
+
+			it('should return true if the record orgUnit id has an ancestor in the selected orgUnit list', () => {
+				const mockOrgUnitAncestors = {
+					hasAncestorsInList: (/* any */) => true
+				};
+				const record = [1, 5, 5];
+				const sut = new OrgUnitSelectorFilter({
+					selectedOrgUnitIds: [1, 2, 3],
+					isRecordsTruncated: false
+				}, mockOrgUnitAncestors);
+
+				expect(sut.shouldInclude(record)).to.be.true;
+			});
+
+			it('should return false if the record orgUnitId has no ancestors in the selected ids', () => {
+				const mockOrgUnitAncestors = {
+					hasAncestorsInList: (/* any */) => false
+				};
+				const record = [10, 5, 5]; // doesn't matter what the ids are here
+				const sut = new OrgUnitSelectorFilter({
+					selectedOrgUnitIds: [2, 3, 4],
+					isRecordsTruncated: false
+				}, mockOrgUnitAncestors);
+
+				expect(sut.shouldInclude(record)).to.be.false;
+			});
+		});
+
+		describe('shouldReloadFromServer', () => {
+			it('should return true if records are truncated', () => {
+				const newOrgUnitIds = [1, 3]; // a list that otherwise wouldn't trigger a server reload
+				const sut = new OrgUnitSelectorFilter({
+					selectedOrgUnitIds: [1, 3, 5],
+					isRecordsTruncated: true
+				}, null);
+				expect(sut.shouldReloadFromServer(newOrgUnitIds)).to.be.true;
+			});
+
+			it('should return true if the existing selected list has items and the new list has no items', () => {
+				// i.e. the filter was cleared
+				const newOrgUnitIds = [/* empty */];
+				const sut = new OrgUnitSelectorFilter({
+					selectedOrgUnitIds: [1, 3, 5],
+					isRecordsTruncated: false
+				}, null);
+				expect(sut.shouldReloadFromServer(newOrgUnitIds)).to.be.true;
+			});
+
+			it('should return true if the new orgUnitIds list has any id that has no ancestors in the existing list', () => {
+				const mockOrgUnitAncestors = {
+					// pretend 3 has no ancestors in the list
+					hasAncestorsInList: (orgUnitId) => orgUnitId !== 3
+				};
+
+				const newOrgUnitIds = [1, 2, 3];
+				const sut = new OrgUnitSelectorFilter({
+					selectedOrgUnitIds: [1, 2],
+					isRecordsTruncated: false
+				}, mockOrgUnitAncestors);
+				expect(sut.shouldReloadFromServer(newOrgUnitIds)).to.be.true;
+			});
+
+			it('should return false if the new list has only ids that had ancestors in the old list', () => {
+				const mockOrgUnitAncestors = {
+					hasAncestorsInList: (/* any */) => true
+				};
+
+				const newOrgUnitIds = [1, 2, 3];
+				const sut = new OrgUnitSelectorFilter({
+					selectedOrgUnitIds: [1, 2],
+					isRecordsTruncated: false
+				}, mockOrgUnitAncestors);
+				expect(sut.shouldReloadFromServer(newOrgUnitIds)).to.be.false;
+			});
+		});
+	});
+});


### PR DESCRIPTION
Reloads data from server based on logic in [the org unit spike](https://rally1.rallydev.com/#/23525809118d/workviews?detail=%2Fuserstory%2F402788988184&view=349baf7a-c63a-4fa4-a43b-2bb09274aad7) with one modification: if we know that all orgUnits in the current query have ancestors in the previous query, then we know that their related data has already been loaded. So it does not reload from the server in that case.

Quality notes
* Testing
  * Chrome, FF, Edgium, Edge Legacy
  * Calling server-side filtering has the same results as local filtering
    * NOTE: there appears to be a bug on the server-side where applying a selectedOrgUnitId and a selectedSemesterId always returns no records
* Security: N/A
* Devops: N/A
* Docs: N/A
* Perf:
  * One possible optimization which is not applied: if all data is loaded in the initial query and no filters are applied initially, then there's never any need to reload data from the server.
  * With the logic that is currently implemented there are actually very few cases where we _don't_ reload data from the server. 
* UX
  * It doesn't apply the filters on filter close anymore. Filters are applied every time a checkbox is clicked, so applying them on close is redundant.

@rohitvinnakota @MykolaGalian @hyehayes @anhill-D2L 