### PR TITLE
Remove space under filter and fix bar after selection DE40834

### DIFF
--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -122,6 +122,8 @@ class Chart extends SkeletonMixin(LitElement) {
 				}
 			});
 			this.chart = H[constructorType](this.chartContainer, this.options, this.chartCreated.bind(this));
+			// force highcharts to recalculate the chart position incase the filter move the graph
+			this.chartContainer.addEventListener('click', (e) => (delete this.chart.pointer.chartPosition));
 		}
 	}
 

--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -123,7 +123,7 @@ class Chart extends SkeletonMixin(LitElement) {
 			});
 			this.chart = H[constructorType](this.chartContainer, this.options, this.chartCreated.bind(this));
 			// force highcharts to recalculate the chart position incase the filter move the graph
-			this.chartContainer.addEventListener('click', (e) => (delete this.chart.pointer.chartPosition));
+			this.chartContainer.addEventListener('click', () => (delete this.chart.pointer.chartPosition));
 		}
 	}
 

--- a/components/course-last-access-card.js
+++ b/components/course-last-access-card.js
@@ -157,7 +157,7 @@ class CourseLastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 	_pointUpdateColor(point, colorForPoint) {
 		point.update({ color: colorForPoint }, false);
 	}
- 
+
 	render() {
 		// NB: relying on mobx rather than lit-element properties to handle update detection: it will trigger a redraw for
 		// any change to a relevant observed property of the Data object

--- a/components/course-last-access-card.js
+++ b/components/course-last-access-card.js
@@ -35,7 +35,6 @@ class CourseLastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 			:host([hidden]) {
 				display: none;
 			}
-
 			.d2l-insights-course-last-access-container {
 				border-color: var(--d2l-color-mica);
 				border-radius: 15px;
@@ -158,7 +157,7 @@ class CourseLastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 	_pointUpdateColor(point, colorForPoint) {
 		point.update({ color: colorForPoint }, false);
 	}
-
+ 
 	render() {
 		// NB: relying on mobx rather than lit-element properties to handle update detection: it will trigger a redraw for
 		// any change to a relevant observed property of the Data object

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -59,7 +59,6 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 
 				.d2l-insights-summary-container-applied-filters {
 					height: auto;
-					min-height: 30px;
 					width: 100%;
 				}
 


### PR DESCRIPTION
Related to #79 

I managed to trace the problem into HighCharts. 

When a bar in the chart is selected and the graphs are shifted down in the document the graphPosition is not updated in the pointer when the chart is not close to the top of the page. If the chart is visible from the top of the page or if you zoom out enough to see the top of the page then the chartPosition is updated. 

By reseting that state on every click the problem is resolved. 

Wondering your thoughts on this fix or if you think we should submit a PR directly to HighCharts.

@anhill-D2L  @bemailloux @rohitvinnakota @hyehayes