### PR TITLE
Us119394/load ou children

### DIFF
--- a/components/ou-filter.js
+++ b/components/ou-filter.js
@@ -57,7 +57,7 @@ class OuFilter extends Localizer(MobxLitElement) {
 	async _onRequestChildren(event) {
 		const id = event.detail.id;
 		const children = await fetchRelevantChildren(id, this.data.selectedSemesterIds);
-		await this._tree.addNodes(id, children);
+		await event.target.tree.addNodes(id, children);
 	}
 }
 customElements.define('d2l-insights-ou-filter', OuFilter);

--- a/components/ou-filter.js
+++ b/components/ou-filter.js
@@ -1,4 +1,5 @@
 import { css, html } from 'lit-element/lit-element.js';
+import { fetchRelevantChildren } from '../model/lms';
 import { Localizer } from '../locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
 
@@ -33,6 +34,7 @@ class OuFilter extends Localizer(MobxLitElement) {
 				opener-text="${this.localize('components.org-unit-filter.name-all-selected')}"
 				opener-text-selected="${this.localize('components.org-unit-filter.name-some-selected')}"
 				@d2l-insights-tree-filter-select="${this._onChange}"
+				@d2l-insights-tree-filter-request-children="${this._onRequestChildren}"
 			>
 			</d2l-insights-tree-filter>
 		</div>`;
@@ -50,6 +52,12 @@ class OuFilter extends Localizer(MobxLitElement) {
 			'd2l-insights-ou-filter-change',
 			{ bubbles: true, composed: false }
 		));
+	}
+
+	async _onRequestChildren(event) {
+		const id = event.detail.id;
+		const children = await fetchRelevantChildren(id, this.data.selectedSemesterIds);
+		await this._tree.addNodes(id, children);
 	}
 }
 customElements.define('d2l-insights-ou-filter', OuFilter);

--- a/components/ou-filter.js
+++ b/components/ou-filter.js
@@ -57,7 +57,7 @@ class OuFilter extends Localizer(MobxLitElement) {
 	async _onRequestChildren(event) {
 		const id = event.detail.id;
 		const children = await fetchRelevantChildren(id, this.data.selectedSemesterIds);
-		await event.target.tree.addNodes(id, children);
+		this.data.orgUnitTree.addNodes(id, children);
 	}
 }
 customElements.define('d2l-insights-ou-filter', OuFilter);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,6 +5,12 @@ const merge = require('deepmerge');
 module.exports = config => {
 	config.set(
 		merge(createDefaultConfig(config), {
+			// from https://support.saucelabs.com/hc/en-us/articles/225104707-Karma-Tests-Disconnect-Particularly-When-Running-Tests-on-Safari
+			// to avoid DISCONNECTED messages
+			browserDisconnectTimeout: 10000, // default 2000
+			browserDisconnectTolerance: 1, // default 0
+			browserNoActivityTimeout: 4 * 60 * 1000, //default 10000
+			captureTimeout: 4 * 60 * 1000, //default 60000
 			files: [
 				// runs all files ending with .test in the test folder,
 				// can be overwritten by passing a --grep flag. examples:
@@ -18,6 +24,11 @@ module.exports = config => {
 				// if you are using 'bare module imports' you will need this option
 				nodeResolve: true,
 			},
+			client: {
+				mocha: {
+					timeout: 20000 // 20 seconds
+				}
+			}
 		}),
 	);
 	return config;

--- a/model/data.js
+++ b/model/data.js
@@ -1,6 +1,7 @@
 import { action, autorun, computed, decorate, observable } from 'mobx';
 import { OrgUnitSelectorFilter, RoleSelectorFilter, SemesterSelectorFilter } from './selectorFilters.js';
 import { CardFilter } from './cardFilter.js';
+import { fetchCachedChildren } from './lms.js';
 import { Tree } from '../components/tree-filter';
 
 export const COURSE_OFFERING = 3;
@@ -94,8 +95,14 @@ export class Data {
 			selectedIds: newServerData.defaultViewOrgUnitIds || newServerData.selectedOrgUnitIds || [],
 			ancestorIds: newServerData.selectedSemestersIds || [],
 			oldTree: this.orgUnitTree,
-			isDynamic: newServerData.isOrgUnitsTruncated
+			isDynamic: newServerData.isOrgUnitsTruncated,
+			// preload the tree with any children queries we've already run: otherwise parts of the
+			// tree blink out and then come back as they are loaded again
+			extraChildren: newServerData.isOrgUnitsTruncated ?
+				fetchCachedChildren(newServerData.selectedSemestersIds) || new Map() :
+				null
 		});
+
 		this._userDictionary = new Map(newServerData.users.map(user => [user[USER.ID], user]));
 		this.isLoading = false;
 		this.serverData = newServerData;

--- a/model/data.js
+++ b/model/data.js
@@ -93,7 +93,8 @@ export class Data {
 			invisibleTypes: [newServerData.semesterTypeId],
 			selectedIds: newServerData.defaultViewOrgUnitIds || newServerData.selectedOrgUnitIds || [],
 			ancestorIds: newServerData.selectedSemestersIds || [],
-			oldTree: this.orgUnitTree
+			oldTree: this.orgUnitTree,
+			isDynamic: newServerData.isOrgUnitsTruncated
 		});
 		this._userDictionary = new Map(newServerData.users.map(user => [user[USER.ID], user]));
 		this.isLoading = false;

--- a/model/lms.js
+++ b/model/lms.js
@@ -1,6 +1,7 @@
 const rolesEndpoint = '/d2l/api/lp/1.23/roles/';
 const semestersEndpoint = '/d2l/api/ap/unstable/insights/data/semesters';
 const dataEndpoint = '/d2l/api/ap/unstable/insights/data/engagement';
+const relevantChildrenEndpoint = orgUnitId => `/d2l/api/ap/unstable/insights/data/orgunits/${orgUnitId}/children`;
 
 /**
  * @param {[Number]} roleIds
@@ -54,4 +55,14 @@ export async function fetchSemesters(pageSize, bookmark, search) {
 	}
 	const response = await fetch(url.toString());
 	return await response.json();
+}
+
+export async function fetchRelevantChildren(orgUnitId, selectedSemesterIds) {
+	const url = new URL(relevantChildrenEndpoint(orgUnitId), window.location.origin);
+	if (selectedSemesterIds) {
+		url.searchParams.set('selectedSemestersCsv', selectedSemesterIds.join(','));
+	}
+	const response = await fetch(url.toString());
+	// Paging not handled yet (work is in backlog)
+	return (await response.json()).Items;
 }

--- a/model/selectorFilters.js
+++ b/model/selectorFilters.js
@@ -65,9 +65,10 @@ export class SemesterSelectorFilter {
 }
 
 export class OrgUnitSelectorFilter {
-	constructor({ selectedOrgUnitIds, isRecordsTruncated }, orgUnitTree) {
+	constructor({ selectedOrgUnitIds, isRecordsTruncated, isOrgUnitsTruncated }, orgUnitTree) {
 		this._latestServerQuery = selectedOrgUnitIds || [];
 		this._isRecordsTruncated = isRecordsTruncated;
+		this._isOrgUnitsTruncated = isOrgUnitsTruncated;
 		this._orgUnitTree = orgUnitTree;
 	}
 
@@ -85,7 +86,11 @@ export class OrgUnitSelectorFilter {
 	}
 
 	shouldReloadFromServer(newOrgUnitIds) {
-		if (this._isRecordsTruncated || isFilterCleared(this._latestServerQuery, newOrgUnitIds)) {
+		if (this._isRecordsTruncated
+			// ou selection affects the *order* of org units, so if the ou tree is
+			// truncated, selection can affect which ones are in view
+			|| this._isOrgUnitsTruncated
+			|| isFilterCleared(this._latestServerQuery, newOrgUnitIds)) {
 			return true;
 		}
 

--- a/test/model/data.test.js
+++ b/test/model/data.test.js
@@ -111,6 +111,7 @@ describe('Data', () => {
 		isOrgUnitsTruncated: false
 	};
 
+	const TRUNCATE_IF_THIS_ROLE_IS_PRESENT = 999999;
 	const recordProvider = async({ roleIds = null, semesterIds = null, orgUnitIds = null }) => {
 		return new Promise((resolve) => {
 			resolve({
@@ -118,7 +119,8 @@ describe('Data', () => {
 				semesterTypeId: mockOuTypes.semester,
 				selectedRolesIds: roleIds,
 				selectedSemestersIds: semesterIds,
-				selectedOrgUnitIds: orgUnitIds
+				selectedOrgUnitIds: orgUnitIds,
+				isOrgUnitsTruncated: roleIds.includes(TRUNCATE_IF_THIS_ROLE_IS_PRESENT)
 			});
 		});
 	};
@@ -143,6 +145,16 @@ describe('Data', () => {
 
 			expect(sut.orgUnitTree).to.not.equal(oldTree); // make sure the the data was loaded
 			expect(sut.orgUnitTree.open.sort()).to.deep.equal([1, 1001]);
+			expect(sut.orgUnitTree.isPopulated(6606)).to.be.true;
+		});
+
+		it('marks the org unit tree as dynamic if the server truncated it', async() => {
+			// trigger a truncated reload and allow recordProvider to resolve
+			sut._selectorFilters.role = new RoleSelectorFilter({ selectedRolesIds: null, isRecordsTruncated: true });
+			sut.selectedRoleIds = [mockRoleIds.student, TRUNCATE_IF_THIS_ROLE_IS_PRESENT];
+			await new Promise(resolve => setTimeout(resolve, 0));
+
+			expect(sut.orgUnitTree.isPopulated(6606)).to.be.false;
 		});
 	});
 

--- a/test/model/lms.test.js
+++ b/test/model/lms.test.js
@@ -1,10 +1,14 @@
+import { fetchRelevantChildren, fetchRoles } from '../../model/lms';
 import { expect } from '@open-wc/testing';
 import fetchMock from 'fetch-mock/esm/client';
-import { fetchRoles } from '../../model/lms';
 
 const rolesEndpoint = '/d2l/api/lp/1.23/roles/';
 
 describe('Lms', () => {
+	afterEach(() => {
+		fetchMock.reset();
+	});
+
 	describe('fetchRoles', () => {
 		it('should fetch roles from LMS', async() => {
 			const mockLmsResponseData = [
@@ -32,7 +36,28 @@ describe('Lms', () => {
 		});
 	});
 
-	after(() => {
-		fetchMock.reset();
+	describe('fetchRelevantChildren', () => {
+		it('should fetch children from the LMS without a semester filter', async() => {
+			const mockLmsResponseData = {
+				Items: [2, 4, 7, 8, 9] // not representative; just for matching
+			};
+
+			fetchMock.get('path:/d2l/api/ap/unstable/insights/data/orgunits/6612/children', mockLmsResponseData);
+
+			expect(await fetchRelevantChildren(6612)).to.deep.equal(mockLmsResponseData.Items);
+		});
+
+		it('should fetch children from the LMS with a semester filter', async() => {
+			const mockLmsResponseData = {
+				Items: [2, 4, 7, 8, 9] // not representative; just for matching
+			};
+
+			fetchMock.get(
+				'end:/d2l/api/ap/unstable/insights/data/orgunits/6612/children?selectedSemestersCsv=4%2C500%2C8',
+				mockLmsResponseData
+			);
+
+			expect(await fetchRelevantChildren(6612, [4, 500, 8])).to.deep.equal(mockLmsResponseData.Items);
+		});
 	});
 });

--- a/test/model/lms.test.js
+++ b/test/model/lms.test.js
@@ -1,4 +1,4 @@
-import { fetchRelevantChildren, fetchRoles } from '../../model/lms';
+import { fetchCachedChildren, fetchRelevantChildren, fetchRoles } from '../../model/lms';
 import { expect } from '@open-wc/testing';
 import fetchMock from 'fetch-mock/esm/client';
 
@@ -58,6 +58,49 @@ describe('Lms', () => {
 			);
 
 			expect(await fetchRelevantChildren(6612, [4, 500, 8])).to.deep.equal(mockLmsResponseData.Items);
+		});
+
+		it('should cache by semester ids', async() => {
+			const mockLmsResponseData1 = {
+				Items: [2, 4, 7, 8, 9] // not representative; just for matching
+			};
+			const mockLmsResponseData2 = {
+				Items: [10, 11, 100] // not representative; just for matching
+			};
+
+			fetchMock.get(
+				'end:/d2l/api/ap/unstable/insights/data/orgunits/9619/children?selectedSemestersCsv=4%2C500%2C8',
+				mockLmsResponseData1
+			);
+			await fetchRelevantChildren(9619, [4, 500, 8]);
+
+			fetchMock.get(
+				'end:/d2l/api/ap/unstable/insights/data/orgunits/6612/children?selectedSemestersCsv=4%2C500%2C8',
+				mockLmsResponseData2
+			);
+			await fetchRelevantChildren(6612, [4, 500, 8]);
+
+			expect([...fetchCachedChildren([4, 500, 8])]).to.deep.equal([
+				[6612, mockLmsResponseData2.Items],
+				[9619, mockLmsResponseData1.Items]
+			]);
+		});
+
+		it('should treat null as empty array in cache key', async() => {
+			const mockLmsResponseData = {
+				Items: [2, 4, 7, 8, 9] // not representative; just for matching
+			};
+
+			fetchMock.get(
+				'end:/d2l/api/ap/unstable/insights/data/orgunits/6612/children?selectedSemestersCsv=',
+				mockLmsResponseData
+			);
+
+			await fetchRelevantChildren(6612, []);
+
+			expect([...fetchCachedChildren(null)]).to.deep.equal([
+				[6612, mockLmsResponseData.Items]
+			]);
 		});
 	});
 });

--- a/test/model/selectorFilters.test.js
+++ b/test/model/selectorFilters.test.js
@@ -264,6 +264,15 @@ describe('selectorFilters', () => {
 				expect(sut.shouldReloadFromServer(newOrgUnitIds)).to.be.true;
 			});
 
+			it('should return true if ou tree is truncated', () => {
+				const newOrgUnitIds = [1, 3]; // a list that otherwise wouldn't trigger a server reload
+				const sut = new OrgUnitSelectorFilter({
+					selectedOrgUnitIds: [1, 3, 5],
+					isOrgUnitsTruncated: true
+				}, null);
+				expect(sut.shouldReloadFromServer(newOrgUnitIds)).to.be.true;
+			});
+
 			it('should return true if the existing selected list has items and the new list has no items', () => {
 				// i.e. the filter was cleared
 				const newOrgUnitIds = [/* empty */];


### PR DESCRIPTION
Quality Notes
* functional (all impersonating Power User)
  * NB: search does not fully work, as it only includes data that is already available client-side
  * with CourseLimit config in LMS set to 5 (instead of default 5000)
    * default view as expected
    * dept containing default selection appears partially selected
    * navigate into unselected dept
    * navigate into selected dept
    * select and deselect dept
      * note that with truncation at only 5 courses, the default selection can become hidden if the user adds another selection without first expanding the department(s) containing default selections: the client doesn't have enough information to mark the default department(s) partially selected because the selected courses are left out of the response . So long as the truncation limit is significantly larger than the number of default courses, this won't happen
    * select and deselect courses within a department
    * confirm that server response includes five of the selected ou ids, whether they are in one department, two, or three
    * use case: deselect semester filter and default courses, then select the department with test final grades data; data appears in graphs
  * with CourseLimit set to default (no truncation regression testing)
* performance
  * many more server hits when truncated, but each is very quick
  * confirmed ou tree data structure is only rebuilt on load of main data from server (not every time children are added)
  * without lms client cache of children, there is noticeable lag and jumpiness when selecting courses; with cache, this is not noticeable
* devops: n/a
* security: n/a
* ux/docs
  * NB: there's no loading spinner/gray-out; it might be desirable to add this in another PR
  * alerting the user about truncation is out-of-scope
  * tree navigation and selection/deselection works the same whether or not there's ou truncation (so no specifically UX demo - functionality to be demoed to team)

FYI: @anhill-D2L @MykolaGalian @rohitvinnakota 