### PR TITLE
US120279 Users table name column

### DIFF
--- a/components/table.js
+++ b/components/table.js
@@ -127,16 +127,6 @@ class Table extends SkeletonMixin(Localizer(RtlMixin(LitElement))) {
 			:host([dir="rtl"]) .d2l-insights-table-table .d2l-insights-table-row-last > .d2l-insights-table-cell-last {
 				border-bottom-left-radius: 8px;
 			}
-
-			:host([skeleton]) .d2l-insights-table-cell > div {
-				width: 45%;
-			}
-
-			@media (max-width: 1024px) {
-				:host([skeleton]) .d2l-insights-table-cell > div {
-					width: 100%;
-				}
-			}
 		`];
 	}
 
@@ -163,6 +153,8 @@ class Table extends SkeletonMixin(Localizer(RtlMixin(LitElement))) {
 	_renderThead() {
 		const styles = {
 			'd2l-insights-table-row-first': true,
+			// if skeleton view is displayed, then there will definitely be skeleton rows in the table,
+			// even if data.length is 0. Therefore if skeleton is true, don't apply the "last row" style to header
 			'd2l-insights-table-row-last': !this.skeleton && this.data.length === 0
 		};
 
@@ -217,18 +209,22 @@ class Table extends SkeletonMixin(Localizer(RtlMixin(LitElement))) {
 			</td>
 		`;
 
-		if (!this.skeleton) {
-			if (columnType === COLUMN_TYPES.TEXT_SUB_TEXT) {
-				return html`
-					<td class="${classMap(styles)}">
-						<div class="d2l-body-standard">${value[0]}</div>
-						<div class="d2l-body-small">${value[1]}</div>
-					</td>
-				`;
-			} // future work: else if COLUMN_TYPES.SUBCOLUMNS...
+		if (this.skeleton) {
+			return defaultHtml; // regardless of the column type, because the data hasn't been loaded yet
 		}
 
-		return defaultHtml;
+		if (columnType === COLUMN_TYPES.TEXT_SUB_TEXT) {
+			return html`
+				<td class="${classMap(styles)}">
+					<div class="d2l-body-standard">${value[0]}</div>
+					<div class="d2l-body-small">${value[1]}</div>
+				</td>
+			`;
+		} else if (columnType === COLUMN_TYPES.NORMAL_TEXT) {
+			return defaultHtml;
+		} // future work: else if COLUMN_TYPES.SUBCOLUMNS...
+
+		throw new Error('Users table: unknown column type');
 	}
 }
 customElements.define('d2l-insights-table', Table);

--- a/components/users-table.js
+++ b/components/users-table.js
@@ -74,6 +74,8 @@ class UsersTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 		return itemsCount ? Math.ceil(itemsCount / this._pageSize) : 0;
 	}
 
