### PR TITLE
Remove circular dependencies

### DIFF
--- a/components/course-last-access-card.js
+++ b/components/course-last-access-card.js
@@ -3,7 +3,7 @@ import { BEFORE_CHART_FORMAT } from './chart/chart';
 import { bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { Localizer } from '../locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
-import { RECORD } from '../model/data';
+import { RECORD } from '../consts';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
 export const CourseLastAccessCardFilter  = {

--- a/components/current-final-grade-card.js
+++ b/components/current-final-grade-card.js
@@ -3,7 +3,7 @@ import { BEFORE_CHART_FORMAT } from './chart/chart';
 import { bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { Localizer } from '../locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
-import { RECORD } from '../model/data';
+import { RECORD } from '../consts';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
 export const CurrentFinalGradeCardFilter  = {

--- a/components/overdue-assignments-card.js
+++ b/components/overdue-assignments-card.js
@@ -1,8 +1,7 @@
-
 import { html } from 'lit-element';
 import { Localizer } from '../locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
-import { RECORD } from '../model/data.js';
+import { RECORD } from '../consts';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
 export const OverdueAssignmentsCardFilter = {

--- a/components/time-in-content-vs-grade-card.js
+++ b/components/time-in-content-vs-grade-card.js
@@ -4,7 +4,7 @@ import { BEFORE_CHART_FORMAT } from './chart/chart';
 import { bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { Localizer } from '../locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
-import { RECORD } from '../model/data';
+import { RECORD } from '../consts';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
 export const TimeInContentVsGradeCardFilter  = {

--- a/consts.js
+++ b/consts.js
@@ -1,0 +1,17 @@
+export const COURSE_OFFERING = 3;
+
+export const RECORD = {
+	ORG_UNIT_ID: 0,
+	USER_ID: 1,
+	ROLE_ID: 2,
+	OVERDUE: 3,
+	CURRENT_FINAL_GRADE: 4,
+	TIME_IN_CONTENT: 5,
+	COURSE_LAST_ACCESS: 6
+};
+export const USER = {
+	ID: 0,
+	FIRST_NAME: 1,
+	LAST_NAME: 2,
+	USERNAME: 3
+};

--- a/model/data.js
+++ b/model/data.js
@@ -1,28 +1,10 @@
 import { action, autorun, computed, decorate, observable } from 'mobx';
+import { COURSE_OFFERING, RECORD, USER } from '../consts';
 import { OrgUnitSelectorFilter, RoleSelectorFilter, SemesterSelectorFilter } from './selectorFilters.js';
 import { CardFilter } from './cardFilter.js';
 import { fetchCachedChildren } from './lms.js';
 import { TABLE_USER } from '../components/users-table';
 import { Tree } from '../components/tree-filter';
-
-export const COURSE_OFFERING = 3;
-
-export const RECORD = {
-	ORG_UNIT_ID: 0,
-	USER_ID: 1,
-	ROLE_ID: 2,
-	OVERDUE: 3,
-	CURRENT_FINAL_GRADE: 4,
-	TIME_IN_CONTENT: 5,
-	COURSE_LAST_ACCESS: 6
-};
-
-export const USER = {
-	ID: 0,
-	FIRST_NAME: 1,
-	LAST_NAME: 2,
-	USERNAME: 3
-};
 
 function unique(array) {
 	return [...new Set(array)];

--- a/model/selectorFilters.js
+++ b/model/selectorFilters.js
@@ -1,5 +1,5 @@
 import { computed, decorate, observable } from 'mobx';
-import { RECORD } from './data';
+import { RECORD } from '../consts';
 
 function hasSelections(selectedIds) {
 	return selectedIds.length > 0;

--- a/test/components/applied-filters.test.js
+++ b/test/components/applied-filters.test.js
@@ -18,20 +18,23 @@ describe('d2l-insights-applied-filters', () => {
 	});
 
 	describe('accessibility', () => {
-		it('should pass all axe tests', async() => {
+		it('should pass all axe tests', async function() {
+			this.timeout(3000);
 			const el = await fixture(html`<d2l-insights-applied-filters .data="${data}"></d2l-insights-applied-filters>`);
 			await expect(el).to.be.accessible();
 		});
 	});
 
 	describe('render', () => {
-		it('should not render if there are no card filters', async() => {
+		it('should not render if there are no card filters', async function() {
+			this.timeout(3000);
 			const el = await fixture(html`<d2l-insights-applied-filters .data="${data}"></d2l-insights-applied-filters>`);
 			const appliedFilters = el.shadowRoot.querySelector('d2l-applied-filters');
 			expect(appliedFilters).to.be.null;
 		});
 
-		it('should not render if card filters are not applied', async() => {
+		it('should not render if card filters are not applied', async function() {
+			this.timeout(3000);
 			data.cardFilters = {
 				'filter-key-1':	{ id: '1', title: 'filter 1', isApplied: false }
 			};


### PR DESCRIPTION
@dlockhart informed me there are some circular dependencies in our repo:
```
..\insights-engagement-dashboard\model\data.js -> ..\insights-engagement-dashboard\model\selectorFilters.js -> ..\insights-engagement-dashboard\model\data.js
```

In general we want to avoid circular dependencies wherever possible, as they can lead to difficult-to-reproduce bugs if files get loaded in the wrong order.

Solution: put all consts that are used in multiple places in a separate dependency-less file.

Quality notes
* Testing
  * Unit tests pass
  * Playing around with the dashboard (including interactions) still works
  * Running `npm run build` in BSI no longer reports this warning
* Security, perf, UX: N/A
* Docs: maybe I should write some? I dunno

@MykolaGalian @Vitalii-Misechko @anhill-D2L 