### PR TITLE
Add hover behavior for current final grade

### DIFF
--- a/components/current-final-grade-card.js
+++ b/components/current-final-grade-card.js
@@ -63,12 +63,12 @@ class CurrentFinalGradeCard extends Localizer(MobxLitElement) {
 		return this.data.currentFinalGrades;
 	}
 
-	get _gradeBetweenText() {
-		return this.localize('components.insights-current-final-grade-card.gradeBetween');
+	_gradeBetweenText(numberOfUsers, range) {
+		return this.localize('components.insights-current-final-grade-card.gradeBetween', { numberOfUsers, range });
 	}
 
-	get _gradeBetweenTextSingleUser() {
-		return this.localize('components.insights-current-final-grade-card.gradeBetweenSingleUser');
+	_gradeBetweenTextSingleUser(range) {
+		return this.localize('components.insights-current-final-grade-card.gradeBetweenSingleUser', { range });
 	}
 
 	render() {
@@ -104,9 +104,16 @@ class CurrentFinalGradeCard extends Localizer(MobxLitElement) {
 					const yCeil = Math.ceil(this.y);
 					const xCeil = Math.ceil(this.x);
 					if (yCeil === 1) {
-						return `${yCeil} ${that._gradeBetweenTextSingleUser} ${xCeil}-${xCeil + 10}%.`;
+						return `${that._gradeBetweenTextSingleUser(`${xCeil}-${xCeil + 10}`)}`;
 					}
-					return `${yCeil} ${that._gradeBetweenText} ${xCeil}-${xCeil + 10}%.`;
+					return `${that._gradeBetweenText(`${yCeil}`, `${xCeil}-${xCeil + 10}`)}`;
+				},
+				backgroundColor: 'var(--d2l-color-ferrite)',
+				borderColor: 'var(--d2l-color-ferrite)',
+				borderRadius: 12,
+				style: {
+					color: 'white',
+					backgroundColor: 'blue'
 				}
 			},
 			title: {

--- a/components/current-final-grade-card.js
+++ b/components/current-final-grade-card.js
@@ -63,6 +63,14 @@ class CurrentFinalGradeCard extends Localizer(MobxLitElement) {
 		return this.data.currentFinalGrades;
 	}
 
+	get _gradeBetweenText() {
+		return this.localize('components.insights-current-final-grade-card.gradeBetween');
+	}
+
+	get _gradeBetweenTextSingleUser() {
+		return this.localize('components.insights-current-final-grade-card.gradeBetweenSingleUser');
+	}
+
 	render() {
 		// NB: relying on mobx rather than lit-element properties to handle update detection: it will trigger a redraw for
 		// any change to a relevant observed property of the Data object
@@ -85,12 +93,22 @@ class CurrentFinalGradeCard extends Localizer(MobxLitElement) {
 	}
 
 	get chartOptions() {
+		const that = this;
 		return {
 			chart: {
 				height: 230
 			},
 			animation: false,
-			tooltip: { enabled: false },
+			tooltip: {
+				formatter: function() {
+					const yCeil = Math.ceil(this.y);
+					const xCeil = Math.ceil(this.x);
+					if (yCeil === 1) {
+						return `${yCeil} ${that._gradeBetweenTextSingleUser} ${xCeil}-${xCeil + 10}%.`;
+					}
+					return `${yCeil} ${that._gradeBetweenText} ${xCeil}-${xCeil + 10}%.`;
+				}
+			},
 			title: {
 				text: this._cardTitle, // override default title
 				style: {
@@ -165,7 +183,7 @@ class CurrentFinalGradeCard extends Localizer(MobxLitElement) {
 			},
 			{
 				data: this._preparedHistogramData,
-				visible: false
+				visible: false,
 			}],
 		};
 	}

--- a/locales/en.js
+++ b/locales/en.js
@@ -45,6 +45,8 @@ export default {
 	"components.insights-current-final-grade-card.numberOfStudents": "Number of Students",
 	"components.insights-current-final-grade-card.textLabel": "This chart displays the current final grade for each user per course",
 	"components.insights-current-final-grade-card.emptyMessage": "There are no results available that match your filters.",
+	"components.insights-current-final-grade-card.gradeBetween":'users have a current grade between',
+	"components.insights-current-final-grade-card.gradeBetweenSingleUser":'user has a current grade between',
 
 	"components.insights-course-last-access-card.courseAccess": "Course Access",
 	"components.insights-course-last-access-card.numberOfUsers": "Number of Users",

--- a/locales/en.js
+++ b/locales/en.js
@@ -45,8 +45,8 @@ export default {
 	"components.insights-current-final-grade-card.numberOfStudents": "Number of Students",
 	"components.insights-current-final-grade-card.textLabel": "This chart displays the current final grade for each user per course",
 	"components.insights-current-final-grade-card.emptyMessage": "There are no results available that match your filters.",
-	"components.insights-current-final-grade-card.gradeBetween":'users have a current grade between',
-	"components.insights-current-final-grade-card.gradeBetweenSingleUser":'user has a current grade between',
+	"components.insights-current-final-grade-card.gradeBetween": "{numberOfUsers} users have a current grade between {range}%",
+	"components.insights-current-final-grade-card.gradeBetweenSingleUser": "1 user has a current grade between {range}%",
 
 	"components.insights-course-last-access-card.courseAccess": "Course Access",
 	"components.insights-course-last-access-card.numberOfUsers": "Number of Users",


### PR DESCRIPTION
[US118264](https://rally1.rallydev.com/#/detail/userstory/402807208416?fdp=true): [Engagement][Cards] Grades Hover Text

![image](https://user-images.githubusercontent.com/21348406/94454096-74623680-017f-11eb-8156-7fd73044b17e.png)

Quality notes: 

-> Tested on chrome, firefox, and edge
-> No changes to accessibility functionality since that relies on the `pointDescriptionFormatter` attribute
-> Tested with filters, tooltip values update as expected. 

fyi: @bemailloux @hyehayes @anhill-D2L @Vitalii-Misechko 