### PR TITLE
Access interaction fix

### DIFF
--- a/components/course-last-access-card.js
+++ b/components/course-last-access-card.js
@@ -198,8 +198,8 @@ class CourseLastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 					if (this.point.y === 1) {
 						return `${that._cardTooltipTextSingleUser[this.point.x]}`;
 					}
-					if (this.point.x !== 6) { 
-					return `${that._cardTooltipText(this.point.y)[this.point.x]}`;
+					if (this.point.x !== 6) {
+						return `${that._cardTooltipText(this.point.y)[this.point.x]}`;
 					} else return false;
 				},
 				backgroundColor: 'var(--d2l-color-ferrite)',

--- a/components/course-last-access-card.js
+++ b/components/course-last-access-card.js
@@ -186,6 +186,9 @@ class CourseLastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 							that._colorAllPoints(this.series[0].data, 'var(--d2l-color-celestine)');
 						}
 						this.render(false);
+					},
+					load: function() {
+						this.series[0].data[6].graphic.hide();
 					}
 				}
 			},
@@ -195,7 +198,9 @@ class CourseLastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 					if (this.point.y === 1) {
 						return `${that._cardTooltipTextSingleUser[this.point.x]}`;
 					}
+					if (this.point.x !== 6) { 
 					return `${that._cardTooltipText(this.point.y)[this.point.x]}`;
+					} else return false;
 				},
 				backgroundColor: 'var(--d2l-color-ferrite)',
 				borderColor: 'var(--d2l-color-ferrite)',
@@ -230,7 +235,8 @@ class CourseLastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 					}
 				},
 				width: '108%',
-				categories: this._cardCategoriesText
+				categories: this._cardCategoriesText,
+				showLastLabel: false
 			},
 			yAxis: {
 				tickAmount: 5,

--- a/model/data.js
+++ b/model/data.js
@@ -220,7 +220,7 @@ export class Data {
 
 	get courseLastAccessDates() {
 		// return an array of size 6, each element mapping to a category on the course last access bar chart
-		const dateBucketCounts = [0, 0, 0, 0, 0, 0];
+		const dateBucketCounts = [0, 0, 0, 0, 0, 0, 0];
 		const lastAccessDatesArray = this.getRecordsInView(CourseLastAccessFilterId).map(record => [record[RECORD.COURSE_LAST_ACCESS] === null ? -1 : (Date.now() - record[RECORD.COURSE_LAST_ACCESS])]);
 		lastAccessDatesArray.forEach(record => dateBucketCounts[ this._bucketCourseLastAccessDates(record) ]++);
 		return dateBucketCounts;

--- a/test/model/data.test.js
+++ b/test/model/data.test.js
@@ -419,7 +419,7 @@ describe('Data', () => {
 
 	describe('courseLastAccess', () => {
 		it('should return the correct current final grade bucket counts', async() => {
-			const expected = [39, 7, 0, 0, 1, 1];
+			const expected = [39, 7, 0, 0, 1, 1, 0];
 			expect(sut.courseLastAccessDates.toString()).to.deep.equal(expected.toString());
 		});
 	});


### PR DESCRIPTION
Issue:
 For the "Course Access" card if I add in a `select` event for a point the `_valueClickHandler()` method, which sets `isApplied = true` for the card filter, we have a problem with that event. The `select` event for the last bar ("< 1 day ago") becomes callable  only in some cases:
1)  If I select the last bar first, before selecting other bars;
2) If the mouse goes outside the plot and then again clicking on this bar. 

If I add one more last bar, then I have the same problems with it. This problem still exists even if I disable all other events and logic (for example, color painting points process). Looks like some kind of conflict with mobx. Because If I remove the observable decorator from `isApplied` in `CardFilter` class,  the `select`event for the last bar start to works.

The proposed solution is to add another last bar and hidе it. But at the same time, the Y-axis is slightly lengthened.

![2](https://user-images.githubusercontent.com/27500223/95189572-b79f5380-07d6-11eb-9640-9a67ddb6dd35.png)

Kevin approve that for now (temporary)

@anhill-D2L @bemailloux @rohitvinnakota @hyehayes