### PR TITLE
Fix accessiblity issues that was found implementing US118543 

### DIFF
--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -4,6 +4,9 @@ import 'highcharts/modules/accessibility';
 import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
 
 import { css, html, LitElement } from 'lit-element';
+
+export const BEFORE_CHART_FORMAT = '<h3>{chartTitle}</h3><div>{typeDescription}</div><div>{chartSubtitle}</div><div>{chartLongdesc}</div><div>{playAsSoundButton}</div><div>{viewTableButton}</div><div>{xAxisDescription}</div><div>{yAxisDescription}</div><div>{annotationsTitle}{annotationsList}</div>';
+
 /**
  * based on highcharts-webcomponent (npm) - main modifications: convert to plain .js, fix import, fix typing,
  * remove flag for suppressing updates, prevent unneeded update on first render

--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -10,10 +10,10 @@ export const BEFORE_CHART_FORMAT = '<h3>{chartTitle}</h3>' +
 	'<div>{typeDescription}</div>' +
 	'<div>{chartSubtitle}</div>' +
 	'<div>{chartLongdesc}</div>' +
-	'<div>{playAsSoundButton}</div>'+
-	'<div>{viewTableButton}</div>'+
-	'<div>{xAxisDescription}</div>'+
-	'<div>{yAxisDescription}</div>'+
+	'<div>{playAsSoundButton}</div>' +
+	'<div>{viewTableButton}</div>' +
+	'<div>{xAxisDescription}</div>' +
+	'<div>{yAxisDescription}</div>' +
 	'<div>{annotationsTitle}{annotationsList}</div>';
 
 /**

--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -99,6 +99,16 @@ class Chart extends LitElement {
 		}
 		else {
 			// Create a chart
+			H.setOptions({
+				lang: {
+					accessibility: {
+						screenReaderSection: {
+							// fixes axe error: Landmarks must have a unique role or role/label/title
+							beforeRegionLabel: ''
+						}
+					}
+				}
+			});
 			this.chart = H[constructorType](this.chartContainer, this.options, this.chartCreated.bind(this));
 		}
 	}

--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -5,7 +5,16 @@ import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
 
 import { css, html, LitElement } from 'lit-element';
 
-export const BEFORE_CHART_FORMAT = '<h3>{chartTitle}</h3><div>{typeDescription}</div><div>{chartSubtitle}</div><div>{chartLongdesc}</div><div>{playAsSoundButton}</div><div>{viewTableButton}</div><div>{xAxisDescription}</div><div>{yAxisDescription}</div><div>{annotationsTitle}{annotationsList}</div>';
+// use default highcharts's template but with <h3> instead of <h4> to fix axe heading-order error
+export const BEFORE_CHART_FORMAT = '<h3>{chartTitle}</h3>' +
+	'<div>{typeDescription}</div>' +
+	'<div>{chartSubtitle}</div>' +
+	'<div>{chartLongdesc}</div>' +
+	'<div>{playAsSoundButton}</div>'+
+	'<div>{viewTableButton}</div>'+
+	'<div>{xAxisDescription}</div>'+
+	'<div>{yAxisDescription}</div>'+
+	'<div>{annotationsTitle}{annotationsList}</div>';
 
 /**
  * based on highcharts-webcomponent (npm) - main modifications: convert to plain .js, fix import, fix typing,

--- a/components/current-final-grade-card.js
+++ b/components/current-final-grade-card.js
@@ -1,5 +1,5 @@
-import './chart/chart';
 import { css, html } from 'lit-element/lit-element.js';
+import { BEFORE_CHART_FORMAT } from './chart/chart';
 import { Localizer } from '../locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
 
@@ -147,6 +147,11 @@ class CurrentFinalGradeCard extends Localizer(MobxLitElement) {
 						}
 					}
 				},
+			},
+			accessibility: {
+				screenReaderSection: {
+					beforeChartFormat: BEFORE_CHART_FORMAT
+				}
 			},
 			series: [{
 				type: 'histogram',

--- a/components/current-final-grade-card.js
+++ b/components/current-final-grade-card.js
@@ -92,7 +92,10 @@ class CurrentFinalGradeCard extends Localizer(MobxLitElement) {
 			animation: false,
 			tooltip: { enabled: false },
 			title: {
-				text: '' // override default title
+				text: this._cardTitle, // override default title
+				style: {
+					display: 'none'
+				}
 			},
 			xAxis: {
 				title: { text: '' }, // override default title

--- a/components/time-in-content-vs-grade-card.js
+++ b/components/time-in-content-vs-grade-card.js
@@ -94,7 +94,10 @@ class TimeInContentVsGradeCard extends Localizer(MobxLitElement) {
 			animation: false,
 			tooltip: { enabled: false },
 			title: {
-				text: ''
+				text: this._cardTitle, // override default title
+				style: {
+					display: 'none'
+				}
 			},
 			legend: {
 				enabled: false

--- a/components/time-in-content-vs-grade-card.js
+++ b/components/time-in-content-vs-grade-card.js
@@ -1,6 +1,6 @@
 import 'highcharts';
-import './chart/chart';
 import { css, html } from 'lit-element/lit-element.js';
+import { BEFORE_CHART_FORMAT } from './chart/chart';
 import { Localizer } from '../locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
 
@@ -166,6 +166,11 @@ class TimeInContentVsGradeCard extends Localizer(MobxLitElement) {
 					value: this._avgGrade,
 					width: 1.5
 				}]
+			},
+			accessibility: {
+				screenReaderSection: {
+					beforeChartFormat: BEFORE_CHART_FORMAT
+				}
 			},
 			series: [{
 				data: this._preparedPlotData,

--- a/test/engagement-dashboard.test.js
+++ b/test/engagement-dashboard.test.js
@@ -5,21 +5,11 @@ import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-help
 describe('d2l-insights-engagement-dashboard', () => {
 
 	describe('accessibility', () => {
-		it('should pass all axe tests', async function() {
-			this.timeout(4000);
-
+		it('should pass all axe tests', async() => {
 			const el = await fixture(html`<d2l-insights-engagement-dashboard></d2l-insights-engagement-dashboard>`);
 			// need for this delay might be tied to the mock data async loading in engagement-dashboard.js
 			await new Promise(resolve => setTimeout(resolve, 1500));
-			try {
-				await expect(el).to.be.accessible();
-			} catch (error) {
-				console.log(`Catched error: ${error}`);
-				// Bypass for chart accessibility
-				if (!error.message.includes('Rule: heading-order') || !error.message.includes('Context: <h5>Chart</h5>')) {
-					throw error;
-				}
-			}
+			await expect(el).to.be.accessible();
 		});
 	});
 

--- a/test/engagement-dashboard.test.js
+++ b/test/engagement-dashboard.test.js
@@ -5,7 +5,9 @@ import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-help
 describe('d2l-insights-engagement-dashboard', () => {
 
 	describe('accessibility', () => {
-		it('should pass all axe tests', async() => {
+		it('should pass all axe tests', async function() {
+			this.timeout(3000);
+
 			const el = await fixture(html`<d2l-insights-engagement-dashboard demo></d2l-insights-engagement-dashboard>`);
 			// need for this delay might be tied to the mock data async loading in engagement-dashboard.js
 			await new Promise(resolve => setTimeout(resolve, 1500));

--- a/test/engagement-dashboard.test.js
+++ b/test/engagement-dashboard.test.js
@@ -6,7 +6,7 @@ describe('d2l-insights-engagement-dashboard', () => {
 
 	describe('accessibility', () => {
 		it('should pass all axe tests', async function() {
-			this.timeout(3000);
+			this.timeout(4000);
 
 			const el = await fixture(html`<d2l-insights-engagement-dashboard demo></d2l-insights-engagement-dashboard>`);
 			// need for this delay might be tied to the mock data async loading in engagement-dashboard.js


### PR DESCRIPTION
Fix of 
* [Heading levels should only increase by one](https://dequeuniversity.com/rules/axe/3.5/heading-order?application=axeAPI)
* [Landmarks must have a unique role or role/label/title (i.e. accessible name) combination](https://dequeuniversity.com/rules/axe/3.5/landmark-unique?application=axeAPI)

```
---
Rule: heading-order
Impact: moderate
Heading levels should only increase by one (https://dequeuniversity.com/rules/axe/3.5/heading-order?application=axeAPI)

Issue target: d2l-insights-engagement-dashboard,d2l-insights-current-final-grade-card,d2l-labs-chart,h5
Context: <h5>Chart</h5>
Fix any of the following:
  Heading order invalid
---
Rule: landmark-unique
Impact: moderate
Ensures landmarks are unique (https://dequeuniversity.com/rules/axe/3.5/landmark-unique?application=axeAPI)

Issue target: d2l-insights-engagement-dashboard,d2l-insights-current-final-grade-card,d2l-labs-chart,#chart-container
Context: <div id="chart-container" tabindex="-1" data-highcharts-chart="6" role="region" aria-label="Chart. Highcharts interactive chart." aria-hidden="f
Fix any of the following:
  The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable

Issue target: d2l-insights-engagement-dashboard,d2l-insights-current-final-grade-card,d2l-labs-chart,#highcharts-screen-reader-region-before-6
Context: <div id="highcharts-screen-reader-region-before-6" aria-label="Chart screen reader information." role="region" aria-hidden="false" style="positi
Fix any of the following:
  The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable
```

FYI @anhill-D2L @Vitalii-Misechko @johngwilkinson @mgalian 