### PR TITLE
US120515, US120514: add avg tic and grade to users table

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@adobe/lit-mobx": "0.0.x",
     "@brightspace-ui-labs/pagination": "^0.0.8",
     "@brightspace-ui/core": "^1.83.1",
+    "@brightspace-ui/intl": "^3.0.11",
     "@webcomponents/webcomponentsjs": "^2",
     "array-flat-polyfill": "^1.0.1",
     "d2l-facet-filter-sort": "BrightspaceUI/facet-filter-sort#semver:^3",

--- a/test/components/users-table.test.js
+++ b/test/components/users-table.test.js
@@ -5,14 +5,19 @@ import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-help
 
 const data = {
 	// returns [
-	//   [['0Last, 0First', 'user0 - 0'], '', '', ''],
-	//   [['1Last, 1First', 'user1 - 1'], '', '', ''],
+	//   [['0Last, 0First', 'user0 - 0'], ...],
+	//   [['1Last, 1First', 'user1 - 1'], ...],
 	//   ...,
-	//   [['22Last, 22First', 'user22 - 22'], '', '', ''],
+	//   [['22Last, 22First', 'user22 - 22'], ...],
 	// ]
 	userDataForDisplay: Array.from(
 		{ length: 23 },
-		(val, idx) => [[`${idx}Last, ${idx}First`, `user${idx} - ${idx}`], Math.floor(Math.random() * 10), '', '']
+		(val, idx) => [
+			[`${idx}Last, ${idx}First`, `user${idx} - ${idx}`],
+			Math.floor(Math.random() * 10),
+			`${(Math.random() * 100).toFixed(1) } %`,
+			(Math.random() * 20).toFixed(2)
+		]
 	)
 };
 
