### PR TITLE
Access interaction fix

### DIFF
--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -58,6 +58,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				}
 
 				.d2l-insights-summary-container-applied-filters {
+					height: 30px;
 					width: 100%;
 				}
 

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -58,8 +58,8 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				}
 
 				.d2l-insights-summary-container-applied-filters {
+					height: auto;
 					min-height: 30px;
-  					height: auto;
 					width: 100%;
 				}
 

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -58,7 +58,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				}
 
 				.d2l-insights-summary-container-applied-filters {
-					height: 30px;
+					height: 80px;
 					width: 100%;
 				}
 

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -58,7 +58,8 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				}
 
 				.d2l-insights-summary-container-applied-filters {
-					height: 80px;
+					min-height: 30px;
+  					height: auto;
 					width: 100%;
 				}
 


### PR DESCRIPTION
Issue: When some bar is selected in "Course Access" card for the first time, the filter button is drawn using "d2l-applied-filters". After that, I cannot select the last bar on this card. It can be selected only if the mouse goes outside the plot and then again clicking on this bar.   
The proposed solution is fix CSS for parent div container .d2l-insights-summary-container-applied-filters (https://stackoverflow.com/a/19221684/14336208).
However, due to the reservation of the minimum space for the container, the indent has increased.

UX: I showed it on demo after stand-up.

![77](https://user-images.githubusercontent.com/27500223/95444018-fb749300-0965-11eb-8dc6-c5bc2ed865b8.png)

![5](https://user-images.githubusercontent.com/27500223/95439731-af731f80-0960-11eb-9a40-d3107a7c0a62.gif)


Previous PR: https://github.com/Brightspace/insights-engagement-dashboard/pull/72

Next story for that defect: https://rally1.rallydev.com/#/23525809118d/iterationstatus?detail=%2Fdefect%2F440857153012&sharedViewId=328666453148

@anhill-D2L @bemailloux @rohitvinnakota @hyehayes

