### PR TITLE
Us118248/filter text change

### DIFF
--- a/components/dropdown-filter.js
+++ b/components/dropdown-filter.js
@@ -71,7 +71,10 @@ class DropdownFilter extends Localizer(LitElement) {
 		let openerSelectedText;
 		if (selectedCount === 1) {
 			// use name instead of displayName here to avoid showing semester ids in the main selector text
-			openerSelectedText = `${this.name}: ${this._selectedData[0].name}`;
+			openerSelectedText = this.localize('components.dropdown-filter.opener-text-single', {
+				filterName: this.name,
+				selectedItemName: this._selectedData[0].name
+			});
 		} else {
 			openerSelectedText = this.localize('components.dropdown-filter.opener-text-multiple', {
 				filterName: this.name,

--- a/components/dropdown-filter.js
+++ b/components/dropdown-filter.js
@@ -51,6 +51,10 @@ class DropdownFilter extends Localizer(LitElement) {
 			.map(item => item.id);
 	}
 
+	get _selectedData() {
+		return this.data.filter(item => item._selected);
+	}
+
 	constructor() {
 		super();
 
@@ -61,13 +65,24 @@ class DropdownFilter extends Localizer(LitElement) {
 	}
 
 	render() {
-		const selectedCount = this._selectedCount;
-		const openerSelectedText = this.localize('components.dropdown-filter.opener-text-multiple', { filterName: this.name, selectedCount: selectedCount });
+		const selected = this._selectedData;
+		const selectedCount = selected.length;
+
+		let openerSelectedText;
+		if (selectedCount === 1) {
+			// use name instead of displayName here to avoid showing semester ids in the main selector text
+			openerSelectedText = `${this.name}: ${this._selectedData[0].name}`;
+		} else {
+			openerSelectedText = this.localize('components.dropdown-filter.opener-text-multiple', {
+				filterName: this.name,
+				selectedCount: selectedCount
+			});
+		}
 
 		return html`
 			<d2l-filter-dropdown
 				total-selected-option-count="${selectedCount}"
-				opener-text="${this.name}"
+				opener-text="${this.localize('components.dropdown-filter.opener-text-all', { filterName: this.name })}"
 				opener-text-single="${openerSelectedText}"
 				opener-text-multiple="${openerSelectedText}"
 				header-text=""
@@ -90,10 +105,6 @@ class DropdownFilter extends Localizer(LitElement) {
 				</d2l-filter-dropdown-category>
 			</d2l-filter-dropdown>
 		`;
-	}
-
-	get _selectedCount() {
-		return this.data.filter(item => item._selected).length;
 	}
 
 	_handleElementSelected(event) {

--- a/components/role-filter.js
+++ b/components/role-filter.js
@@ -50,7 +50,7 @@ class RoleFilter extends Localizer(LitElement) {
 
 	_setFilterData(roleData) {
 		this._filterData = roleData.map(obj => {
-			return { id: obj.Identifier, displayName: obj.DisplayName };
+			return { id: obj.Identifier, name: obj.DisplayName, displayName: obj.DisplayName };
 		});
 	}
 

--- a/components/semester-filter.js
+++ b/components/semester-filter.js
@@ -61,6 +61,7 @@ class SemesterFilter extends Localizer(LitElement) {
 
 		this._filterData = data.Items.map(item => ({
 			id: item.orgUnitId.toString(),
+			name: item.orgUnitName,
 			displayName: this.localize('components.semester-filter.semester-name', item)
 		}));
 	}

--- a/locales/en.js
+++ b/locales/en.js
@@ -27,6 +27,7 @@ export default {
 	"components.tree-selector.node.aria-label": "{name}, child of {parentName},",
 
 	"components.dropdown-filter.load-more": "Load More",
+	"components.dropdown-filter.opener-text-all": "{filterName}: All",
 	"components.dropdown-filter.opener-text-multiple": "{filterName}: {selectedCount} selected",
 
 	"components.insights-users-table.title": "User Details",

--- a/locales/en.js
+++ b/locales/en.js
@@ -29,6 +29,7 @@ export default {
 	"components.dropdown-filter.load-more": "Load More",
 	"components.dropdown-filter.opener-text-all": "{filterName}: All",
 	"components.dropdown-filter.opener-text-multiple": "{filterName}: {selectedCount} selected",
+	"components.dropdown-filter.opener-text-single": '{filterName}: {selectedItemName}',
 
 	"components.insights-users-table.title": "User Details",
 	"components.insights-users-table.lastFirstName": "Last Name, First Name",

--- a/test/components/dropdown-filter.test.js
+++ b/test/components/dropdown-filter.test.js
@@ -9,11 +9,13 @@ describe('d2l-insights-dropdown-filter', () => {
 	const testData = [
 		{
 			id: '1',
-			displayName: 'name 1'
+			name: 'name 1',
+			displayName: 'name 1 id 1'
 		},
 		{
 			id: '2',
-			displayName: 'name 2'
+			name: 'name 2',
+			displayName: 'name 2 id 2'
 		},
 	];
 
@@ -36,11 +38,40 @@ describe('d2l-insights-dropdown-filter', () => {
 	});
 
 	describe('render', () => {
-		it('should render the dropdown opener with the correct name', async() => {
+		it('should render the dropdown opener with the correct name if none are selected', async() => {
 			const filter = el.shadowRoot.querySelector('d2l-filter-dropdown');
-			expect(filter.openerText).to.equal(name);
+			expect(filter.openerText).to.equal(`${name}: All`);
 			expect(filter.openerTextSingle).to.equal(`${name}: 0 selected`);
 			expect(filter.openerTextMultiple).to.equal(`${name}: 0 selected`);
+		});
+
+		it('should render the dropdown opener with the correct name if one is selected', async() => {
+			const data = JSON.parse(JSON.stringify(testData)); // deep copy
+			data[0]._selected = true;
+
+			el = await fixture(html`<d2l-insights-dropdown-filter name="${name}" more .data="${data}"></d2l-insights-dropdown-filter>`);
+			await new Promise(resolve => setTimeout(resolve, 0)); // allow fetch to run
+			await el.updateComplete;
+
+			const filter = el.shadowRoot.querySelector('d2l-filter-dropdown');
+			expect(filter.openerText).to.equal(`${name}: All`);
+			expect(filter.openerTextSingle).to.equal(`${name}: ${data[0].name}`);
+			expect(filter.openerTextMultiple).to.equal(`${name}: ${data[0].name}`);
+		});
+
+		it('should render the dropdown opener with the correct name if multiple are selected', async() => {
+			const data = JSON.parse(JSON.stringify(testData)); // deep copy
+			data[0]._selected = true;
+			data[1]._selected = true;
+
+			el = await fixture(html`<d2l-insights-dropdown-filter name="${name}" more .data="${data}"></d2l-insights-dropdown-filter>`);
+			await new Promise(resolve => setTimeout(resolve, 0)); // allow fetch to run
+			await el.updateComplete;
+
+			const filter = el.shadowRoot.querySelector('d2l-filter-dropdown');
+			expect(filter.openerText).to.equal(`${name}: All`);
+			expect(filter.openerTextSingle).to.equal(`${name}: 2 selected`);
+			expect(filter.openerTextMultiple).to.equal(`${name}: 2 selected`);
 		});
 
 		it('should render with the correct checkbox elements', () => {
@@ -144,9 +175,9 @@ describe('d2l-insights-dropdown-filter', () => {
 
 			//  verify opener textes are changed
 			let filter = el.shadowRoot.querySelector('d2l-filter-dropdown');
-			expect(filter.openerText).to.equal(name);
-			expect(filter.openerTextSingle).to.equal(`${name}: 1 selected`);
-			expect(filter.openerTextMultiple).to.equal(`${name}: 1 selected`);
+			expect(filter.openerText).to.equal(`${name}: All`);
+			expect(filter.openerTextSingle).to.equal(`${name}: ${testData[0].name}`);
+			expect(filter.openerTextMultiple).to.equal(`${name}: ${testData[0].name}`);
 
 			listener = oneEvent(el, 'd2l-insights-dropdown-filter-selected');
 
@@ -159,9 +190,9 @@ describe('d2l-insights-dropdown-filter', () => {
 			// verify `selected` property changed
 			expect(el.selected.length).to.equal(0);
 
-			// verify opener textes are changed
+			// verify opener texts are changed
 			filter = el.shadowRoot.querySelector('d2l-filter-dropdown');
-			expect(filter.openerText).to.equal(name);
+			expect(filter.openerText).to.equal(`${name}: All`);
 			expect(filter.openerTextSingle).to.equal(`${name}: 0 selected`);
 			expect(filter.openerTextMultiple).to.equal(`${name}: 0 selected`);
 		});

--- a/test/components/role-filter.test.js
+++ b/test/components/role-filter.test.js
@@ -74,10 +74,10 @@ describe('d2l-insights-role-filter', () => {
 			fetchMock.get(rolesEndpoint, mockLmsResponseData);
 
 			const expectedFilterData = [
-				{ id: '1', displayName: 'role' },
-				{ id: '2', displayName: 'Role' },
-				{ id: '3', displayName: 'Role' },
-				{ id: '4', displayName: 'ZZZRole' }
+				{ id: '1', name: 'role', displayName: 'role' },
+				{ id: '2', name: 'Role', displayName: 'Role' },
+				{ id: '3', name: 'Role', displayName: 'Role' },
+				{ id: '4', name: 'ZZZRole', displayName: 'ZZZRole' }
 			];
 			const el = await fixture(html`<d2l-insights-role-filter></d2l-insights-role-filter>`);
 			await new Promise(resolve => setTimeout(resolve, 200)); // allow fetch to run. Add 200 ms for Firefox on OSX

--- a/test/components/semester-filter.test.js
+++ b/test/components/semester-filter.test.js
@@ -50,9 +50,9 @@ describe('d2l-insights-semester-filter', () => {
 	describe('render', () => {
 		it('should render semesters', async() => {
 			const expectedFilterData = [
-				{ id: '10007', displayName: 'IPSIS Semester New (Id: 10007)' },
-				{ id: '121194', displayName: 'Fall Test Semester (Id: 121194)' },
-				{ id: '120127', displayName: 'IPSIS Test Semester 1 (Id: 120127)' }
+				{ id: '10007', name: 'IPSIS Semester New', displayName: 'IPSIS Semester New (Id: 10007)' },
+				{ id: '121194', name: 'Fall Test Semester', displayName: 'Fall Test Semester (Id: 121194)' },
+				{ id: '120127', name: 'IPSIS Test Semester 1', displayName: 'IPSIS Test Semester 1 (Id: 120127)' }
 			];
 
 			const el = await fixture(html`<d2l-insights-semester-filter></d2l-insights-semester-filter>`);


### PR DESCRIPTION
Sets the following filter text for role and semester filters:
* if 0 selected, `<filter name>: All`
* if 1 selected, `<filter name>: <selected item name (without id)>`
* if >1 selected, `<filter name>: <N> selected`

This PR doesn't affect the OU filter text.

Quality notes
* Testing
  * Browsers: Chrome, FF, Edgium, Legacy
  * Truncation: no truncation, OU and record truncation
  * Cases
    * Initial load
    * 0 -> 1 selected
    * 1 -> multiple selected
    * multiple -> 1 selected
    * 1 -> 0 selected
    * multiple -> 0 selected (using the Clear button)
  * NOT tested: if selections already exist on initial load
* Security, perf, docs: N/A
* UX:
  * Localized
  * Screen reader: NVDA puts an uncomfortable pause in between two things that are separated by a colon, but otherwise it works correctly.

@anhill-D2L @hyehayes @MykolaGalian @rohitvinnakota 