### PR TITLE
US117442 More users table headers

### DIFF
--- a/components/table.js
+++ b/components/table.js
@@ -13,7 +13,7 @@ class Table extends Localizer(RtlMixin(LitElement)) {
 	static get properties() {
 		return {
 			title: { type: String, attribute: true },
-			columns: { type: Array, attribute: false },
+			columnHeaders: { type: Array, attribute: false },
 			data: { type: Array, attribute: false }
 		};
 	}
@@ -124,7 +124,7 @@ class Table extends Localizer(RtlMixin(LitElement)) {
 
 	constructor() {
 		super();
-		this.columns = [];
+		this.columnHeaders = [];
 		this.data = [];
 		this.title = '';
 	}
@@ -142,7 +142,7 @@ class Table extends Localizer(RtlMixin(LitElement)) {
 		return html`
 			<thead class="d2l-insights-table-header">
 				<tr class="d2l-insights-table-row-first ${ (this.data.length === 0) ? 'd2l-insights-table-row-last' : '' }">
-					${this.columns.map(this._renderHeaderCell)}
+					${this.columnHeaders.map(this._renderHeaderCell)}
 				</tr>
 			</thead>
 		`;

--- a/components/users-table.js
+++ b/components/users-table.js
@@ -6,6 +6,15 @@ import { css, html } from 'lit-element';
 import { Localizer } from '../locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
 
+export const TABLE_USER = {
+	LAST_FIRST_NAME: 0,
+	// LAST_ACCESSED_SYSTEM: 1,
+	COURSES: 1,
+	AVG_GRADE: 2,
+	AVG_TIME_IN_CONTENT: 3
+	// AVG_DISCUSSION_ACTIVITY: 4
+};
+
 /**
  * At the moment the mobx data object is doing sorting / filtering logic
  *
@@ -74,9 +83,14 @@ class UsersTable extends Localizer(MobxLitElement) {
 		return [];
 	}
 
-	get columns() {
+	get columnHeaders() {
 		return [
-			this.localize('components.insights-users-table.lastFirstName')
+			this.localize('components.insights-users-table.lastFirstName'),
+			// this.localize('components.insights-users-table.lastAccessedSystem'),
+			this.localize('components.insights-users-table.courses'),
+			this.localize('components.insights-users-table.avgGrade'),
+			this.localize('components.insights-users-table.avgTimeInContent')
+			// this.localize('components.insights-users-table.avgDiscussionActivity')
 		];
 	}
 
@@ -84,7 +98,7 @@ class UsersTable extends Localizer(MobxLitElement) {
 		return html`
 			<d2l-insights-table
 				title="${this.localize('components.insights-users-table.title')}"
-				.columns=${this.columns}
+				.columnHeaders=${this.columnHeaders}
 				.data="${this._displayData}"></d2l-insights-table>
 
 			<d2l-labs-pagination

--- a/locales/en.js
+++ b/locales/en.js
@@ -34,6 +34,11 @@ export default {
 
 	"components.insights-users-table.title": "User Details",
 	"components.insights-users-table.lastFirstName": "Last Name, First Name",
+	"components.insights-users-table.lastAccessedSystem": "Last Accessed System",
+	"components.insights-users-table.courses": "Courses",
+	"components.insights-users-table.avgGrade": "Average Grade",
+	"components.insights-users-table.avgTimeInContent": "Average Time In Content",
+	"components.insights-users-table.avgDiscussionActivity": "Average Discussion Activity",
 	"components.insights-users-table.totalUsers": "Total Users: {num}",
 	"components.insights-engagement-dashboard.resultsReturned": "Users returned within results.",
 

--- a/model/data.js
+++ b/model/data.js
@@ -2,6 +2,7 @@ import { action, autorun, computed, decorate, observable } from 'mobx';
 import { OrgUnitSelectorFilter, RoleSelectorFilter, SemesterSelectorFilter } from './selectorFilters.js';
 import { CardFilter } from './cardFilter.js';
 import { fetchCachedChildren } from './lms.js';
+import { TABLE_USER } from '../components/users-table';
 import { Tree } from '../components/tree-filter';
 
 export const COURSE_OFFERING = 3;
@@ -171,9 +172,16 @@ export class Data {
 		// then sort by lastFirstName
 
 		return this.users
-			.map(user => [`${user[USER.LAST_NAME]}, ${user[USER.FIRST_NAME]}`])
+			.map(user => [
+				`${user[USER.LAST_NAME]}, ${user[USER.FIRST_NAME]}`, // last first name
+				// 'N/A', // last accessed system
+				'', // courses
+				'', // average grade
+				'', // average time in content
+				// 'N/A', // average discussion activity
+			])
 			.sort((user1, user2) => {
-				return user1[0].localeCompare(user2[0]);
+				return user1[TABLE_USER.LAST_FIRST_NAME].localeCompare(user2[TABLE_USER.LAST_FIRST_NAME]);
 			});
 	}
 

--- a/test/components/table.test.js
+++ b/test/components/table.test.js
@@ -4,7 +4,7 @@ import { expect, fixture, html } from '@open-wc/testing';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
 
 describe('d2l-insights-table', () => {
-	const columns = [
+	const headers = [
 		'header1',
 		'header2',
 		'header3'
@@ -25,19 +25,19 @@ describe('d2l-insights-table', () => {
 
 	describe('accessibility', () => {
 		it('should pass all axe tests', async() => {
-			const el = await fixture(html`<d2l-insights-table .columns=${columns} .data="${data}"></d2l-insights-table>`);
+			const el = await fixture(html`<d2l-insights-table .columnHeaders=${headers} .data="${data}"></d2l-insights-table>`);
 			await expect(el).to.be.accessible();
 		});
 	});
 
 	describe('render', () => {
 		it('should have correct header and data', async() => {
-			const el = await fixture(html`<d2l-insights-table .columns=${columns} .data="${data}"></d2l-insights-table>`);
+			const el = await fixture(html`<d2l-insights-table .columnHeaders=${headers} .data="${data}"></d2l-insights-table>`);
 
 			const headerCells = Array.from(el.shadowRoot.querySelectorAll('thead>tr>th'));
-			expect(headerCells.length).to.equal(columns.length);
+			expect(headerCells.length).to.equal(headers.length);
 			headerCells.forEach((cell, idx) => {
-				expect(cell.innerText).to.equal(columns[idx]);
+				expect(cell.innerText).to.equal(headers[idx]);
 			});
 
 			const rows = Array.from(el.shadowRoot.querySelectorAll('tbody>tr'));

--- a/test/components/users-table.test.js
+++ b/test/components/users-table.test.js
@@ -6,7 +6,7 @@ import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-help
 describe('d2l-insights-users-table', () => {
 	const data = {
 		// returns [ ['0First', '0Last'], ['1First', '1Last'], ..., ['22First', '22Last'] ]
-		userDataForDisplay: Array.from({ length: 23 }, (val, idx) => [`${idx}First`, `${idx}Last`])
+		userDataForDisplay: Array.from({ length: 23 }, (val, idx) => [`${idx}First`, `${idx}Last`, '', '', ''])
 	};
 
 	describe('constructor', () => {

--- a/test/model/data.test.js
+++ b/test/model/data.test.js
@@ -369,12 +369,12 @@ describe('Data', () => {
 	});
 
 	describe('userDataForDisplay', () => {
-		it('should return a sorted array of lastFirstName', async() => {
+		it('should return an array of arrays sorted by lastFirstName', async() => {
 			const expected = [
-				['Harrison, George'],
-				['Lennon, John'],
-				['McCartney, Paul'],
-				['Starr, Ringo']
+				['Harrison, George', '', '', ''],
+				['Lennon, John', '', '', ''],
+				['McCartney, Paul', '', '', ''],
+				['Starr, Ringo', '', '', '']
 			];
 
 			expect(sut.userDataForDisplay).to.deep.equal(expected);
@@ -383,8 +383,8 @@ describe('Data', () => {
 		it('should only display users in view', async() => {
 			const roleFilters = [mockRoleIds.instructor];
 			const expectedUsers = [
-				['Harrison, George'],
-				['McCartney, Paul']
+				['Harrison, George', '', '', ''],
+				['McCartney, Paul', '', '', '']
 			];
 
 			sut.selectedRoleIds = roleFilters;


### PR DESCRIPTION
Adds headers for courses, avg grade and avg time in content. Last system access and avg discussion activity will eventually exist, but are not targeted for this iteration.

Quality notes:
* Testing
  * Responsive
  * Browsers: Chrome, FF, Edgium, Legacy
  * RTL
* Security, docs, perf: N/A
* UX
  * A11y: NVDA reads out all the column names: `Column 1 Last Name, First Name | Column 2 Courses | Column 3 Average Grade | Column 4 Average Time in Content`

Screenshot
![image](https://user-images.githubusercontent.com/11587338/94936734-a4ba1580-049c-11eb-9bad-346bebcaa63b.png)

 @johngwilkinson @Vitalii-Misechko @anhill-D2L @hyehayes 