### PR TITLE
US119012: refactor: move user table logic out of Data

### DIFF
--- a/components/results-card.js
+++ b/components/results-card.js
@@ -27,7 +27,7 @@ class ResultsCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 	}
 
 	get _cardValue() {
-		return this.data.userDataForDisplay.length;
+		return this.data.users.length;
 	}
 
 	render() {

--- a/components/users-table.js
+++ b/components/users-table.js
@@ -1,24 +1,33 @@
 import '@brightspace-ui/core/components/inputs/input-text';
 import '@brightspace-ui-labs/pagination/pagination';
 import './table.js';
-
+import { computed, decorate } from 'mobx';
 import { css, html } from 'lit-element';
+import { formatNumber, formatPercent } from '@brightspace-ui/intl';
+import { RECORD, USER } from '../consts';
 import { COLUMN_TYPES } from './table';
 import { Localizer } from '../locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin';
 
-export const TABLE_USER = {
+const TABLE_USER = {
 	NAME_INFO: 0,
 	COURSES: 1,
 	AVG_GRADE: 2,
 	AVG_TIME_IN_CONTENT: 3
 };
 
+const numberFormatOptions = { maximumFractionDigits: 2 };
+
 const DEFAULT_PAGE_SIZE = 20;
 
+function avgOf(records, field) {
+	const total = records.reduce((sum, r) => sum + r[field], 0);
+	return total / records.length;
+}
+
 /**
- * At the moment the mobx data object is doing sorting / filtering logic
+ * The mobx data object is doing filtering logic
  *
  * @property {Object} data - an instance of Data from model/data.js
  * @property {Number} _currentPage
@@ -59,14 +68,14 @@ class UsersTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 	constructor() {
 		super();
 		this.data = {
-			userDataForDisplay: []
+			users: []
 		};
 		this._currentPage = 1;
 		this._pageSize = DEFAULT_PAGE_SIZE;
 	}
 
 	get _itemsCount() {
-		return this.data.userDataForDisplay.length;
+		return this.userDataForDisplay.length;
 	}
 
 	get _maxPages() {
@@ -88,10 +97,33 @@ class UsersTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 			const start = this._pageSize * (this._currentPage - 1);
 			const end = this._pageSize * (this._currentPage); // it's ok if this goes over the end of the array
 
-			return this.data.userDataForDisplay.slice(start, end);
+			return this.userDataForDisplay.slice(start, end);
 		}
 
 		return [];
+	}
+
+	// @computed
+	get userDataForDisplay() {
+		// map to a 2D userData array, with column 0 as a sub-array of [lastFirstName, username - id]
+		// then sort by lastFirstName
+		const recordsByUser = this.data.recordsByUser;
+		return this.data.users
+			.map(user => {
+				const records = recordsByUser.get(user[USER.ID]);
+				const recordsWithGrades = records.filter(r => r[RECORD.CURRENT_FINAL_GRADE] !== null);
+				const avgFinalGrade = avgOf(recordsWithGrades, RECORD.CURRENT_FINAL_GRADE);
+				return [
+					[`${user[USER.LAST_NAME]}, ${user[USER.FIRST_NAME]}`, `${user[USER.USERNAME]} - ${user[USER.ID]}`],
+					records.length, // courses
+					avgFinalGrade ? formatPercent(avgFinalGrade / 100, numberFormatOptions) : '',
+					formatNumber(avgOf(records, RECORD.TIME_IN_CONTENT) / 60, numberFormatOptions)
+				];
+			})
+			.sort((user1, user2) => {
+				// sort by lastFirstName
+				return user1[TABLE_USER.NAME_INFO][0].localeCompare(user2[TABLE_USER.NAME_INFO][0]);
+			});
 	}
 
 	get columnInfo() {
@@ -169,4 +201,7 @@ class UsersTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 		this._pageSize = Number(event.detail.itemCount); // itemCount comes back as a string
 	}
 }
+decorate(UsersTable, {
+	userDataForDisplay: computed
+});
 customElements.define('d2l-insights-users-table', UsersTable);

--- a/model/data.js
+++ b/model/data.js
@@ -4,20 +4,11 @@ import {
 	OverdueAssignmentsFilterId, RECORD, TiCVsGradesFilterId, USER
 } from '../consts';
 import { fetchCachedChildren, fetchLastSearch } from './lms.js';
-import { formatNumber, formatPercent } from '@brightspace-ui/intl/lib/number.js';
 import { OrgUnitSelectorFilter, RoleSelectorFilter, SemesterSelectorFilter } from './selectorFilters.js';
-import { TABLE_USER } from '../components/users-table';
 import { Tree } from '../components/tree-filter';
-
-const numberFormatOptions = { maximumFractionDigits: 2 };
 
 function unique(array) {
 	return [...new Set(array)];
-}
-
-function avgOf(records, field) {
-	const total = records.reduce((sum, r) => sum + r[field], 0);
-	return total / records.length;
 }
 
 // cardFilters must be an array of filters; a filter must have fields id, title, and isApplied,
@@ -184,29 +175,6 @@ export class Data {
 		return userIdsInView.map(userId => this._userDictionary.get(userId));
 	}
 
-	// @computed
-	get userDataForDisplay() {
-		// map to a 2D userData array, with column 0 as a sub-array of [lastFirstName, username - id]
-		// then sort by lastFirstName
-		const recordsByUser = this.recordsByUser;
-		return this.users
-			.map(user => {
-				const records = recordsByUser.get(user[USER.ID]);
-				const recordsWithGrades = records.filter(r => r[RECORD.CURRENT_FINAL_GRADE] !== null);
-				const avgFinalGrade = avgOf(recordsWithGrades, RECORD.CURRENT_FINAL_GRADE);
-				return [
-					[`${user[USER.LAST_NAME]}, ${user[USER.FIRST_NAME]}`, `${user[USER.USERNAME]} - ${user[USER.ID]}`],
-					records.length, // courses
-					avgFinalGrade ? formatPercent(avgFinalGrade / 100, numberFormatOptions) : '',
-					formatNumber(avgOf(records, RECORD.TIME_IN_CONTENT) / 60, numberFormatOptions)
-				];
-			})
-			.sort((user1, user2) => {
-				// sort by lastFirstName
-				return user1[TABLE_USER.NAME_INFO][0].localeCompare(user2[TABLE_USER.NAME_INFO][0]);
-			});
-	}
-
 	get recordsByUser() {
 		const recordsByUser = new Map();
 		this.getRecordsInView().forEach(r => {
@@ -321,7 +289,6 @@ decorate(Data, {
 	orgUnitTree: observable,
 	records: computed,
 	users: computed,
-	userDataForDisplay: computed,
 	usersCountsWithOverdueAssignments: computed,
 	courseLastAccessDates: computed,
 	tiCVsGrades: computed,

--- a/test/components/results-card.test.js
+++ b/test/components/results-card.test.js
@@ -5,7 +5,7 @@ import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-help
 
 describe('d2l-insights-results-card', () => {
 	const data = {
-		userDataForDisplay: [
+		users: [
 			'Lennon, John',
 			'McCartney, Paul',
 			'Harrison, George',

--- a/test/model/data.test.js
+++ b/test/model/data.test.js
@@ -1,21 +1,8 @@
+import { mockOuTypes, mockRoleIds, records } from './mocks';
 import { OrgUnitSelectorFilter, RoleSelectorFilter, SemesterSelectorFilter } from '../../model/selectorFilters';
 import { Data } from '../../model/data.js';
 import { expect } from '@open-wc/testing';
 import sinon from 'sinon/pkg/sinon-esm.js';
-
-const mockOuTypes = {
-	organization: 0,
-	department: 1,
-	course: 2,
-	courseOffering: 3,
-	semester: 5
-};
-
-const mockRoleIds = {
-	admin: 100,
-	instructor: 200,
-	student: 300
-};
 
 describe('Data', () => {
 	const serverData = {
@@ -36,68 +23,7 @@ describe('Data', () => {
 			[311, 'Course 3 / Semester 1', mockOuTypes.courseOffering, [3, 11]],
 			[313, 'Course 3 / Semester 3', mockOuTypes.courseOffering, [3, 13]]
 		],
-		records: [
-			[6606, 100, mockRoleIds.student, 0, 22, 2000, 10293819283], // this user has a cascading admin role on dept and sem levels
-			[6606, 200, mockRoleIds.student, 0, 33, 2500, 10293819283],
-			[6606, 300, mockRoleIds.student, 0, 44, 4000, 10293819283],
-			[6606, 400, mockRoleIds.student, 0, 55, 4500, 10293819283], // this user has a cascading admin role on dept and sem levels
-
-			// semesters
-			[11, 100, mockRoleIds.admin, 0, null, 0, null],
-			[12, 100, mockRoleIds.admin, 0, null, 0, null],
-			[13, 100, mockRoleIds.admin, 0, null, 0, null],
-
-			[11, 200, mockRoleIds.student, 0, 33, 0, null],
-			[12, 200, mockRoleIds.instructor, 0, null, 0, null],
-
-			[11, 300, mockRoleIds.student, 0, 100, 0, null],
-			[12, 300, mockRoleIds.student, 0, 100, 0, null],
-			[13, 300, mockRoleIds.student, 0, 100, 0, null],
-
-			[11, 400, mockRoleIds.admin, 0, null, 0, 12392838182],
-			[12, 400, mockRoleIds.admin, 0, null, 0, 12392838182],
-			[13, 400, mockRoleIds.admin, 0, null, 0, null],
-
-			// dept 1
-			[1001, 100, mockRoleIds.admin, 0, null, 0, null],
-			[1001, 200, mockRoleIds.student, 0, 73, 0, null],
-			[1001, 300, mockRoleIds.student, 0, 73, 0, null],
-			// courses
-			[1, 100, mockRoleIds.admin, 0, null, 0, null],
-			[1, 200, mockRoleIds.instructor, 0, null, 0, null],
-			[1, 300, mockRoleIds.student, 1, 41, 3500, null],
-			[2, 100, mockRoleIds.admin, 0, null, 0, null],
-			[2, 200, mockRoleIds.student, 0, 55, 5000, null],
-			[2, 300, mockRoleIds.student, 0, 39, 3000, null],
-			// course 1 offerings
-			[111, 100, mockRoleIds.admin, 0, null, 0, null],
-			[111, 200, mockRoleIds.student, 1, 93, 7000, null],
-			[112, 100, mockRoleIds.admin, 0, null, 0, null],
-			[112, 200, mockRoleIds.instructor, 0, null, 0, null], // this person was promoted from student to instructor
-			[113, 100, mockRoleIds.admin, 0, null, 0, null],
-			[113, 300, mockRoleIds.student, 0, 75, 6000, null],
-			// course 2 offerings
-			[212, 100, mockRoleIds.admin, 0, null, 0, 0],
-			[212, 200, mockRoleIds.student, 0, 84, 4000, null],
-			[212, 300, mockRoleIds.instructor, 0, null, 0, null],
-
-			// dept 2
-			[1002, 200, mockRoleIds.student, 0, 98, 0, null],
-			[1002, 300, mockRoleIds.student, 0, 89, 0, null],
-			[1002, 400, mockRoleIds.admin, 0, null, 0, null],
-			[3, 200, mockRoleIds.student, 0, 98, 0, Date.now() - 299],
-			[3, 300, mockRoleIds.student, 0, 88, 0, Date.now() - 86500000],
-			[3, 400, mockRoleIds.admin, 0, null, 0, null],
-			[311, 200, mockRoleIds.student, 0, 99, 0, null],
-			[311, 300, mockRoleIds.student, 0, 42, 0, null],
-			[311, 400, mockRoleIds.admin, 0, null, 0, null],
-			[313, 300, mockRoleIds.student, 0, 66, 0, null],
-			[313, 400, mockRoleIds.admin, 0, null, 0, null],
-			[6606, 100, mockRoleIds.student, 0, null, 0, null], // this user has a cascading admin role on dept and sem levels
-			[6606, 200, mockRoleIds.student, 0, null, 0, null],
-			[6606, 300, mockRoleIds.student, 0, null, 0, null],
-			[6606, 400, mockRoleIds.student, 0, null, 0, null], // this user has a cascading admin role on dept and sem levels
-		],
+		records,
 		users: [
 			[100, 'John', 'Lennon', 'jlennon',  Date.now() - 2000000000],
 			[200, 'Paul', 'McCartney', 'pmccartney', null],
@@ -415,31 +341,6 @@ describe('Data', () => {
 			sut.selectedRoleIds = roleFilters;
 
 			expect(sut.users).to.deep.equal(expectedUsers);
-		});
-	});
-
-	describe('userDataForDisplay', () => {
-		it('should return an array of arrays sorted by lastFirstName', async() => {
-			const expected = [
-				[['Harrison, George', 'gharrison - 300'], 14, '71.42 %', '19.64'],
-				[['Lennon, John', 'jlennon - 100'], 12, '22 %', '2.78'],
-				[['McCartney, Paul', 'pmccartney - 200'], 13, '74 %', '23.72'],
-				[['Starr, Ringo', 'rstarr - 400'], 9, '55 %', '8.33']
-			];
-
-			expect(sut.userDataForDisplay).to.deep.equal(expected);
-		});
-
-		it('should only display users in view', async() => {
-			const roleFilters = [mockRoleIds.instructor];
-			const expectedUsers = [
-				[['Harrison, George', 'gharrison - 300'], 1, '', '0'],
-				[['McCartney, Paul', 'pmccartney - 200'], 3, '', '0']
-			];
-
-			sut.selectedRoleIds = roleFilters;
-
-			expect(sut.userDataForDisplay).to.deep.equal(expectedUsers);
 		});
 	});
 

--- a/test/model/mocks.js
+++ b/test/model/mocks.js
@@ -1,0 +1,76 @@
+export const mockOuTypes = {
+	organization: 0,
+	department: 1,
+	course: 2,
+	courseOffering: 3,
+	semester: 5
+};
+
+export const mockRoleIds = {
+	admin: 100,
+	instructor: 200,
+	student: 300
+};
+
+export const records = [
+	[6606, 100, mockRoleIds.student, 0, 22, 2000, 10293819283], // this user has a cascading admin role on dept and sem levels
+	[6606, 200, mockRoleIds.student, 0, 33, 2500, 10293819283],
+	[6606, 300, mockRoleIds.student, 0, 44, 4000, 10293819283],
+	[6606, 400, mockRoleIds.student, 0, 55, 4500, 10293819283], // this user has a cascading admin role on dept and sem levels
+
+	// semesters
+	[11, 100, mockRoleIds.admin, 0, null, 0, null],
+	[12, 100, mockRoleIds.admin, 0, null, 0, null],
+	[13, 100, mockRoleIds.admin, 0, null, 0, null],
+
+	[11, 200, mockRoleIds.student, 0, 33, 0, null],
+	[12, 200, mockRoleIds.instructor, 0, null, 0, null],
+
+	[11, 300, mockRoleIds.student, 0, 100, 0, null],
+	[12, 300, mockRoleIds.student, 0, 100, 0, null],
+	[13, 300, mockRoleIds.student, 0, 100, 0, null],
+
+	[11, 400, mockRoleIds.admin, 0, null, 0, 12392838182],
+	[12, 400, mockRoleIds.admin, 0, null, 0, 12392838182],
+	[13, 400, mockRoleIds.admin, 0, null, 0, null],
+
+	// dept 1
+	[1001, 100, mockRoleIds.admin, 0, null, 0, null],
+	[1001, 200, mockRoleIds.student, 0, 73, 0, null],
+	[1001, 300, mockRoleIds.student, 0, 73, 0, null],
+	// courses
+	[1, 100, mockRoleIds.admin, 0, null, 0, null],
+	[1, 200, mockRoleIds.instructor, 0, null, 0, null],
+	[1, 300, mockRoleIds.student, 1, 41, 3500, null],
+	[2, 100, mockRoleIds.admin, 0, null, 0, null],
+	[2, 200, mockRoleIds.student, 0, 55, 5000, null],
+	[2, 300, mockRoleIds.student, 0, 39, 3000, null],
+	// course 1 offerings
+	[111, 100, mockRoleIds.admin, 0, null, 0, null],
+	[111, 200, mockRoleIds.student, 1, 93, 7000, null],
+	[112, 100, mockRoleIds.admin, 0, null, 0, null],
+	[112, 200, mockRoleIds.instructor, 0, null, 0, null], // this person was promoted from student to instructor
+	[113, 100, mockRoleIds.admin, 0, null, 0, null],
+	[113, 300, mockRoleIds.student, 0, 75, 6000, null],
+	// course 2 offerings
+	[212, 100, mockRoleIds.admin, 0, null, 0, 0],
+	[212, 200, mockRoleIds.student, 0, 84, 4000, null],
+	[212, 300, mockRoleIds.instructor, 0, null, 0, null],
+
+	// dept 2
+	[1002, 200, mockRoleIds.student, 0, 98, 0, null],
+	[1002, 300, mockRoleIds.student, 0, 89, 0, null],
+	[1002, 400, mockRoleIds.admin, 0, null, 0, null],
+	[3, 200, mockRoleIds.student, 0, 98, 0, Date.now() - 299],
+	[3, 300, mockRoleIds.student, 0, 88, 0, Date.now() - 86500000],
+	[3, 400, mockRoleIds.admin, 0, null, 0, null],
+	[311, 200, mockRoleIds.student, 0, 99, 0, null],
+	[311, 300, mockRoleIds.student, 0, 42, 0, null],
+	[311, 400, mockRoleIds.admin, 0, null, 0, null],
+	[313, 300, mockRoleIds.student, 0, 66, 0, null],
+	[313, 400, mockRoleIds.admin, 0, null, 0, null],
+	[6606, 100, mockRoleIds.student, 0, null, 0, null], // this user has a cascading admin role on dept and sem levels
+	[6606, 200, mockRoleIds.student, 0, null, 0, null],
+	[6606, 300, mockRoleIds.student, 0, null, 0, null],
+	[6606, 400, mockRoleIds.student, 0, null, 0, null], // this user has a cascading admin role on dept and sem levels
+];


### PR DESCRIPTION
Just a refactor

Regression testing (local e2e): load page; apply role filter and grade filter and verify that users in table, calculated values, and results card change accordingly.

FYI @anhill-D2L @MykolaGalian @rohitvinnakota @Vitalii-Misechko 