### PR TITLE
handle org units that aren't in the parents map

### DIFF
--- a/model/orgUnitAncestors.js
+++ b/model/orgUnitAncestors.js
@@ -36,7 +36,8 @@ class OrgUnitAncestors {
 		}
 
 		const ancestorsSet = new Set([orgUnitId]);
-		parentsMap.get(orgUnitId).forEach(parent => {
+		const parentIds = parentsMap.get(orgUnitId) || [];
+		parentIds.forEach(parent => {
 			const ancestorsOfParent = this._addOrgUnitToAncestorsMap(parent, parentsMap);
 			ancestorsOfParent.forEach(ancestor => ancestorsSet.add(ancestor));
 		});

--- a/test/engagement-dashboard.test.js
+++ b/test/engagement-dashboard.test.js
@@ -8,7 +8,7 @@ describe('d2l-insights-engagement-dashboard', () => {
 		it('should pass all axe tests', async function() {
 			this.timeout(3000);
 
-			const el = await fixture(html`<d2l-insights-engagement-dashboard></d2l-insights-engagement-dashboard>`);
+			const el = await fixture(html`<d2l-insights-engagement-dashboard demo></d2l-insights-engagement-dashboard>`);
 			// need for this delay might be tied to the mock data async loading in engagement-dashboard.js
 			await new Promise(resolve => setTimeout(resolve, 1500));
 			try {

--- a/test/model/orgUnitAncestors.test.js
+++ b/test/model/orgUnitAncestors.test.js
@@ -78,6 +78,14 @@ describe('orgUnitAncestors', () => {
 			});
 		});
 
+		it('should not throw if an org unit has no parents', () => {
+			new OrgUnitAncestors([
+				[6606, 'Org', mockOuTypes.organization, [0]],
+				[1001, 'Department 1', mockOuTypes.department, null],
+				[1002, 'Department 2', mockOuTypes.department, [6606]]
+			]);
+		});
+
 		it('returns undefined if an orgUnit was not in the map', () => {
 			expect(sut.getAncestorsFor(12345)).to.be.undefined;
 		});


### PR DESCRIPTION
This fixes a potential bug, possibly seen on Spark.

FYI @anhill-D2L @MykolaGalian  @Vitalii-Misechko 