### PR TITLE
TiC v Grades Hover Text

### DIFF
--- a/components/time-in-content-vs-grade-card.js
+++ b/components/time-in-content-vs-grade-card.js
@@ -118,15 +118,6 @@ class TimeInContentVsGradeCard extends Localizer(MobxLitElement) {
 			[(maxTimeInContent + this._avgTimeInContent) / 2, 75]];
 	}
 
-	get _plotDataLengths() {
-		return [
-			this._plotDataForLeftBottomQuadrant.length,
-			this._plotDataForLeftTopQuadrant.length,
-			this._plotDataForRightTopQuadrant.length,
-			this._plotDataForRightBottomQuadrant.length
-		];
-	}
-
 	_setQuadrant(quadrant) {
 		this.data.setTiCVsGradesQuadrant(quadrant);
 	}
@@ -216,20 +207,19 @@ class TimeInContentVsGradeCard extends Localizer(MobxLitElement) {
 			tooltip: {
 				formatter: function() {
 					if (this.series.name === 'midPoint') {
-						const dataLengths = that._plotDataLengths;
 						const midPoints = that._dataMidPoints;
-						const currentPoint = [this.x, this.y];
-						if (currentPoint.toString() === midPoints[0].toString()) {
-							return that._toolTipTextByQuadrant('leftBottom', dataLengths[0]);
+						const currentMidPoint = [this.x, this.y];
+						if (currentMidPoint.toString() === midPoints[0].toString()) {
+							return that._toolTipTextByQuadrant(this.series.chart.series[0].name, this.series.chart.series[0].data.length);
 						}
-						if (currentPoint.toString() === midPoints[1].toString()) {
-							return that._toolTipTextByQuadrant('leftTop', dataLengths[1]);
+						if (currentMidPoint.toString() === midPoints[1].toString()) {
+							return that._toolTipTextByQuadrant(this.series.chart.series[1].name, this.series.chart.series[1].data.length);
 						}
-						if (currentPoint.toString() === midPoints[2].toString()) {
-							return that._toolTipTextByQuadrant('rightTop', dataLengths[2]);
+						if (currentMidPoint.toString() === midPoints[2].toString()) {
+							return that._toolTipTextByQuadrant(this.series.chart.series[2].name, this.series.chart.series[2].data.length);
 						}
-						if (currentPoint.toString() === midPoints[3].toString()) {
-							return that._toolTipTextByQuadrant('rightBottom', dataLengths[3]);
+						if (currentMidPoint.toString() === midPoints[3].toString()) {
+							return that._toolTipTextByQuadrant(this.series.chart.series[3].name, this.series.chart.series[3].data.length);
 						}
 					}
 					return false;
@@ -240,7 +230,8 @@ class TimeInContentVsGradeCard extends Localizer(MobxLitElement) {
 				style: {
 					color: 'white',
 					width: 375
-				}
+				},
+				shared: true
 			},
 			title: {
 				text: this._cardTitle, // override default title

--- a/locales/en.js
+++ b/locales/en.js
@@ -40,6 +40,10 @@ export default {
 	"components.insights-time-in-content-vs-grade-card.timeInContentVsGrade": "Time in Content vs. Grade",
 	"components.insights-time-in-content-vs-grade-card.currentGrade": "Current Grade (%)",
 	"components.insights-time-in-content-vs-grade-card.timeInContent": "Time in Content (mins)",
+	"components.insights-time-in-content-vs-grade-card.leftTop": "{numberOfUsers} user enrollments are getting an above average grade and spending below average time in content.",
+	"components.insights-time-in-content-vs-grade-card.rightTop": " {numberOfUsers} user enrollments are getting an above average grade and spending above average time in content.",
+	"components.insights-time-in-content-vs-grade-card.leftBottom": "{numberOfUsers} user enrollments are getting a below average grade and spending below average time in content.",
+	"components.insights-time-in-content-vs-grade-card.rightBottom": "{numberOfUsers} user enrollments are getting a below average grade and spending above average time in content.",
 
 	"components.insights-current-final-grade-card.currentGrade": "Current Grade",
 	"components.insights-current-final-grade-card.numberOfStudents": "Number of Students",


### PR DESCRIPTION
[US118263](https://rally1.rallydev.com/#/detail/userstory/402807206872?fdp=true): [Engagement][Cards] TiC v Grades Hover Text

![image](https://user-images.githubusercontent.com/21348406/94937727-fa42f200-049d-11eb-9eaa-0fa64e58dd61.png)

After a discussion with Kevin, it was agreed that we want the arrow of the tooltip to point to the midpoint of the quadrant. The tradeoff here is that the tooltip will not pop up if we hover at the edge of the chart, otherwise it works as expected. 

**Quality Notes**
Functional testing
Tested the following cases
-> No data in quadrant: Shows "0 users have x grade.."
-> Tested on edge, chrome, and firefox
-> Tooltip updates with filters

Accessibility
->No effect on accessibility 


- [x] Perf(): make query more optimal 
Devops: local app works as expected with test data
UX: Went over design with Kevin
Security: n/a

fyi: @bemailloux @hyehayes @Vitalii-Misechko @anhill-D2L 