### PR TITLE
prevent massive amounts of recalculation

### DIFF
--- a/model/data.js
+++ b/model/data.js
@@ -325,6 +325,7 @@ decorate(Data, {
 	usersCountsWithOverdueAssignments: computed,
 	courseLastAccessDates: computed,
 	tiCVsGrades: computed,
+	tiCVsGradesAvgValues: computed,
 	cardFilters: observable,
 	isLoading: observable,
 	tiCVsGradesQuadrant: observable,


### PR DESCRIPTION
Yikes! Console logging in this getter shows that without the `computed` decoration, it's unsurprisingly getting called many many times per render (it gets called by the filter method for the corresponding card, so once per row, calculate the average of all the rows... so n^2).

FYI @bemailloux @MykolaGalian @NicholasHallman @Vitalii-Misechko 