### PR TITLE
Us118248/ou filter text change

### DIFF
--- a/components/ou-filter.js
+++ b/components/ou-filter.js
@@ -1,4 +1,3 @@
-
 import { CHILDREN, ID, PARENTS, Tree, TYPE } from './tree-filter.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { Localizer } from '../locales/localizer';
@@ -33,7 +32,8 @@ class OuFilter extends Localizer(MobxLitElement) {
 		return html`<div class="ou-filter" ?loading="${this.data.isLoading}">
 			<d2l-insights-tree-filter
 				.tree="${this._tree}"
-				name="${this.localize('components.org-unit-filter.name')}"
+				opener-text="${this.localize('components.org-unit-filter.name-all-selected')}"
+				opener-text-selected="${this.localize('components.org-unit-filter.name-some-selected')}"
 				@d2l-insights-tree-filter-select="${this._onChange}"
 			>
 			</d2l-insights-tree-filter>

--- a/components/tree-filter.js
+++ b/components/tree-filter.js
@@ -24,6 +24,7 @@ export class Tree {
 	constructor(tree, selectedIds, leafTypes) {
 		this.tree = tree;
 		this.leafTypes = leafTypes;
+		this.initialSelectedIds = selectedIds;
 		if (selectedIds) {
 			selectedIds.forEach(x => this.setSelected(x, true));
 		}
@@ -124,7 +125,8 @@ decorate(Tree, {
  * This is an opinionated wrapper around d2l-insights-tree-selector which maintains state
  * in the above Tree class.
  * @property {Object} tree - a Tree (defined above)
- * @property {String} name - appears on the dropdown opener
+ * @property {String} openerText - appears on the dropdown opener if no items are selected
+ * @property {String} openerTextSelected - appears on the dropdown opener if one or more items are selected
  * @fires d2l-insights-tree-filter-select - selection has changed; selected property of this element is the list of selected ids
  */
 class TreeFilter extends Localizer(MobxLitElement) {
@@ -132,7 +134,8 @@ class TreeFilter extends Localizer(MobxLitElement) {
 	static get properties() {
 		return {
 			tree: { type: Object, attribute: false },
-			name: { type: String },
+			openerText: { type: String, attribute: 'opener-text' },
+			openerTextSelected: { type: String, attribute: 'opener-text-selected' },
 			searchString: { type: String, attribute: 'search-string', reflect: true }
 		};
 	}
@@ -151,7 +154,8 @@ class TreeFilter extends Localizer(MobxLitElement) {
 	constructor() {
 		super();
 
-		this.name = 'MISSING NAME';
+		this.openerText = 'MISSING NAME';
+		this.openerTextSelected = 'MISSING NAME';
 		this.searchString = '';
 
 		this._needResize = false;
@@ -169,8 +173,15 @@ class TreeFilter extends Localizer(MobxLitElement) {
 	}
 
 	render() {
+		// if selections are applied when loading from server but the selected ids were truncated out of the results,
+		// the visible selections in the UI (this.tree.selected) could be empty even though selections are applied.
+		// In that case, we should indicate to the user that selections are applied, even if they can't see them.
+		const openerText = (this.tree.selected.length || (this.tree.initialSelectedIds && this.tree.initialSelectedIds.length))
+			? this.openerTextSelected
+			: this.openerText;
+
 		return html`<d2l-insights-tree-selector
-				name="${this.name}"
+				name="${openerText}"
 				?search="${this._isSearch}"
 				@d2l-insights-tree-selector-search="${this._onSearch}"
 			>

--- a/locales/en.js
+++ b/locales/en.js
@@ -8,7 +8,8 @@ export default {
 
 	"components.insights-role-filter.name": "Role",
 
-	"components.org-unit-filter.name": "Org Unit",
+	"components.org-unit-filter.name-all-selected": "Org Unit: All",
+	"components.org-unit-filter.name-some-selected": "Org Unit: Selections Applied",
 
 	"components.semester-filter.name": "Semester",
 	"components.semester-filter.semester-name": "{orgUnitName} (Id: {orgUnitId})",

--- a/test/components/current-final-grade-card.test.js
+++ b/test/components/current-final-grade-card.test.js
@@ -15,7 +15,9 @@ describe('d2l-insights-current-final-grade-card', () => {
 	});
 
 	describe('accessibility', () => {
-		it('should pass all axe tests', async() => {
+		it('should pass all axe tests', async function() {
+			this.timeout(3000);
+
 			const el = await fixture(html`<d2l-insights-current-final-grade-card .data="${data}"></d2l-insights-current-final-grade-card>`);
 			await expect(el).to.be.accessible();
 		});

--- a/test/components/tree-filter.test.js
+++ b/test/components/tree-filter.test.js
@@ -21,7 +21,13 @@ describe('d2l-insights-tree-filter', () => {
 			'6607': [6607, 'Dev', 1, [0], [5, 10], 'none', false]
 		}, [1, 2, 7], [3]);
 
-		el = await fixture(html`<d2l-insights-tree-filter name="filter" .tree="${tree}"></d2l-insights-tree-filter>`);
+		el = await fixture(
+			html`<d2l-insights-tree-filter
+				opener-text="filter"
+				opener-text-selected="filter with selections"
+				.tree="${tree}"
+			></d2l-insights-tree-filter>`
+		);
 		await el.treeUpdateComplete;
 	});
 
@@ -44,6 +50,44 @@ describe('d2l-insights-tree-filter', () => {
 	});
 
 	describe('render', () => {
+		it('should render with opener-text if no items are selected', async() => {
+			const treeWithNoSelections = new Tree({
+				'1': [1, 'Course 1', 3, [3], [], 'none', false],
+				'3': [3, 'Department 1', 2, [5], [1], 'none', false],
+				'5': [5, 'Faculty 1', 7, [6607], [3], 'none', false],
+				'6607': [6607, 'Dev', 1, [0], [5], 'none', false]
+			}, [], [3]);
+
+			el = await fixture(
+				html`<d2l-insights-tree-filter
+				opener-text="filter"
+				opener-text-selected="filter with selections"
+				.tree="${treeWithNoSelections}"
+			></d2l-insights-tree-filter>`
+			);
+			await el.treeUpdateComplete;
+
+			const treeSelector = el.shadowRoot.querySelector('d2l-insights-tree-selector');
+			expect(treeSelector.name).to.equal('filter');
+		});
+
+		it('should render with opener-text-selected if any items are selected', () => {
+			const treeSelector = el.shadowRoot.querySelector('d2l-insights-tree-selector');
+			expect(treeSelector.name).to.equal('filter with selections');
+		});
+
+		it('should render with opener-text-selected if all items are deselected but initial selections are not reset', async() => {
+			const treeSelector = el.shadowRoot.querySelector('d2l-insights-tree-selector');
+			node(3).simulateCheckboxClick();
+			await el.treeUpdateComplete;
+
+			node(7).simulateCheckboxClick();
+			await el.treeUpdateComplete;
+
+			expect(el.selected).to.deep.equal([]);
+			expect(treeSelector.name).to.equal('filter with selections');
+		});
+
 		// NB: visual diffs should be the main check on the expected layout
 		it('should render nodes closed by default', async() => {
 			expect(node(3).isOpen).to.be.false;

--- a/test/components/users-table.test.js
+++ b/test/components/users-table.test.js
@@ -41,7 +41,9 @@ describe('d2l-insights-users-table', () => {
 			let pageSelector;
 			let innerTable;
 
-			before(async() => {
+			before(async function() {
+				this.timeout(10000);
+
 				el = await fixture(html`<d2l-insights-users-table .data="${data}"></d2l-insights-users-table>`);
 				innerTable = el.shadowRoot.querySelector('d2l-insights-table');
 				await new Promise(resolve => setTimeout(resolve, 200));
@@ -51,6 +53,9 @@ describe('d2l-insights-users-table', () => {
 				pageSizeSelector = pageSelector.shadowRoot.querySelector('select');
 			});
 
+			// this test is randomly very flaky. When testing locally, I was able to reproduce the error by
+			// minimizing my browser, so I think the browsers are also being minimized on the Sauce servers.
+			// I don't see any options to force maximized windows though, so I'm increasing timeout in before instead
 			it('should show the first 20 users in order on the first page, if there are more than 20 users', () => {
 				// the default page size is 20
 				expect(pageSelector.selectedCountOption).to.equal(20);


### PR DESCRIPTION
Changes the OU filter text:
- 0 selected: "Org Unit: All"
- 1 or more selected: "Org Unit: Selections Applied"

Quality notes
* Testing
  * Browsers: Chrome, FF, Edgium, Legacy
  * Cases
    * No truncation
      * 0, 1, multiple top-level OUs selected / deselected
      * 0, 1, multiple descendant OUs selected / deselected
      * selection / deselection after searching
      * selection / deselection after semester selected
    * Truncation (there's some edge-casey behaviour here, detailed notes further down)
      * 0, 1, multiple top-level OUs selected / deselected
      * 0, 1, multiple descendant OUs selected / deselected
      * selection / deselection after searching
      * selection / deselection of an OU that disappears when a semester is selected
      * selection / deselection of an OU that is visible before and after a semester is selected
      * selection / deselection of an OU that only appears after a semester is selected
* Security, docs, perf: N/A
* UX
  * Checked with Kevin on wording
  * Localized
  * Screen reader: NVDA changes the text it reads out to match what is shown on-screen

Truncation special cases - let Sem be a semester, OU1 be an OU not in Sem, and OU2 be an OU in Sem
* Case 1
  * For this case, assume OU2 is visible before and after Sem is selected.
  * Select OU1, then select Sem. Displayed: `OU: Selections Applied`, even though no selections appear in the UI. This is ok since the selections are affecting which results are displayed. If it's just OU1 and Sem selected, the set of displayed records will be the empty set.
  * Then select OU2. Displayed: `OU: Selections Applied` (normal)
  * Then deselect OU2: Displayed: `OU: All`, which makes sense given the state of the filter. Why: selecting OU2 caused a reload from server, but since Sem was selected OU1 was no longer in the results. So the filter "forgot" it had OU1 selected.
* Case 2
  * For this case, assume OU2 is only visible after Sem is selected.
  * Select Sem, then select OU2. Displayed: `OU: Selections Applied` (normal)
  * Then unselect sem. Displayed: `OU: Selections Applied`. Why: OU2 was still present in the last server request, so it's affecting the returned results.
  * Then select OU1. Displayed: `OU: Selections Applied` (normal)
  * Then unselect OU1. Displayed: `OU: All`. Why: selecting OU1 caused a server reload but since OU2 didn't exist in the filter it wasn't sent in that server reload, so the filter forgot it had OU2 selected.

@rohitvinnakota @hyehayes @MykolaGalian @anhill-D2L 