+	// don't use displayData.length to get the itemsCount. When we display a skeleton view, displayData.length is
+	// the number of skeleton rows we're displaying, but the Total Users count should still be 0
 	get _displayData() {
 		if (this.skeleton) {
 			const loadingPlaceholderText = this.localize('components.insights-users-table.loadingPlaceholder');

--- a/components/users-table.js
+++ b/components/users-table.js
@@ -76,10 +76,10 @@ class UsersTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 
 	get _displayData() {
 		if (this.skeleton) {
+			const loadingPlaceholderText = this.localize('components.insights-users-table.loadingPlaceholder');
+
 			// a DEFAULT_PAGE_SIZE x columnInfoLength 2D array filled with a generic string
-			// the text does not matter here, as long as it's not an empty string.
-			// (an empty string leads to an empty div which in turn does not render skeleton rectangle)
-			return Array(DEFAULT_PAGE_SIZE).fill(Array(this.columnInfo.length).fill('Loading'));
+			return Array(DEFAULT_PAGE_SIZE).fill(Array(this.columnInfo.length).fill(loadingPlaceholderText));
 		}
 
 		if (this._itemsCount) {

--- a/components/users-table.js
+++ b/components/users-table.js
@@ -3,18 +3,19 @@ import '@brightspace-ui-labs/pagination/pagination';
 import './table.js';
 
 import { css, html } from 'lit-element';
+import { COLUMN_TYPES } from './table';
 import { Localizer } from '../locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
-import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin';
 
 export const TABLE_USER = {
-	LAST_FIRST_NAME: 0,
-	// LAST_ACCESSED_SYSTEM: 1,
+	NAME_INFO: 0,
 	COURSES: 1,
 	AVG_GRADE: 2,
 	AVG_TIME_IN_CONTENT: 3
-	// AVG_DISCUSSION_ACTIVITY: 4
 };
+
+const DEFAULT_PAGE_SIZE = 20;
 
 /**
  * At the moment the mobx data object is doing sorting / filtering logic
@@ -61,41 +62,29 @@ class UsersTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 			userDataForDisplay: []
 		};
 		this._currentPage = 1;
-		this._pageSize = 20;
-		// must have the same number of columns as this.data.userDataForDisplay to display skeleton correctly
-		this._loadingData = [...Array(5).keys()].map(() => this._getColumnsDataWhenLoading({ numberOfColumns: 4 }));
-	}
-
-	_getColumnsDataWhenLoading({ numberOfColumns }) {
-		// the text does not matter here. The empty text leads to empty div which in turn does not render skeleton rectangle
-		return [...Array(numberOfColumns).keys()].map(() => 'Loading');
+		this._pageSize = DEFAULT_PAGE_SIZE;
 	}
 
 	get _itemsCount() {
-		if (this.skeleton) {
-			return this._loadingData.length;
-		}
-
 		return this.data.userDataForDisplay.length;
 	}
 
 	get _maxPages() {
-		if (this.skeleton) {
-			return 0;
-		}
-
 		const itemsCount = this._itemsCount;
 		return itemsCount ? Math.ceil(itemsCount / this._pageSize) : 0;
 	}
 
 	get _displayData() {
 		if (this.skeleton) {
-			return this._loadingData;
+			// a DEFAULT_PAGE_SIZE x columnInfoLength 2D array filled with a generic string
+			// the text does not matter here, as long as it's not an empty string.
+			// (an empty string leads to an empty div which in turn does not render skeleton rectangle)
+			return Array(DEFAULT_PAGE_SIZE).fill(Array(this.columnInfo.length).fill('Loading'));
 		}
 
 		if (this._itemsCount) {
 			const start = this._pageSize * (this._currentPage - 1);
-			const end = this._pageSize * (this._currentPage); // it's ok if this is larger than the size of the array
+			const end = this._pageSize * (this._currentPage); // it's ok if this goes over the end of the array
 
 			return this.data.userDataForDisplay.slice(start, end);
 		}
@@ -103,24 +92,34 @@ class UsersTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 		return [];
 	}
 
-	get columnHeaders() {
+	get columnInfo() {
 		return [
-			this.localize('components.insights-users-table.lastFirstName'),
-			// this.localize('components.insights-users-table.lastAccessedSystem'),
-			this.localize('components.insights-users-table.courses'),
-			this.localize('components.insights-users-table.avgGrade'),
-			this.localize('components.insights-users-table.avgTimeInContent')
-			// this.localize('components.insights-users-table.avgDiscussionActivity')
+			{
+				headerText: this.localize('components.insights-users-table.lastFirstName'),
+				columnType: COLUMN_TYPES.TEXT_SUB_TEXT
+			},
+			{
+				headerText: this.localize('components.insights-users-table.courses'),
+				columnType: COLUMN_TYPES.NORMAL_TEXT
+			},
+			{
+				headerText: this.localize('components.insights-users-table.avgGrade'),
+				columnType: COLUMN_TYPES.NORMAL_TEXT
+			},
+			{
+				headerText: this.localize('components.insights-users-table.avgTimeInContent'),
+				columnType: COLUMN_TYPES.NORMAL_TEXT
+			}
 		];
 	}
 
 	render() {
 		return html`
 			<d2l-insights-table
-				?skeleton="${this.skeleton}"
 				title="${this.localize('components.insights-users-table.title')}"
-				.columnHeaders=${this.columnHeaders}
-				.data="${this._displayData}"></d2l-insights-table>
+				.columnInfo=${this.columnInfo}
+				.data="${this._displayData}"
+				?skeleton="${this.skeleton}"></d2l-insights-table>
 
 			<d2l-labs-pagination
 				show-item-count-select

--- a/locales/en.js
+++ b/locales/en.js
@@ -36,7 +36,7 @@ export default {
 	"components.insights-users-table.loadingPlaceholder": "Loading",
 	"components.insights-users-table.lastFirstName": "Name",
 	"components.insights-users-table.lastAccessedSystem": "Last Accessed System",
-	"components.insights-users-table.courses": "Course(s)",
+	"components.insights-users-table.courses": "Courses",
 	"components.insights-users-table.avgGrade": "Average Grade",
 	"components.insights-users-table.avgTimeInContent": "Average Time in Content (mins)",
 	"components.insights-users-table.avgDiscussionActivity": "Average Discussion Activity",

--- a/locales/en.js
+++ b/locales/en.js
@@ -33,6 +33,7 @@ export default {
 	"components.dropdown-filter.opener-text-single": '{filterName}: {selectedItemName}',
 
 	"components.insights-users-table.title": "User Details",
+	"components.insights-users-table.loadingPlaceholder": "Loading",
 	"components.insights-users-table.lastFirstName": "Name",
 	"components.insights-users-table.lastAccessedSystem": "Last Accessed System",
 	"components.insights-users-table.courses": "Course(s)",

--- a/model/data.js
+++ b/model/data.js
@@ -20,7 +20,8 @@ export const RECORD = {
 export const USER = {
 	ID: 0,
 	FIRST_NAME: 1,
-	LAST_NAME: 2
+	LAST_NAME: 2,
+	USERNAME: 3
 };
 
 function unique(array) {
@@ -170,22 +171,19 @@ export class Data {
 
 	// @computed
 	get userDataForDisplay() {
-		// map to a 2D userData array, with column 0 as the lastFirstName
+		// map to a 2D userData array, with column 0 as a sub-array of [lastFirstName, username - id]
 		// then sort by lastFirstName
 
 		return this.users
 			.map(user => [
-				// When add/remove column here DO NOT forget to update `user-table._lodaingData` to show skeleton properly
-
-				`${user[USER.LAST_NAME]}, ${user[USER.FIRST_NAME]}`, // last first name
-				// 'N/A', // last accessed system
+				[`${user[USER.LAST_NAME]}, ${user[USER.FIRST_NAME]}`, `${user[USER.USERNAME]} - ${user[USER.ID]}`],
 				'', // courses
 				'', // average grade
 				'', // average time in content
-				// 'N/A', // average discussion activity
 			])
 			.sort((user1, user2) => {
-				return user1[TABLE_USER.LAST_FIRST_NAME].localeCompare(user2[TABLE_USER.LAST_FIRST_NAME]);
+				// sort by lastFirstName
+				return user1[TABLE_USER.NAME_INFO][0].localeCompare(user2[TABLE_USER.NAME_INFO][0]);
 			});
 	}
 

--- a/model/fake-lms.js
+++ b/model/fake-lms.js
@@ -36,17 +36,17 @@ export async function fetchData({ roleIds, semesterIds, orgUnitIds, defaultView 
 			[6606, 'Dev', 1, [0]]
 		],
 		users: [ // some of which are out of order
-			[100,  'ATest', 'AStudent'],
-			[300,  'CTest', 'CStudent'],
-			[200,  'BTest', 'BStudent'],
-			[400,  'DTest', 'DStudent'],
-			[500,  'ETest', 'EStudent'],
-			[600,  'GTest', 'GStudent'],
-			[700,  'FTest', 'FStudent'],
-			[800,  'HTest', 'HStudent'],
-			[900,  'ITest', 'IStudent'],
-			[1000, 'KTest', 'KStudent'],
-			[1100, 'JTest', 'JStudent']
+			[100,  'ATest', 'AStudent', 'AStudent'],
+			[300,  'CTest', 'CStudent', 'CStudent'],
+			[200,  'BTest', 'BStudent', 'BStudent'],
+			[400,  'DTest', 'DStudent', 'DStudent'],
+			[500,  'ETest', 'EStudent', 'EStudent'],
+			[600,  'GTest', 'GStudent', 'GStudent'],
+			[700,  'FTest', 'FStudent', 'FStudent'],
+			[800,  'HTest', 'HStudent', 'HStudent'],
+			[900,  'ITest', 'IStudent', 'IStudent'],
+			[1000, 'KTest', 'KStudent', 'KStudent'],
+			[1100, 'JTest', 'JStudent', 'JStudent']
 		],
 		semesterTypeId: 25,
 		selectedSemestersIds: semesterIds,

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "d2l-facet-filter-sort": "BrightspaceUI/facet-filter-sort#semver:^3",
     "highcharts": "^8.1.2",
     "lit-element": "^2",
+    "lit-html": "^1.3.0",
     "mobx": "^5.15.4"
   }
 }

--- a/test/components/course-last-access-card.test.js
+++ b/test/components/course-last-access-card.test.js
@@ -15,7 +15,9 @@ describe('d2l-insights-course-last-access-card', () => {
 	});
 
 	describe('accessibility', () => {
-		it('should pass all axe tests', async() => {
+		it('should pass all axe tests', async function() {
+			this.timeout(3000);
+
 			const el = await fixture(html`<d2l-insights-course-last-access-card .data="${data}"></d2l-insights-course-last-access-card>`);
 			await expect(el).to.be.accessible();
 		});

--- a/test/components/results-card.test.js
+++ b/test/components/results-card.test.js
@@ -3,7 +3,7 @@ import '../../components/users-table.js';
 import { expect, fixture, html } from '@open-wc/testing';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
 
-describe('d2l-insights-users-table', () => {
+describe('d2l-insights-results-card', () => {
 	const data = {
 		userDataForDisplay: [
 			'Lennon, John',

--- a/test/components/table.test.js
+++ b/test/components/table.test.js
@@ -1,21 +1,32 @@
 import '../../components/table.js';
 
 import { expect, fixture, html } from '@open-wc/testing';
+import { COLUMN_TYPES } from '../../components/table';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
 
-describe('d2l-insights-table', () => {
-	const headers = [
-		'header1',
-		'header2',
-		'header3'
-	];
+const columnInfo = [
+	{
+		headerText: 'header1',
+		columnType: COLUMN_TYPES.NORMAL_TEXT
+	},
+	{
+		headerText: 'header2',
+		columnType: COLUMN_TYPES.NORMAL_TEXT
+	},
+	{
+		headerText: 'header3',
+		columnType: COLUMN_TYPES.TEXT_SUB_TEXT
+	}
+];
 
-	const data = [
-		['First Item', 1, 'value1'],
-		['Second Item', 2, 'value2'],
-		['Third Item', 3, 'value3'],
-		['Fourth Item', 4, 'value4']
-	];
+const data = [
+	['First Item', 1, ['text1', 'subtext1']],
+	['Second Item', 2, ['text2', 'subtext2']],
+	['Third Item', 3, ['text3', 'subtext3']],
+	['Fourth Item', 4, ['text4', 'subtext4']]
+];
+
+describe('d2l-insights-table', () => {
 
 	describe('constructor', () => {
 		it('should construct', () => {
@@ -25,32 +36,47 @@ describe('d2l-insights-table', () => {
 
 	describe('accessibility', () => {
 		it('should pass all axe tests', async() => {
-			const el = await fixture(html`<d2l-insights-table .columnHeaders=${headers} .data="${data}"></d2l-insights-table>`);
+			const el = await fixture(html`<d2l-insights-table .columnInfo=${columnInfo} .data="${data}"></d2l-insights-table>`);
 			await expect(el).to.be.accessible();
 		});
 	});
 
 	describe('render', () => {
 		it('should have correct header and data', async() => {
-			const el = await fixture(html`<d2l-insights-table .columnHeaders=${headers} .data="${data}"></d2l-insights-table>`);
+			const el = await fixture(html`<d2l-insights-table .columnInfo=${columnInfo} .data="${data}"></d2l-insights-table>`);
 
 			const headerCells = Array.from(el.shadowRoot.querySelectorAll('thead>tr>th'));
-			expect(headerCells.length).to.equal(headers.length);
+			expect(headerCells.length).to.equal(columnInfo.length);
 			headerCells.forEach((cell, idx) => {
-				expect(cell.innerText).to.equal(headers[idx]);
+				expect(cell.innerText).to.equal(columnInfo[idx].headerText);
 			});
 
 			const rows = Array.from(el.shadowRoot.querySelectorAll('tbody>tr'));
 			expect(rows.length).to.equal(4);
 
-			rows.forEach((row, idx) => {
-				const cells = Array.from(row.querySelectorAll('td>div'));
+			rows.forEach((row, rowIdx) => {
+				const cells = Array.from(row.querySelectorAll('td'));
 				expect(cells.length).to.equal(3);
 
-				cells.forEach((cell, jdx) => {
-					expect(cell.innerText).to.equal(data[idx][jdx].toString());
+				cells.forEach((cell, colIdx) => {
+					verifyCellData(cell, rowIdx, colIdx);
 				});
 			});
 		});
 	});
 });
+
+function verifyCellData(cell, rowIdx, colIdx) {
+	const columnType = columnInfo[colIdx].columnType;
+
+	if (columnType === COLUMN_TYPES.NORMAL_TEXT) {
+		const innerDiv = cell.querySelector('div');
+		expect(innerDiv.innerText).to.equal(data[rowIdx][colIdx].toString());
+
+	} else if (columnType === COLUMN_TYPES.TEXT_SUB_TEXT) {
+		const mainTextDiv = cell.querySelector('div:first-child');
+		const subTextDiv = cell.querySelector('div:last-child');
+		expect(mainTextDiv.innerText).to.equal(data[rowIdx][colIdx][0].toString());
+		expect(subTextDiv.innerText).to.equal(data[rowIdx][colIdx][1].toString());
+	}
+}

--- a/test/model/data.test.js
+++ b/test/model/data.test.js
@@ -99,10 +99,10 @@ describe('Data', () => {
 			[6606, 400, mockRoleIds.student, 0, null, 0, null], // this user has a cascading admin role on dept and sem levels
 		],
 		users: [
-			[100, 'John', 'Lennon'],
-			[200, 'Paul', 'McCartney'],
-			[300, 'George', 'Harrison'],
-			[400, 'Ringo', 'Starr']
+			[100, 'John', 'Lennon', 'jlennon'],
+			[200, 'Paul', 'McCartney', 'pmccartney'],
+			[300, 'George', 'Harrison', 'gharrison'],
+			[400, 'Ringo', 'Starr', 'rstarr']
 		],
 		selectedRolesIds: null,
 		selectedSemestersIds: null,
@@ -371,10 +371,10 @@ describe('Data', () => {
 	describe('userDataForDisplay', () => {
 		it('should return an array of arrays sorted by lastFirstName', async() => {
 			const expected = [
-				['Harrison, George', '', '', ''],
-				['Lennon, John', '', '', ''],
-				['McCartney, Paul', '', '', ''],
-				['Starr, Ringo', '', '', '']
+				[['Harrison, George', 'gharrison - 300'], '', '', ''],
+				[['Lennon, John', 'jlennon - 100'], '', '', ''],
+				[['McCartney, Paul', 'pmccartney - 200'], '', '', ''],
+				[['Starr, Ringo', 'rstarr - 400'], '', '', '']
 			];
 
 			expect(sut.userDataForDisplay).to.deep.equal(expected);
@@ -383,8 +383,8 @@ describe('Data', () => {
 		it('should only display users in view', async() => {
 			const roleFilters = [mockRoleIds.instructor];
 			const expectedUsers = [
-				['Harrison, George', '', '', ''],
-				['McCartney, Paul', '', '', '']
+				[['Harrison, George', 'gharrison - 300'], '', '', ''],
+				[['McCartney, Paul', 'pmccartney - 200'], '', '', '']
 			];
 
 			sut.selectedRoleIds = roleFilters;


### PR DESCRIPTION
Adds additional info to the name column in the users table.

Quality notes
* Testing
  * Responsiveness - the table as a whole is wonky (and should be fixed along with the wonky cards) but this column in particular is good: the text resizes
  * Browsers: Chrome, FF, Edgium, Legacy
* Security, perf, docs: N/A
* UX
  * Checked with Kevin on text sizes (main text is d2l-body-standard, subtext is d2l-body-small)
  * Checked with Megan that if a username is blank, it can appear as blank in the table (consistent with Class Engagement page)
  * works in RTL
  * a11y: still needs work. I need to ask Kevin what a screen reader user should hear for the column and the table during loading

Screenshots - Loaded
![image](https://user-images.githubusercontent.com/11587338/95128813-f924f580-0727-11eb-85cd-7daf432190cc.png)

Loading: medium size screen
![image](https://user-images.githubusercontent.com/11587338/95147846-e45c5800-074f-11eb-83ce-f01499d0fcf1.png)

Loading: full size screen
![image](https://user-images.githubusercontent.com/11587338/95206972-5450f980-07b5-11eb-88cb-58306d57bc7b.png)

@anhill-D2L @johngwilkinson @MykolaGalian 