@@ -78,8 +83,7 @@ describe('d2l-insights-users-table', () => {
 				expect(pageSelector.pageNumber).to.equal(1);
 
 				// since there are 23 users, the first (default) page should show the first 20 users, in order, on it
-				verifyUserInfoColumn(innerTable, 20, 0);
-				verifyCourseCountColumn(innerTable, 20, 0);
+				verifyColumns(innerTable, 20, 0);
 			});
 
 			it('should show the correct number of users on the last page', async() => {
@@ -91,8 +95,7 @@ describe('d2l-insights-users-table', () => {
 
 				expect(pageSelector.pageNumber).to.equal(2);
 
-				verifyUserInfoColumn(innerTable, 3, 20);
-				verifyCourseCountColumn(innerTable, 3, 20);
+				verifyColumns(innerTable, 3, 20);
 			});
 
 			it('should change number of users shown and total number of pages if the page size changes', async() => {
@@ -104,8 +107,7 @@ describe('d2l-insights-users-table', () => {
 				expect(pageSelector.maxPageNumber).to.equal(3);
 				expect(pageSelector.pageNumber).to.equal(1);
 
-				verifyUserInfoColumn(innerTable, 10, 0);
-				verifyCourseCountColumn(innerTable, 10, 0);
+				verifyColumns(innerTable, 10, 0);
 
 				pageSelector
 					.shadowRoot.querySelector('d2l-button-icon[text="Next page"]')
@@ -115,8 +117,7 @@ describe('d2l-insights-users-table', () => {
 
 				expect(pageSelector.pageNumber).to.equal(2);
 
-				verifyUserInfoColumn(innerTable, 10, 10);
-				verifyCourseCountColumn(innerTable, 10, 10);
+				verifyColumns(innerTable, 10, 10);
 
 				pageSelector
 					.shadowRoot.querySelector('d2l-button-icon[text="Next page"]')
@@ -126,8 +127,7 @@ describe('d2l-insights-users-table', () => {
 
 				expect(pageSelector.pageNumber).to.equal(3);
 
-				verifyUserInfoColumn(innerTable, 3, 20);
-				verifyCourseCountColumn(innerTable, 3, 20);
+				verifyColumns(innerTable, 3, 20);
 			});
 
 			it('should show all users on a single page if there are fewer users than the page size', async() => {
@@ -139,8 +139,7 @@ describe('d2l-insights-users-table', () => {
 				expect(pageSelector.maxPageNumber).to.equal(1);
 				expect(pageSelector.pageNumber).to.equal(1);
 
-				verifyUserInfoColumn(innerTable, 23, 0);
-				verifyCourseCountColumn(innerTable, 23, 0);
+				verifyColumns(innerTable, 23, 0);
 			});
 
 			it('should show zero pages if there are no users to display', async() => {
@@ -151,8 +150,7 @@ describe('d2l-insights-users-table', () => {
 				expect(pageSelector.maxPageNumber).to.equal(0);
 				expect(pageSelector.pageNumber).to.equal(0);
 
-				verifyUserInfoColumn(innerTable, 0, 0);
-				verifyCourseCountColumn(innerTable, 0, 0);
+				verifyColumns(innerTable, 0, 0);
 			});
 
 			it('should show 20 skeleton rows with zero pages if loading', async() => {
@@ -171,8 +169,8 @@ describe('d2l-insights-users-table', () => {
 	});
 });
 
-function verifyUserInfoColumn(table, expectedNumDisplayedRows, startRowNum) {
-	const displayedUserInfo = Array.from(table.shadowRoot.querySelectorAll('tbody > tr > td:first-child'));
+function verifyColumns(table, expectedNumDisplayedRows, startRowNum) {
+	let displayedUserInfo = Array.from(table.shadowRoot.querySelectorAll('tbody > tr > td:first-child'));
 	expect(displayedUserInfo.length).to.equal(expectedNumDisplayedRows);
 	displayedUserInfo.forEach((cell, rowIdx) => {
 		const mainText = cell.querySelector('div:first-child');
@@ -180,13 +178,14 @@ function verifyUserInfoColumn(table, expectedNumDisplayedRows, startRowNum) {
 		expect(mainText.innerText).to.equal(data.userDataForDisplay[rowIdx + startRowNum][0][0]);
 		expect(subText.innerText).to.equal(data.userDataForDisplay[rowIdx + startRowNum][0][1]);
 	});
-}
 
-function verifyCourseCountColumn(table, expectedNumDisplayedRows, startRowNum) {
-	const displayedUserInfo = Array.from(table.shadowRoot.querySelectorAll('tbody > tr > td:nth-child(2)'));
-	expect(displayedUserInfo.length).to.equal(expectedNumDisplayedRows);
-	displayedUserInfo.forEach((cell, rowIdx) => {
-		const mainText = cell.querySelector('div');
-		expect(mainText.innerText).to.equal(data.userDataForDisplay[rowIdx + startRowNum][1].toString());
+	[2, 3, 4].forEach(child => {
+
+		displayedUserInfo = Array.from(table.shadowRoot.querySelectorAll(`tbody > tr > td:nth-child(${child})`));
+		expect(displayedUserInfo.length).to.equal(expectedNumDisplayedRows);
+		displayedUserInfo.forEach((cell, rowIdx) => {
+			const mainText = cell.querySelector('div');
+			expect(mainText.innerText).to.equal(data.userDataForDisplay[rowIdx + startRowNum][child - 1].toString());
+		});
 	});
 }

--- a/test/model/data.test.js
+++ b/test/model/data.test.js
@@ -371,10 +371,10 @@ describe('Data', () => {
 	describe('userDataForDisplay', () => {
 		it('should return an array of arrays sorted by lastFirstName', async() => {
 			const expected = [
-				[['Harrison, George', 'gharrison - 300'], 14, '', ''],
-				[['Lennon, John', 'jlennon - 100'], 12, '', ''],
-				[['McCartney, Paul', 'pmccartney - 200'], 13, '', ''],
-				[['Starr, Ringo', 'rstarr - 400'], 9, '', '']
+				[['Harrison, George', 'gharrison - 300'], 14, '71.42 %', '19.64'],
+				[['Lennon, John', 'jlennon - 100'], 12, '22 %', '2.78'],
+				[['McCartney, Paul', 'pmccartney - 200'], 13, '74 %', '23.72'],
+				[['Starr, Ringo', 'rstarr - 400'], 9, '55 %', '8.33']
 			];
 
 			expect(sut.userDataForDisplay).to.deep.equal(expected);
@@ -383,8 +383,8 @@ describe('Data', () => {
 		it('should only display users in view', async() => {
 			const roleFilters = [mockRoleIds.instructor];
 			const expectedUsers = [
-				[['Harrison, George', 'gharrison - 300'], 1, '', ''],
-				[['McCartney, Paul', 'pmccartney - 200'], 3, '', '']
+				[['Harrison, George', 'gharrison - 300'], 1, '', '0'],
+				[['McCartney, Paul', 'pmccartney - 200'], 3, '', '0']
 			];
 
 			sut.selectedRoleIds = roleFilters;


### PR DESCRIPTION
Quality Notes
* functional
  * user w. time and grade in two courses (NB: to get time in content, need to log in as the user - impersonation doesn't seem to work)
  * users with no time in content or grades
  * filtered by role so one or the other of the user's courses were in view; numbers update accordingly
  * i18n: tried german and confirmed dots and commas get switched
* security: n/a
* performance: no significant change
* devops: n/a
* ux/docs
  * uses standard d2l number/percent formatting
  * screen-reader + keyboard works (need to use arrow keys from the last graph to reach the table)

![image](https://user-images.githubusercontent.com/11181217/95368678-6eb5d080-08a4-11eb-97cb-2ec03405a9a9.png)
