### PR TITLE
revert mobx-lit package to match others in BSI

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "stylelint": "^13.6.1"
   },
   "dependencies": {
-    "@adobe/lit-mobx": "1.0.0",
+    "@adobe/lit-mobx": "0.0.x",
     "@brightspace-ui-labs/pagination": "^0.0.8",
     "@brightspace-ui/core": "^1.69.0",
     "@webcomponents/webcomponentsjs": "^2",


### PR DESCRIPTION
BSI won't build with the newer version because two other components use this lib on 0.0.x

Testing: ran via BSI with npm link; interactions worked as expected. Confirmed in package-lock that v0.0.4 was used.