### PR TITLE
Tweak layout

### DIFF
--- a/components/current-final-grade-card.js
+++ b/components/current-final-grade-card.js
@@ -34,8 +34,8 @@ class CurrentFinalGradeCard extends Localizer(MobxLitElement) {
 				height: 275px;
 				margin-right: 10px;
 				margin-top: 19.5px;
-				padding: 10px;
-				width: 592px;
+				padding: 15px;
+				width: 602px;
 			}
 
 			.d2l-insights-current-final-grade-title {
@@ -43,15 +43,6 @@ class CurrentFinalGradeCard extends Localizer(MobxLitElement) {
 				font-size: smaller;
 				font-weight: bold;
 				text-indent: 3%;
-			}
-
-			.d2l-insights-empty-chart-message {
-				color: var(--d2l-color-ferrite);
-				display: flex-wrap;
-				font-size: 14px;
-				line-height: 1rem;
-				margin: 3%;
-				vertical-align: middle;
 			}
 		`;
 	}

--- a/components/current-final-grade-card.js
+++ b/components/current-final-grade-card.js
@@ -31,11 +31,11 @@ class CurrentFinalGradeCard extends Localizer(MobxLitElement) {
 				border-style: solid;
 				border-width: 1.5px;
 				display: inline-block;
-				height: 250px;
+				height: 275px;
 				margin-right: 10px;
-				margin-top: 10px;
+				margin-top: 19.5px;
 				padding: 10px;
-				width: 500px;
+				width: 592px;
 			}
 
 			.d2l-insights-current-final-grade-title {

--- a/components/summary-card.js
+++ b/components/summary-card.js
@@ -34,7 +34,7 @@ class SummaryCard extends LitElement {
 				height: 121px;
 				margin-right: 10px;
 				margin-top: 10px;
-				padding: 10px;
+				padding: 15px;
 				width: 280px;
 			}
 

--- a/components/summary-card.js
+++ b/components/summary-card.js
@@ -31,7 +31,7 @@ class SummaryCard extends LitElement {
 				border-style: solid;
 				border-width: 1.5px;
 				display: inline-block;
-				height: 120px;
+				height: 121px;
 				margin-right: 10px;
 				margin-top: 10px;
 				padding: 10px;

--- a/components/time-in-content-vs-grade-card.js
+++ b/components/time-in-content-vs-grade-card.js
@@ -28,9 +28,10 @@ class TimeInContentVsGradeCard extends Localizer(MobxLitElement) {
 				height: 275px;
 				margin-right: 10px;
 				margin-top: 19.5px;
-				padding: 10px;
-				width: 592px;
+				padding: 15px;
+				width: 602px;
 			}
+
 			:host([hidden]) {
 				display: none;
 			}

--- a/components/time-in-content-vs-grade-card.js
+++ b/components/time-in-content-vs-grade-card.js
@@ -25,11 +25,11 @@ class TimeInContentVsGradeCard extends Localizer(MobxLitElement) {
 				border-style: solid;
 				border-width: 1.5px;
 				display: inline-block;
-				height: 270px;
+				height: 275px;
 				margin-right: 10px;
-				margin-top: 10px;
+				margin-top: 19.5px;
 				padding: 10px;
-				width: 590px;
+				width: 592px;
 			}
 			:host([hidden]) {
 				display: none;

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -40,11 +40,16 @@ class EngagementDashboard extends Localizer(LitElement) {
 					display: none;
 				}
 
-				/* NB: this layout css doesn't quite work; do not ship */
-				.d2l-insights-summary-container {
+				.data-wrapper {
 					display: flex;
 					flex-wrap: wrap;
-					margin-bottom: 25px;
+				}
+
+				.d2l-insights-summary-container {
+					display: grid;
+					grid-template-columns: max-content max-content;
+					flex-wrap: wrap;
+					margin-bottom: 5px;
 					margin-top: 10px;
 				}
 
@@ -105,14 +110,17 @@ class EngagementDashboard extends Localizer(LitElement) {
 				</div>
 
 				<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.summaryHeading')}</h2>
-				<div class="d2l-insights-summary-container">
-					<d2l-insights-results-card .data="${this._data}"></d2l-insights-results-card>
-					<d2l-insights-current-final-grade-card .data="${this._data}"></d2l-insights-current-final-grade-card>
-					<d2l-insights-overdue-assignments-card .data="${this._data}"></d2l-insights-overdue-assignments-card>
-					<d2l-insights-debug-card .data="${this._data}" metric-to-display="recordsLength" title="Records" message="number of records within filter parameters"></d2l-insights-debug-card>
-					<d2l-insights-time-in-content-vs-grade-card .data="${this._data}"></d2l-insights-time-in-content-vs-grade-card>
+				<div class="data-wrapper">
+					<div class="d2l-insights-summary-container">
+						<d2l-insights-results-card .data="${this._data}"></d2l-insights-results-card>
+						<d2l-insights-overdue-assignments-card .data="${this._data}"></d2l-insights-overdue-assignments-card>
+						<d2l-insights-debug-card .data="${this._data}" metric-to-display="recordsLength" title="Records" message="number of records within filter parameters"></d2l-insights-debug-card>
+						<d2l-insights-debug-card .data="${this._data}" metric-to-display="recordsLength" title="Records" message="number of records within filter parameters"></d2l-insights-debug-card>
+					</div>
+					<div><d2l-insights-current-final-grade-card .data="${this._data}"></d2l-insights-current-final-grade-card></div>
+					<div><d2l-insights-time-in-content-vs-grade-card .data="${this._data}"></d2l-insights-time-in-content-vs-grade-card></div>
+					<div></div><!--Empty div for course last access chart-->
 				</div>
-
 				<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.resultsHeading')}</h2>
 				<d2l-insights-users-table .data="${this._data}"></d2l-insights-users-table>
 		`;

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -41,17 +41,15 @@ class EngagementDashboard extends Localizer(LitElement) {
 					display: none;
 				}
 
-				.d2l-insights-data-wrapper {
+				.d2l-insights-chart-container {
 					display: flex;
 					flex-wrap: wrap;
+					margin-top: -10px;
 				}
 
 				.d2l-insights-summary-container {
-					display: grid;
+					display: flex;
 					flex-wrap: wrap;
-					grid-template-columns: max-content max-content;
-					margin-bottom: 5px;
-					margin-top: 10px;
 				}
 
 				.d2l-insights-summary-container-applied-filters {
@@ -112,17 +110,16 @@ class EngagementDashboard extends Localizer(LitElement) {
 				</div>
 
 				<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.summaryHeading')}</h2>
-				<div class="d2l-insights-data-wrapper">
-					<div class="d2l-insights-summary-container-applied-filters">
-						<d2l-insights-applied-filters .data="${this._data}"></d2l-insights-applied-filters>
-					</div>
-					<div class="d2l-insights-summary-container">
-						<d2l-insights-results-card .data="${this._data}"></d2l-insights-results-card>
-						<d2l-insights-overdue-assignments-card .data="${this._data}"></d2l-insights-overdue-assignments-card>
-					</div>
+				<div class="d2l-insights-summary-container-applied-filters">
+					<d2l-insights-applied-filters .data="${this._data}"></d2l-insights-applied-filters>
+				</div>
+				<div class="d2l-insights-summary-container">
+					<d2l-insights-results-card .data="${this._data}"></d2l-insights-results-card>
+					<d2l-insights-overdue-assignments-card .data="${this._data}"></d2l-insights-overdue-assignments-card>
+				</div>
+				<div class="d2l-insights-chart-container">
 					<div><d2l-insights-current-final-grade-card .data="${this._data}"></d2l-insights-current-final-grade-card></div>
 					<div><d2l-insights-time-in-content-vs-grade-card .data="${this._data}"></d2l-insights-time-in-content-vs-grade-card></div>
-					<div></div><!--Empty div for course last access chart-->
 				</div>
 				<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.resultsHeading')}</h2>
 				<d2l-insights-users-table .data="${this._data}"></d2l-insights-users-table>

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -41,15 +41,15 @@ class EngagementDashboard extends Localizer(LitElement) {
 					display: none;
 				}
 
-				.data-wrapper {
+				.d2l-insights-data-wrapper {
 					display: flex;
 					flex-wrap: wrap;
 				}
 
 				.d2l-insights-summary-container {
 					display: grid;
-					grid-template-columns: max-content max-content;
 					flex-wrap: wrap;
+					grid-template-columns: max-content max-content;
 					margin-bottom: 5px;
 					margin-top: 10px;
 				}
@@ -112,7 +112,7 @@ class EngagementDashboard extends Localizer(LitElement) {
 				</div>
 
 				<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.summaryHeading')}</h2>
-				<div class="data-wrapper">
+				<div class="d2l-insights-data-wrapper">
 					<div class="d2l-insights-summary-container-applied-filters">
 						<d2l-insights-applied-filters .data="${this._data}"></d2l-insights-applied-filters>
 					</div>
@@ -137,14 +137,6 @@ class EngagementDashboard extends Localizer(LitElement) {
 	_orgUnitFilterChange(event) {
 		event.stopPropagation();
 		this._data.applyOrgUnitFilters(event.target.selected);
-		// <div class="d2l-insights-summary-container">
-		// <div class="d2l-insights-summary-container-applied-filters">
-		// 	<d2l-insights-applied-filters .data="${this._data}"></d2l-insights-applied-filters>
-		// </div>
-		// <d2l-insights-results-card .data="${this._data}"></d2l-insights-results-card>
-		// <d2l-insights-current-final-grade-card .data="${this._data}"></d2l-insights-current-final-grade-card>
-		// <d2l-insights-overdue-assignments-card .data="${this._data}"></d2l-insights-overdue-assignments-card>
-		// <d2l-insights-time-in-content-vs-grade-card .data="${this._data}"></d2l-insights-time-in-content-vs-grade-card>
 	}
 
 	_semesterFilterChange(event) {


### PR DESCRIPTION
https://rally1.rallydev.com/#/23525809118d/custom/12155517225?detail=%2Fuserstory%2F399914048420

**Quality Notes**

For now, I ended up using a flex design, so on wider screens, the graphs display side by side. We should have a discussion on whether we want to resize the charts themselves when we change the screen size. For now, the size of the cards is fixed. 

Tested on my laptop screen, a 27 inch monitor, and different browsers. Added 2 extra debug cards for comparison. 

security: n/a
perf: n/a
devops: n/a
ux/docs: Have screenshots for now, as mentioned, I think we should have further discussion on this. 

![largeScreen](https://user-images.githubusercontent.com/21348406/92802569-9f2d4c00-f384-11ea-8788-954e573a0c7f.PNG)
![smallerscreen](https://user-images.githubusercontent.com/21348406/92802578-a3f20000-f384-11ea-948c-52a757ad008c.PNG)

fyi @hyehayes @Vitalii-Misechko @MykolaGalian @anhill-D2L 