### PR TITLE
Us118210/default view popup followup

### DIFF
--- a/components/default-view-popup.js
+++ b/components/default-view-popup.js
@@ -4,6 +4,10 @@ import './expander-with-control';
 import { css, html, LitElement } from 'lit-element';
 import { Localizer } from '../locales/localizer';
 
+/**
+ * @property {Array} data - [{id: orgUnitId, name: orgUnitName}]
+ * @property {Boolean} opened - whether or not the dialog should be opened
+ */
 class DefaultViewPopup extends Localizer(LitElement) {
 
 	static get properties() {
@@ -27,18 +31,13 @@ class DefaultViewPopup extends Localizer(LitElement) {
 
 	constructor() {
 		super();
-		this.data = {};
+		this.data = [];
 		this.opened = false;
 	}
 
 	get _displayData() {
-		if (!this.data.isDefaultView) {
-			return [];
-		}
-
-		return this.data.serverData.defaultViewOrgUnitIds.map(id => {
-			const name = this.data.orgUnitTree.getName(id);
-			return this.localize('components.tree-filter.node-name', { orgUnitName: name, id });
+		return this.data.map((item) => {
+			return this.localize('components.tree-filter.node-name', { orgUnitName: item.name, id: item.id });
 		});
 	}
 

--- a/components/expander-with-control.js
+++ b/components/expander-with-control.js
@@ -4,6 +4,11 @@ import '@brightspace-ui/core/components/button/button-icon';
 import { css, html, LitElement } from 'lit-element';
 import { Localizer } from '../locales/localizer';
 
+/**
+ * @property {String} controlExpandedText - The text to display in the control div when the control is expanded
+ * @property {String} controlCollapsedText - The text to display in the control div when the control is collapsed
+ * @property {Boolean} expanded - whether the content is expanded or not
+ */
 class ExpanderWithControl extends Localizer(LitElement) {
 
 	static get properties() {
@@ -43,8 +48,8 @@ class ExpanderWithControl extends Localizer(LitElement) {
 
 		// having events be handled on the div makes the whole div clickable, as specified in the spec
 		// the div's click handler also handles any events fired by the d2l-button-icon, including Enter
-		// and Spacebar keypress events. When Enter/Spacebar is pressed on a focused button, it fires
-		// a MouseEvent which can be handled by the click handler
+		// and Spacebar keypress events.
+		// Note: when Enter/Spacebar is pressed on a focused button, it fires a KeyboardEvent, as well as a MouseEvent
 		return html`
 			<div
 				role="button"

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -25,7 +25,7 @@ import { OverdueAssignmentsCardFilter } from './components/overdue-assignments-c
 import { TimeInContentVsGradeCardFilter } from './components/time-in-content-vs-grade-card';
 
 /**
- * @property {Boolean} useTestData - if true, use canned data; otherwise call the LMS
+ * @property {Boolean} isDemo - if true, use canned data; otherwise call the LMS
  */
 class EngagementDashboard extends Localizer(MobxLitElement) {
 
@@ -126,7 +126,11 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				</div>
 				<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.resultsHeading')}</h2>
 				<d2l-insights-users-table .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-users-table>
-				<d2l-insights-default-view-popup .data="${this._data}" ?opened="${this._data.isDefaultView}"></d2l-insights-default-view-popup>
+
+				<d2l-insights-default-view-popup
+					?opened=${Boolean(this._data.defaultViewPopupDisplayData.length)}
+					.data="${this._data.defaultViewPopupDisplayData}">
+				</d2l-insights-default-view-popup>
 		`;
 	}
 

--- a/model/data.js
+++ b/model/data.js
@@ -43,6 +43,7 @@ export class Data {
 			records: [],
 			orgUnits: [],
 			users: [],
+			isDefaultView: false,
 			isRecordsTruncated: false,
 			isOrgUnitsTruncated: false,
 			semesterTypeId: null,
@@ -149,8 +150,20 @@ export class Data {
 		return this._selectorFilters.orgUnit.selected;
 	}
 
-	get isDefaultView() {
-		return this.serverData.defaultViewOrgUnitIds && this.serverData.defaultViewOrgUnitIds.length;
+	get defaultViewPopupDisplayData() {
+		let courseIdsToDisplay = [];
+
+		if (this.serverData.isDefaultView) {
+			if (this.serverData.defaultViewOrgUnitIds && this.serverData.defaultViewOrgUnitIds.length) {
+				courseIdsToDisplay = this.serverData.defaultViewOrgUnitIds;
+			} else if (this.serverData.selectedOrgUnitIds && this.serverData.selectedOrgUnitIds.length) {
+				courseIdsToDisplay = this.serverData.selectedOrgUnitIds;
+			}
+		} // else return empty array
+
+		return courseIdsToDisplay.map(id => {
+			return { id, name: this.orgUnitTree.getName(id) };
+		});
 	}
 
 	// @computed

--- a/model/data.js
+++ b/model/data.js
@@ -43,7 +43,11 @@ export class Data {
 			records: [],
 			orgUnits: [],
 			users: [],
+
+			// NB: isDefaultView just means that data was loaded using the defaultViewDataProvider. It does not
+			// necessarily mean that the client-side has preselected OUs - also see get defaultViewPopupDisplayData
 			isDefaultView: false,
+
 			isRecordsTruncated: false,
 			isOrgUnitsTruncated: false,
 			semesterTypeId: null,
@@ -150,6 +154,9 @@ export class Data {
 		return this._selectorFilters.orgUnit.selected;
 	}
 
+	// returns OU ids (and respective names) that have been preselected to create the client-side default view, if any.
+	// NB: it's possible for isDefaultView to be true but for there to be no preselected ids; this happens if the
+	// defaultCourses and defaultSemesters config variables are set to 0
 	get defaultViewPopupDisplayData() {
 		let courseIdsToDisplay = [];
 

--- a/model/fake-lms.js
+++ b/model/fake-lms.js
@@ -52,7 +52,8 @@ export async function fetchData({ roleIds, semesterIds, orgUnitIds, defaultView 
 		selectedSemestersIds: semesterIds,
 		selectedRolesIds: roleIds,
 		selectedOrgUnitIds: orgUnitIds,
-		defaultViewOrgUnitIds: defaultView ? [1, 2] : null
+		defaultViewOrgUnitIds: defaultView ? [1, 2] : null,
+		isDefaultView: defaultView
 	};
 	return new Promise(resolve => setTimeout(() => resolve(demoData), 100));
 }

--- a/test/components/default-view-popup.test.js
+++ b/test/components/default-view-popup.test.js
@@ -4,12 +4,11 @@ import { expect, fixture, html } from '@open-wc/testing';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper';
 
 describe('d2l-insights-default-view-popup', () => {
-	const data = {
-		serverData: {
-			defaultViewOrgUnitIds: [1, 2, 3, 4]
-		},
-		orgUnitTree: { getName: (id) => `Name for ${id}` }
-	};
+	const data = [
+		{ id: 1, name: 'Course 1' },
+		{ id: 2, name: 'Course 2' },
+		{ id: 3, name: 'Course 3' }
+	];
 	let el;
 
 	beforeEach(async() => {
@@ -37,8 +36,8 @@ describe('d2l-insights-default-view-popup', () => {
 		it('should have the correct entries for the courses list', () => {
 			const listEntries = Array.from(el.shadowRoot.querySelectorAll('li'));
 			listEntries.forEach((entry, idx) => {
-				const id = data.serverData.defaultViewOrgUnitIds[idx];
-				expect(entry.innerText).to.equal(`Name for ${id} (Id: ${id})`);
+				const expected = data[idx];
+				expect(entry.innerText).to.equal(`${expected.name} (Id: ${expected.id})`);
 			});
 		});
 	});


### PR DESCRIPTION
PR 2 of 2 to address this comment: https://github.com/Brightspace/insights-engagement-dashboard/pull/86#discussion_r501746118
PR 1: https://github.com/Brightspace/lms/pull/2250

This shows the default view popup if enrollments were truncated and some OUs were pre-selected to show a default view. The previous PR (#86) only showed the default view popup if enrollments were not truncated and some OUs were preselected.

Quality notes
* Testing (browsers: Chrome, FF, Edgium, Legacy)
  * Test cases
    * [x] Preselected ids, no truncation. Expected: dialog appears
    * [x] Preselected ids, truncation. Expected: dialog appears
    * [x] No preselected ids, no truncation. Expected: dialog does not appear
    * [x] No preselected ids, truncation. Expected: dialog does not appear. Actual: dialog did not appear. But also, this case has strange behaviour when a default view is requested. The current DefaultViewDataProvider returns no records if DefaultCourses = 0 and the number of records returned is greater than EnrollmentLimit. 
        * Test params (with a dev LMS): DefaultCourses = 0, DefaultSemesters = 0, EnrollmentLimit = 15, CourseLimit = 5. Returns an empty list of records. Increasing EnrollmentLimit to 20 returns 16 records.
* Security, perf, UX: N/A
* Docs; added some comments around how this works in code

@anhill-D2L @MykolaGalian @rohitvinnakota @NicholasHallman 