### PR TITLE
Add hover behavior for course last access

### DIFF
--- a/components/course-last-access-card.js
+++ b/components/course-last-access-card.js
@@ -86,6 +86,28 @@ class CourseLastAccessCard extends Localizer(MobxLitElement) {
 		];
 	}
 
+	_cardTooltipText(numberOfUsers) {
+		return [
+			this.localize('components.insights-course-last-access-card.tooltipNeverAccessed', { numberOfUsers }),
+			this.localize('components.insights-course-last-access-card.tooltipMoreThanFourteenDays', { numberOfUsers }),
+			this.localize('components.insights-course-last-access-card.toolTipSevenToFourteenDays', { numberOfUsers }),
+			this.localize('components.insights-course-last-access-card.toolTipFiveToSevenDays', { numberOfUsers }),
+			this.localize('components.insights-course-last-access-card.toolTipOneToFiveDays', { numberOfUsers }),
+			this.localize('components.insights-course-last-access-card.toolTipLessThanOneDay', { numberOfUsers })
+		];
+	}
+
+	get _cardTooltipTextSingleUser() {
+		return [
+			this.localize('components.insights-course-last-access-card.tooltipNeverAccessedSingleUser'),
+			this.localize('components.insights-course-last-access-card.tooltipMoreThanFourteenDaysSingleUser'),
+			this.localize('components.insights-course-last-access-card.toolTipSevenToFourteenDaysSingleUser'),
+			this.localize('components.insights-course-last-access-card.toolTipFiveToSevenDaysSingleUser'),
+			this.localize('components.insights-course-last-access-card.toolTipOneToFiveDaysSingleUser'),
+			this.localize('components.insights-course-last-access-card.toolTipLessThanOneDaySingleUser')
+		];
+	}
+
 	render() {
 		// NB: relying on mobx rather than lit-element properties to handle update detection: it will trigger a redraw for
 		// any change to a relevant observed property of the Data object
@@ -103,7 +125,20 @@ class CourseLastAccessCard extends Localizer(MobxLitElement) {
 				height: '250px',
 			},
 			animation: false,
-			tooltip: { enabled: false },
+			tooltip: {
+				formatter: function() {
+					if (this.point.y === 1) {
+						return `${that._cardTooltipTextSingleUser[this.point.x]}`;
+					}
+					return `${that._cardTooltipText(this.point.y)[this.point.x]}`;
+				},
+				backgroundColor: 'var(--d2l-color-ferrite)',
+				borderColor: 'var(--d2l-color-ferrite)',
+				borderRadius: 12,
+				style: {
+					color: 'white',
+				}
+			},
 			title: {
 				text: this._cardTitle,
 				style: {

--- a/components/current-final-grade-card.js
+++ b/components/current-final-grade-card.js
@@ -113,7 +113,6 @@ class CurrentFinalGradeCard extends Localizer(MobxLitElement) {
 				borderRadius: 12,
 				style: {
 					color: 'white',
-					backgroundColor: 'blue'
 				}
 			},
 			title: {

--- a/locales/en.js
+++ b/locales/en.js
@@ -59,6 +59,18 @@ export default {
 	"components.insights-course-last-access-card.oneToFiveDaysAgo": "1-5 days ago",
 	"components.insights-course-last-access-card.lessThanOneDayAgo": "< 1 day ago",
 	"components.insights-course-last-access-card.accessibilityLessThanOne": "Less than 1 day ago",
+	"components.insights-course-last-access-card.tooltipNeverAccessed": "{numberOfUsers} users have never accessed the course",
+	"components.insights-course-last-access-card.tooltipMoreThanFourteenDays": "{numberOfUsers} users last accessed the course more than 14 days ago",
+	"components.insights-course-last-access-card.toolTipSevenToFourteenDays": "{numberOfUsers} users last accessed the course 7 to 14 days ago",
+	"components.insights-course-last-access-card.toolTipFiveToSevenDays": "{numberOfUsers} users last accessed the course 5 to 7 days ago",
+	"components.insights-course-last-access-card.toolTipOneToFiveDays": "{numberOfUsers} users last accessed the course 1 to 5 days ago",
+	"components.insights-course-last-access-card.toolTipLessThanOneDay": "{numberOfUsers} users last accessed the course less than 1 day ago",
+	"components.insights-course-last-access-card.tooltipNeverAccessedSingleUser": "1 user has never accessed the course",
+	"components.insights-course-last-access-card.tooltipMoreThanFourteenDaysSingleUser": "1 user last accessed the course more than 14 days ago",
+	"components.insights-course-last-access-card.toolTipSevenToFourteenDaysSingleUser": "1 user last accessed the course 7 to 14 days ago",
+	"components.insights-course-last-access-card.toolTipFiveToSevenDaysSingleUser": "1 user last accessed the course 5 to 7 days ago",
+	"components.insights-course-last-access-card.toolTipOneToFiveDaysSingleUser": "1 user last accessed the course 1 to 5 days ago",
+	"components.insights-course-last-access-card.toolTipLessThanOneDaySingleUser": "1 user last accessed the course less than 1 day ago",
 
 	"components.insights-engagement-dashboard.overdueAssignments": "Users currently have one or more overdue assignments.",
 


### PR DESCRIPTION
[US118262](https://rally1.rallydev.com/#/detail/userstory/402806125096?fdp=true): [Engagement][Cards] Course Access Hover Text

![image](https://user-images.githubusercontent.com/21348406/94475719-7d620080-019d-11eb-9a46-4dae4b42ad48.png)

Quality notes:

Similar to current final grade
-> Tested on chrome, firefox, and edge
-> No changes to accessibility functionality since that relies on the pointDescriptionFormatter attribute
-> Tested with filters, tooltip values update as expected.

fyi: @bemailloux @hyehayes @anhill-D2L @Vitalii-Misechko

