### PR TITLE
US118543 [Engagement] Loading states

### DIFF
--- a/components/aria-loading-progress.js
+++ b/components/aria-loading-progress.js
@@ -2,13 +2,6 @@ import { css, html } from 'lit-element/lit-element.js';
 import { Localizer } from '../locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
 
-
-/**
- * Requires that parent element has non-static position property. For instance, position: relative;
- *
- * @property {Number} spinner-size
- * @property {Boolean} loading
- */
 class AriaLoadingProgress extends Localizer(MobxLitElement) {
 	static get properties() {
 		return {

--- a/components/aria-loading-progress.js
+++ b/components/aria-loading-progress.js
@@ -26,6 +26,9 @@ class AriaLoadingProgress extends Localizer(MobxLitElement) {
 	}
 
 	render() {
+		// loading-start-message is rendered as text node that forces FF to read it, otherwise FF skips it
+		// when loading is finished the code replaces `div` with text node to `div` with aria-label to
+		// to hide loading-finish-message from screen reader (from navigation with arrow keys)
 		return html`
 			<div class="d2l-insights-aria-loading-progress" aria-live="assertive">
 				${this.data.isLoading

--- a/components/aria-loading-progress.js
+++ b/components/aria-loading-progress.js
@@ -1,0 +1,44 @@
+import { css, html } from 'lit-element/lit-element.js';
+import { Localizer } from '../locales/localizer';
+import { MobxLitElement } from '@adobe/lit-mobx';
+
+
+/**
+ * Requires that parent element has non-static position property. For instance, position: relative;
+ *
+ * @property {Number} spinner-size
+ * @property {Boolean} loading
+ */
+class AriaLoadingProgress extends Localizer(MobxLitElement) {
+	static get properties() {
+		return {
+			data: { type: Object, attribute: false }
+		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: inline-block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+
+			.d2l-insights-aria-loading-progress {
+				left: -100vw;
+				position: absolute;
+			}
+		`;
+	}
+
+	render() {
+		return html`
+			<div class="d2l-insights-aria-loading-progress" aria-live="assertive">
+				${this.data.isLoading
+					? html`<div role="alert">${this.localize('components.insights-aria-loading-progress.loading-start')}</div>`
+					: html`<div role="alert" aria-label="${this.localize('components.insights-aria-loading-progress.loading-finish')}"></div>`}
+			</div>`;
+	}
+}
+customElements.define('d2l-insights-aria-loading-progress', AriaLoadingProgress);

--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -71,7 +71,7 @@ class Chart extends LitElement {
 	render() {
 		return html`
 			<d2l-insights-overlay spinner-size="200" ?loading="${this.isLoading}"></d2l-insights-overlay>
-			<div id="chart-container"></div>
+			<div id="chart-container" aria-hidden="${this.isLoading}" tabindex="${this.isLoading ? -1 : 0}"></div>
       	`;
 	}
 

--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -1,8 +1,9 @@
 import 'highcharts';
 import 'highcharts/modules/histogram-bellcurve';
 import 'highcharts/modules/accessibility';
+import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
 
-import { html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 /**
  * based on highcharts-webcomponent (npm) - main modifications: convert to plain .js, fix import, fix typing,
  * remove flag for suppressing updates, prevent unneeded update on first render
@@ -15,7 +16,8 @@ class Chart extends LitElement {
 			constructorType: { type: String },
 			highcharts: { type: Object, attribute: false },
 			immutable: { type: Boolean },
-			updateArgs: { type: Array, attribute: false }
+			updateArgs: { type: Array, attribute: false },
+			isLoading: { type: Boolean, attribute: 'loading' }
 		};
 	}
 
@@ -52,12 +54,27 @@ class Chart extends LitElement {
 			true,
 			true
 		];
+
+		this.isLoading = true;
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: inline-block;
+				position: relative;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+		`;
 	}
 
 	render() {
 		return html`
-        <div></div>
-      `;
+			<d2l-insights-overlay spinner-size="200" ?loading="${this.isLoading}"></d2l-insights-overlay>
+			<div id="chart-container"></div>
+      	`;
 	}
 
 	updated() {
@@ -103,7 +120,7 @@ class Chart extends LitElement {
 	}
 
 	get chartContainer() {
-		return this.shadowRoot.querySelector('div');
+		return this.shadowRoot.querySelector('#chart-container');
 	}
 }
 customElements.define('d2l-labs-chart', Chart);

--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -71,7 +71,7 @@ class Chart extends LitElement {
 	render() {
 		return html`
 			<d2l-insights-overlay spinner-size="200" ?loading="${this.isLoading}"></d2l-insights-overlay>
-			<div id="chart-container" aria-hidden="${this.isLoading}" tabindex="${this.isLoading ? -1 : 0}"></div>
+			<div id="chart-container" aria-hidden="${!!this.isLoading}" tabindex="${this.isLoading ? -1 : 0}"></div>
       	`;
 	}
 

--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -71,7 +71,7 @@ class Chart extends LitElement {
 	render() {
 		return html`
 			<d2l-insights-overlay spinner-size="200" ?loading="${this.isLoading}"></d2l-insights-overlay>
-			<div id="chart-container" aria-hidden="${!!this.isLoading}" tabindex="${this.isLoading ? -1 : 0}"></div>
+			<div id="chart-container" tabindex="${this.isLoading ? -1 : 0}"></div>
       	`;
 	}
 

--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -54,8 +54,6 @@ class Chart extends LitElement {
 			true,
 			true
 		];
-
-		this.isLoading = true;
 	}
 
 	static get styles() {

--- a/components/current-final-grade-card.js
+++ b/components/current-final-grade-card.js
@@ -136,7 +136,6 @@ class CurrentFinalGradeCard extends Localizer(MobxLitElement) {
 					pointWidth: 37,
 					pointPadding: 0.60,
 					accessibility: {
-						chartContainerLabel: this._cardTitle,
 						description: this._chartDescriptionTextLabel,
 						pointDescriptionFormatter: function(point) {
 							const ix = (point.index + 1) * 10,

--- a/components/current-final-grade-card.js
+++ b/components/current-final-grade-card.js
@@ -136,6 +136,7 @@ class CurrentFinalGradeCard extends Localizer(MobxLitElement) {
 					pointWidth: 37,
 					pointPadding: 0.60,
 					accessibility: {
+						chartContainerLabel: this._cardTitle,
 						description: this._chartDescriptionTextLabel,
 						pointDescriptionFormatter: function(point) {
 							const ix = (point.index + 1) * 10,

--- a/components/current-final-grade-card.js
+++ b/components/current-final-grade-card.js
@@ -67,7 +67,7 @@ class CurrentFinalGradeCard extends Localizer(MobxLitElement) {
 		// NB: relying on mobx rather than lit-element properties to handle update detection: it will trigger a redraw for
 		// any change to a relevant observed property of the Data object
 		const options = this.chartOptions;
-		if (!options.series[1].data.length) {
+		if (!this.data.isLoading && !options.series[1].data.length) {
 			return html`<div class="d2l-insights-final-grade-container">
 				<div class="d2l-insights-current-final-grade-title">${this._cardTitle}</div>
 				<div class="d2l-insights-summary-card-body">
@@ -79,7 +79,7 @@ class CurrentFinalGradeCard extends Localizer(MobxLitElement) {
 		} else {
 			return html`<div class="d2l-insights-final-grade-container">
 				<div class="d2l-insights-current-final-grade-title">${this._cardTitle}</div>
-				<d2l-labs-chart class="d2l-insights-summary-card-body" .options="${options}"></d2l-labs-chart>
+				<d2l-labs-chart class="d2l-insights-summary-card-body" .options="${options}" ?loading="${this.data.isLoading}" ></d2l-labs-chart>
 			</div>`;
 		}
 	}

--- a/components/overdue-assignments-card.js
+++ b/components/overdue-assignments-card.js
@@ -44,6 +44,7 @@ class OverdueAssignmentsCard extends Localizer(MobxLitElement) {
 				card-title="${this._cardTitle}"
 				card-value="${this._cardValue}"
 				card-message="${this._cardMessage}"
+				?loading="${this.data.isLoading}"
 				@d2l-labs-summary-card-value-click=${this._valueClickHandler}
 			></d2l-labs-summary-card>
 		`;

--- a/components/overlay.js
+++ b/components/overlay.js
@@ -1,0 +1,59 @@
+import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
+
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+
+/**
+ * Requires that parent element has non-static position property. For instance, position: relative;
+ *
+ * @property {Number} spinner-size
+ * @property {Boolean} loading
+ */
+class Overlay extends LitElement {
+	static get properties() {
+		return {
+			spinnerSize: { type: Number, attribute: 'spinner-size' },
+			isLoading: { type: Boolean, attribute: 'loading' }
+		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: block;
+				position: absolute;
+				top: 0;
+				left: 0;
+				height: 100%;
+				width: 100%;
+				z-index: 1;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+
+			.d2l-insights-overlay {
+				background-color: white;
+				height: 100%;
+				width: 100%;
+				border-radius: 15px;
+				margin: 1 1 1 1;
+				display: flex;
+				align-items: center;
+    			justify-content: center;
+			}
+		`;
+	}
+
+	render() {
+		if (!this.isLoading) {
+			return html``;
+		}
+
+		return html`
+			<div class="d2l-insights-overlay">
+				<d2l-loading-spinner size="${this.spinnerSize}"></d2l-loading-spinner>
+			</div>`;
+	}
+
+}
+customElements.define('d2l-insights-overlay', Overlay);

--- a/components/overlay.js
+++ b/components/overlay.js
@@ -20,10 +20,12 @@ class Overlay extends LitElement {
 		return css`
 			:host {
 				display: block;
-				height: 100%;
 				left: 0;
 				position: absolute;
 				top: 0;
+			}
+			:host([loading]) {
+				height: 100%;
 				width: 100%;
 				z-index: 1;
 			}

--- a/components/overlay.js
+++ b/components/overlay.js
@@ -20,10 +20,10 @@ class Overlay extends LitElement {
 		return css`
 			:host {
 				display: block;
+				height: 100%;
+				left: 0;
 				position: absolute;
 				top: 0;
-				left: 0;
-				height: 100%;
 				width: 100%;
 				z-index: 1;
 			}
@@ -32,14 +32,14 @@ class Overlay extends LitElement {
 			}
 
 			.d2l-insights-overlay {
-				background-color: white;
-				height: 100%;
-				width: 100%;
-				border-radius: 15px;
-				margin: 1 1 1 1;
-				display: flex;
 				align-items: center;
-    			justify-content: center;
+				background-color: white;
+				border-radius: 15px;
+				display: flex;
+				height: 100%;
+				justify-content: center;
+				margin: 1 1 1 1;
+				width: 100%;
 			}
 		`;
 	}

--- a/components/results-card.js
+++ b/components/results-card.js
@@ -31,7 +31,14 @@ class ResultsCard extends Localizer(MobxLitElement) {
 
 	render() {
 		return html`
-			<d2l-labs-summary-card id="d2l-insights-engagement-results" .data="${this.data}" card-title="${this._cardTitle}" card-value="${this._cardValue}" card-message="${this._cardMessage}"></d2l-labs-summary-card>
+			<d2l-labs-summary-card
+				id="d2l-insights-engagement-results"
+				.data="${this.data}"
+				card-title="${this._cardTitle}"
+				card-value="${this._cardValue}"
+				card-message="${this._cardMessage}"
+				?loading="${this.data.isLoading}"
+			></d2l-labs-summary-card>
 		`;
 	}
 }

--- a/components/summary-card.js
+++ b/components/summary-card.js
@@ -102,7 +102,7 @@ class SummaryCard extends LitElement {
 		// any change to a relevant observed property of the Data object
 		return html`<div class="d2l-insights-summary-card">
 			<div class="d2l-insights-summary-card-title">${this.title}</div>
-			<div class="d2l-insights-summary-card-body">
+			<div class="d2l-insights-summary-card-body" aria-hidden="${this.isLoading}">
 			<d2l-insights-overlay spinner-size="100" ?loading="${this.isLoading}"></d2l-insights-overlay>
 			${this.isValueClickable ?
 			html`<span class="d2l-insights-summary-card-value d2l-insights-summary-card-field" ?is-value-clickable=${this.isValueClickable} @click=${this._valueClickHandler}>${this.value}</span>` :

--- a/components/summary-card.js
+++ b/components/summary-card.js
@@ -32,13 +32,13 @@ class SummaryCard extends LitElement {
 				border-radius: 15px;
 				border-style: solid;
 				border-width: 1.5px;
+				display: flex;
+				flex-direction: column;
 				height: 121px;
 				margin-right: 10px;
 				margin-top: 10px;
 				padding: 15px;
 				width: 280px;
-				display: flex;
-   				flex-direction: column;
 			}
 
 			.d2l-insights-summary-card-body {

--- a/components/summary-card.js
+++ b/components/summary-card.js
@@ -32,20 +32,21 @@ class SummaryCard extends LitElement {
 				border-radius: 15px;
 				border-style: solid;
 				border-width: 1.5px;
-				display: inline-block;
 				height: 121px;
 				margin-right: 10px;
 				margin-top: 10px;
 				padding: 15px;
 				width: 280px;
-				position: relative;
+				display: flex;
+   				flex-direction: column;
 			}
 
 			.d2l-insights-summary-card-body {
 				align-items: center;
 				display: flex;
 				height: 100%;
-				margin-top: -15px;
+				position: relative;
+
 			}
 
 			.d2l-insights-summary-card-title {
@@ -100,9 +101,9 @@ class SummaryCard extends LitElement {
 		// NB: relying on mobx rather than lit-element properties to handle update detection: it will trigger a redraw for
 		// any change to a relevant observed property of the Data object
 		return html`<div class="d2l-insights-summary-card">
-			<d2l-insights-overlay spinner-size="100" ?loading="${this.isLoading}"></d2l-insights-overlay>
 			<div class="d2l-insights-summary-card-title">${this.title}</div>
 			<div class="d2l-insights-summary-card-body">
+			<d2l-insights-overlay spinner-size="100" ?loading="${this.isLoading}"></d2l-insights-overlay>
 			${this.isValueClickable ?
 			html`<span class="d2l-insights-summary-card-value d2l-insights-summary-card-field" ?is-value-clickable=${this.isValueClickable} @click=${this._valueClickHandler}>${this.value}</span>` :
 			html`<span class="d2l-insights-summary-card-value d2l-insights-summary-card-field">${this.value}</span>`}

--- a/components/summary-card.js
+++ b/components/summary-card.js
@@ -102,7 +102,7 @@ class SummaryCard extends LitElement {
 		// any change to a relevant observed property of the Data object
 		return html`<div class="d2l-insights-summary-card">
 			<div class="d2l-insights-summary-card-title">${this.title}</div>
-			<div class="d2l-insights-summary-card-body" aria-hidden="${this.isLoading}">
+			<div class="d2l-insights-summary-card-body" aria-hidden="${!!this.isLoading}">
 			<d2l-insights-overlay spinner-size="100" ?loading="${this.isLoading}"></d2l-insights-overlay>
 			${this.isValueClickable ?
 			html`<span class="d2l-insights-summary-card-value d2l-insights-summary-card-field" ?is-value-clickable=${this.isValueClickable} @click=${this._valueClickHandler}>${this.value}</span>` :

--- a/components/summary-card.js
+++ b/components/summary-card.js
@@ -1,3 +1,4 @@
+import './overlay';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 
 /**
@@ -12,7 +13,8 @@ class SummaryCard extends LitElement {
 			title: { type: String, attribute: 'card-title' },
 			value: { type: String, attribute: 'card-value' },
 			message: { type: String, attribute: 'card-message' },
-			isValueClickable: { type: Boolean, attribute: 'is-value-clickable' }
+			isValueClickable: { type: Boolean, attribute: 'is-value-clickable' },
+			isLoading: { type: Boolean, attribute: 'loading' }
 		};
 	}
 
@@ -36,6 +38,7 @@ class SummaryCard extends LitElement {
 				margin-top: 10px;
 				padding: 15px;
 				width: 280px;
+				position: relative;
 			}
 
 			.d2l-insights-summary-card-body {
@@ -97,6 +100,7 @@ class SummaryCard extends LitElement {
 		// NB: relying on mobx rather than lit-element properties to handle update detection: it will trigger a redraw for
 		// any change to a relevant observed property of the Data object
 		return html`<div class="d2l-insights-summary-card">
+			<d2l-insights-overlay spinner-size="100" ?loading="${this.isLoading}"></d2l-insights-overlay>
 			<div class="d2l-insights-summary-card-title">${this.title}</div>
 			<div class="d2l-insights-summary-card-body">
 			${this.isValueClickable ?

--- a/components/time-in-content-vs-grade-card.js
+++ b/components/time-in-content-vs-grade-card.js
@@ -75,7 +75,7 @@ class TimeInContentVsGradeCard extends Localizer(MobxLitElement) {
 		// NB: relying on mobx rather than lit-element properties to handle update detection: it will trigger a redraw for
 		// any change to a relevant observed property of the Data object
 		return html`<div class="d2l-insights-time-in-content-vs-grade-title">${this._cardTitle}</div>
-		<d2l-labs-chart class="d2l-insights-summary-card-body" .options="${this.chartOptions}"></d2l-labs-chart>`;
+		<d2l-labs-chart class="d2l-insights-summary-card-body" .options="${this.chartOptions}" ?loading="${this.data.isLoading}"></d2l-labs-chart>`;
 	}
 
 	get chartOptions() {

--- a/components/time-in-content-vs-grade-card.js
+++ b/components/time-in-content-vs-grade-card.js
@@ -175,6 +175,7 @@ class TimeInContentVsGradeCard extends Localizer(MobxLitElement) {
 					}
 				},
 				accessibility: {
+					chartContainerLabel: this._cardTitle,
 					pointDescriptionFormatter: function(point) {
 						return `${that._currentGradeText}: ${point.y} - ${that._timeInContentText}: ${point.x}`;
 					}

--- a/components/time-in-content-vs-grade-card.js
+++ b/components/time-in-content-vs-grade-card.js
@@ -175,7 +175,6 @@ class TimeInContentVsGradeCard extends Localizer(MobxLitElement) {
 					}
 				},
 				accessibility: {
-					chartContainerLabel: this._cardTitle,
 					pointDescriptionFormatter: function(point) {
 						return `${that._currentGradeText}: ${point.y} - ${that._timeInContentText}: ${point.x}`;
 					}

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -9,6 +9,7 @@ import './components/table.js';
 import './components/time-in-content-vs-grade-card';
 import './components/current-final-grade-card.js';
 import './components/applied-filters';
+import './components/aria-loading-progress';
 
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { Data } from './model/data.js';
@@ -91,6 +92,8 @@ class EngagementDashboard extends Localizer(LitElement) {
 		});
 
 		return html`
+				<d2l-insights-aria-loading-progress .data="${this._data}"></d2l-insights-aria-loading-progress>
+
 				<h1 class="d2l-heading-1">${this.localize('components.insights-engagement-dashboard.title')}</h1>
 
 				<div class="view-filters-container">

--- a/locales/en.js
+++ b/locales/en.js
@@ -48,5 +48,8 @@ export default {
 
 	"components.insights-engagement-dashboard.overdueAssignments": "Users currently have one or more overdue assignments.",
 
-	"components.insights-applied-filters.clear-all": "Clear all"
+	"components.insights-applied-filters.clear-all": "Clear all",
+
+	"components.insights-aria-loading-progress.loading-start": "Loading is in progress",
+	"components.insights-aria-loading-progress.loading-finish": "Loading is finished"
 };

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-	"extends": "brightspace/open-wc-testing-config"
+  "extends": "brightspace/open-wc-testing-config",
+  "rules": {
+    "no-console": ["off"]
+  }
 }

--- a/test/components/aria-loading-progress.test.js
+++ b/test/components/aria-loading-progress.test.js
@@ -1,0 +1,46 @@
+import '../../components/aria-loading-progress';
+
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
+
+describe('d2l-insights-aria-loading-progress', () => {
+	const data = {
+		isLoading: true
+	};
+
+	describe('constructor', () => {
+		it('should construct', () => {
+			runConstructor('d2l-insights-aria-loading-progress');
+		});
+	});
+
+	describe('accessibility', () => {
+		it('should pass all axe tests', async() => {
+			const el = await fixture(html`<d2l-insights-aria-loading-progress .data="${data}"></d2l-insights-aria-loading-progress>`);
+			await expect(el).to.be.accessible();
+		});
+	});
+
+	describe('render', () => {
+		it('should render only screen reader visible alerts', async() => {
+			const renderData = {
+				isLoading: true
+			};
+
+			const el = await fixture(html`<d2l-insights-aria-loading-progress .data="${renderData}"></d2l-insights-aria-loading-progress>`);
+
+			const nodes = el.shadowRoot.querySelectorAll('div div[role="alert"]');
+			expect(nodes.length).to.equal(1);
+			expect(nodes[0].innerText).to.equal('Loading is in progress');
+
+			// simulate loading completion
+			renderData.isLoading = false;
+			el.requestUpdate();
+			await elementUpdated(el);
+
+			const nodesAfterLoading = el.shadowRoot.querySelectorAll('div div[role="alert"]');
+			expect(nodesAfterLoading.length).to.equal(1);
+			expect(nodesAfterLoading[0].getAttribute('aria-label')).to.equal('Loading is finished');
+		});
+	});
+});

--- a/test/components/current-final-grade-card.test.js
+++ b/test/components/current-final-grade-card.test.js
@@ -1,6 +1,6 @@
 import '../../components/current-final-grade-card.js';
 
-import { expect, fixture, html } from '@open-wc/testing';
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
 
 describe('d2l-insights-current-final-grade-card', () => {
@@ -30,6 +30,20 @@ describe('d2l-insights-current-final-grade-card', () => {
 			const title = (el.shadowRoot.querySelectorAll('div.d2l-insights-current-final-grade-title'));
 			expect(title[0].innerText).to.equal('Current Grade');
 			expect(el._preparedHistogramData.toString()).to.equal(data.currentFinalGrades.toString());
+		});
+
+		it('should exclude chart form tabindex when data is loading', async() => {
+			const loadingData = Object.assign({}, data, { isLoading: true });
+			const el = await fixture(html`<d2l-insights-time-in-content-vs-grade-card .data="${loadingData}"></d2l-insights-time-in-content-vs-grade-card>`);
+
+			const chart = el.shadowRoot.querySelector('d2l-labs-chart');
+			const chartDiv = chart.shadowRoot.querySelector('#chart-container');
+			expect(chartDiv.getAttribute('tabindex')).to.equal('-1');
+
+			loadingData.isLoading = false;
+			el.requestUpdate();
+			await elementUpdated(el);
+			expect(chartDiv.getAttribute('tabindex')).to.equal('0');
 		});
 	});
 

--- a/test/components/current-final-grade-card.test.js
+++ b/test/components/current-final-grade-card.test.js
@@ -16,7 +16,7 @@ describe('d2l-insights-current-final-grade-card', () => {
 
 	describe('accessibility', () => {
 		it('should pass all axe tests', async function() {
-			this.timeout(4000);
+			this.timeout(3000);
 
 			const el = await fixture(html`<d2l-insights-current-final-grade-card .data="${data}"></d2l-insights-current-final-grade-card>`);
 			await expect(el).to.be.accessible();

--- a/test/components/current-final-grade-card.test.js
+++ b/test/components/current-final-grade-card.test.js
@@ -16,7 +16,7 @@ describe('d2l-insights-current-final-grade-card', () => {
 
 	describe('accessibility', () => {
 		it('should pass all axe tests', async function() {
-			this.timeout(3000);
+			this.timeout(4000);
 
 			const el = await fixture(html`<d2l-insights-current-final-grade-card .data="${data}"></d2l-insights-current-final-grade-card>`);
 			await expect(el).to.be.accessible();

--- a/test/components/overlay.test.js
+++ b/test/components/overlay.test.js
@@ -1,0 +1,36 @@
+import '../../components/overlay';
+
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
+
+describe('d2l-insights-overlay', () => {
+	describe('constructor', () => {
+		it('should construct', () => {
+			runConstructor('d2l-insights-overlay');
+		});
+	});
+
+	describe('accessibility', () => {
+		it('should pass all axe tests', async() => {
+			const el = await fixture(html`<d2l-insights-overlay loading spinner-size='50'></d2l-insights-overlay>`);
+			await expect(el).to.be.accessible();
+		});
+	});
+
+	describe('render', () => {
+		it('should render overlay in front of parent div with the size of parent div', async() => {
+			const parentNode = document.createElement('div');
+			parentNode.setAttribute('style', 'height: 100px; width: 100px; position: relative;');
+			const el = await fixture(html`<d2l-insights-overlay loading spinner-size='10'></d2l-insights-overlay>`, { parentNode });
+
+			expect(el.clientHeight).to.equal(100);
+			expect(el.clientWidth).to.equal(100);
+			expect(getComputedStyle(el, null).zIndex).equal('1');
+
+			el.removeAttribute('loading');
+			await elementUpdated(el);
+			expect(el.isLoading).to.equal(false);
+			expect(getComputedStyle(el, null).zIndex).equal('auto');
+		});
+	});
+});

--- a/test/components/time-in-content-vs-grade-card.test.js
+++ b/test/components/time-in-content-vs-grade-card.test.js
@@ -1,6 +1,6 @@
 import '../../components/time-in-content-vs-grade-card';
 
-import { expect, fixture, html } from '@open-wc/testing';
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
 
 describe('d2l-insights-time-in-content-vs-grade-card', () => {
@@ -27,6 +27,20 @@ describe('d2l-insights-time-in-content-vs-grade-card', () => {
 			const title = (el.shadowRoot.querySelectorAll('div.d2l-insights-time-in-content-vs-grade-title'));
 			expect(title[0].innerText).to.equal('Time in Content vs. Grade');
 			expect(el._preparedPlotData).to.equal(data.currentFinalGradesVsTimeInContent);
+		});
+
+		it('should exclude chart form tabindex when data is loading', async() => {
+			const loadingData = Object.assign({}, data, { isLoading: true });
+			const el = await fixture(html`<d2l-insights-time-in-content-vs-grade-card .data="${loadingData}"></d2l-insights-time-in-content-vs-grade-card>`);
+
+			const chart = el.shadowRoot.querySelector('d2l-labs-chart');
+			const chartDiv = chart.shadowRoot.querySelector('#chart-container');
+			expect(chartDiv.getAttribute('tabindex')).to.equal('-1');
+
+			loadingData.isLoading = false;
+			el.requestUpdate();
+			await elementUpdated(el);
+			expect(chartDiv.getAttribute('tabindex')).to.equal('0');
 		});
 	});
 });

--- a/test/engagement-dashboard.test.js
+++ b/test/engagement-dashboard.test.js
@@ -6,7 +6,7 @@ describe('d2l-insights-engagement-dashboard', () => {
 
 	describe('accessibility', () => {
 		it('should pass all axe tests', async function() {
-			this.timeout(3000);
+			this.timeout(4000);
 
 			const el = await fixture(html`<d2l-insights-engagement-dashboard></d2l-insights-engagement-dashboard>`);
 			// need for this delay might be tied to the mock data async loading in engagement-dashboard.js
@@ -14,6 +14,7 @@ describe('d2l-insights-engagement-dashboard', () => {
 			try {
 				await expect(el).to.be.accessible();
 			} catch (error) {
+				console.log(`Catched error: ${error}`);
 				// Bypass for chart accessibility
 				if (!error.message.includes('Rule: heading-order') || !error.message.includes('Context: <h5>Chart</h5>')) {
 					throw error;


### PR DESCRIPTION
[US118543](https://rally1.rallydev.com/#/detail/userstory/404486515748?fdp=true): [Engagement] Loading states

AC:

Add the spinners/grey cards/table into the UI for when the dashboard is loading as per the design

- [x] Overlay with spinner
- [x] Keyboard navigation while loading
- [x] Screen reader announcement
  - [x] Get proper langterms from Kevin
- [x] Unit tests
- [x] Grey card/table - separate PR

Out of scope of the story:
* Tab-navigation over dashboard's cards is a part of US120050 story. I believe that tab-navigation when loading is in-progress should be part of that story as well.
* Grey cards/table - skeleton components are [in active development](https://d2l.slack.com/archives/C0PHG3QB0/p1600085625042300). Should be implemented in a separate PR or story. 

### Functional Testing
* Unit tests
* Manual tests  
  * Keyboard navigation
  * Announcement when loading is started/finished. 
    * Alerts are not accessible for screen reader via tab and arrow navigation.
    * Alerts are not visible on the screen
    * FF: 1) alert Loading is in progress; 2) Loading is finished alert. NVDA repeats Loading is finished
    * Chrome: 1) alert Loading is in progress; 2) Loading is finished alert. NVDA repeats Loading is finished
    * Edge: 1) alert Loading is in progress; 2) Loading is finished alert .
  * Screen reader reads only titles of summary cards if tabindex is set
  * Charts are not available for tab-navigation when data is loading
  * Screen reader

### Security Testing - N/A
### Performance Testing - N/A
### Devops - N/A
### UX and docs 
- [x] Demo to Kevin
- [x] NVDA
- [x] JAWS
- [x] FF 
- [x] Chrome
- [x] Edge
- [x] ~Legacy edge~ - N/A

![loading](https://user-images.githubusercontent.com/9429561/93244498-7ea12f80-f792-11ea-94cd-acf65f0a3f21.gif)
