### PR TITLE
US119012: refactor: move last access logic out of Data

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -19,4 +19,3 @@ export const USER = {
 
 export const TiCVsGradesFilterId = 'd2l-insights-time-in-content-vs-grade-card';
 export const OverdueAssignmentsFilterId = 'd2l-insights-overdue-assignments-card';
-export const CourseLastAccessFilterId = 'd2l-insights-course-last-access-card';

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -14,7 +14,7 @@ import './components/default-view-popup.js';
 import './components/last-access-card';
 
 import { css, html } from 'lit-element/lit-element.js';
-import { CourseLastAccessCardFilter } from './components/course-last-access-card';
+import { CourseLastAccessFilter } from './components/course-last-access-card';
 import { CurrentFinalGradesFilter } from './components/current-final-grade-card';
 import { Data } from './model/data.js';
 import { fetchData } from './model/lms.js';
@@ -144,7 +144,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 			const cardFilters = [
 				OverdueAssignmentsCardFilter,
 				TimeInContentVsGradeCardFilter,
-				CourseLastAccessCardFilter,
+				new CourseLastAccessFilter(),
 				new CurrentFinalGradesFilter()
 			];
 

--- a/model/data.js
+++ b/model/data.js
@@ -1,6 +1,6 @@
 import { action, autorun, computed, decorate, observable } from 'mobx';
 import {
-	COURSE_OFFERING, CourseLastAccessFilterId,
+	COURSE_OFFERING,
 	OverdueAssignmentsFilterId, RECORD, TiCVsGradesFilterId, USER
 } from '../consts';
 import { fetchCachedChildren, fetchLastSearch } from './lms.js';
@@ -31,8 +31,6 @@ export class Data {
 		this._userDictionary = null;
 
 		// @observables
-		this.selectedLastAccessCategory = new Set();
-		this.selectedGradesCategories = new Set();
 		this.tiCVsGradesQuadrant = 'leftBottom';
 		this.avgTimeInContent = 0;
 		this.avgGrades = 0;
@@ -218,47 +216,6 @@ export class Data {
 		return recordsByUser;
 	}
 
-	get courseLastAccessDates() {
-		// return an array of size 6, each element mapping to a category on the course last access bar chart
-		const dateBucketCounts = [0, 0, 0, 0, 0, 0];
-		const lastAccessDatesArray = this.getRecordsInView(CourseLastAccessFilterId).map(record => [record[RECORD.COURSE_LAST_ACCESS] === null ? -1 : (Date.now() - record[RECORD.COURSE_LAST_ACCESS])]);
-		lastAccessDatesArray.forEach(record => dateBucketCounts[ this._bucketCourseLastAccessDates(record) ]++);
-		return dateBucketCounts;
-	}
-
-	_bucketCourseLastAccessDates(courseLastAccessDateRange) {
-		const fourteenDayMillis = 1209600000;
-		const sevenDayMillis = 604800000;
-		const fiveDayMillis = 432000000;
-		const oneDayMillis = 86400000;
-		if (courseLastAccessDateRange < 0) {
-			return 0;
-		}
-		if (courseLastAccessDateRange >= fourteenDayMillis) {
-			return 1;
-		}
-		if (courseLastAccessDateRange <= oneDayMillis) {
-			return 5;
-		}
-		if (courseLastAccessDateRange <= fiveDayMillis) {
-			return 4;
-		}
-		if (courseLastAccessDateRange <= sevenDayMillis) {
-			return 3;
-		}
-		if (courseLastAccessDateRange <= fourteenDayMillis) {
-			return 2;
-		}
-	}
-
-	addToLastAccessCategory(category) {
-		this.selectedLastAccessCategory.add(category);
-	}
-
-	setLastAccessCategoryEmpty() {
-		this.selectedLastAccessCategory.clear();
-	}
-
 	get tiCVsGrades() {
 		return this.getRecordsInView(TiCVsGradesFilterId)
 			.filter(record => record[RECORD.CURRENT_FINAL_GRADE] !== null && record[RECORD.CURRENT_FINAL_GRADE] !== undefined)
@@ -323,16 +280,11 @@ decorate(Data, {
 	users: computed,
 	userDataForDisplay: computed,
 	usersCountsWithOverdueAssignments: computed,
-	courseLastAccessDates: computed,
 	tiCVsGrades: computed,
 	tiCVsGradesAvgValues: computed,
 	cardFilters: observable,
 	isLoading: observable,
 	tiCVsGradesQuadrant: observable,
-	selectedLastAccessCategory: observable,
-	selectedGradesCategories: observable,
 	onServerDataReload: action,
-	setApplied: action,
-	addToLastAccessCategory: action,
-	setLastAccessCategoryEmpty: action
+	setApplied: action
 });

--- a/test/components/course-last-access-card.test.js
+++ b/test/components/course-last-access-card.test.js
@@ -1,11 +1,13 @@
-import '../../components/course-last-access-card.js';
-
 import { expect, fixture, html } from '@open-wc/testing';
+import { CourseLastAccessFilter } from '../../components/course-last-access-card';
+import { records } from '../model/mocks';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
 
 describe('d2l-insights-course-last-access-card', () => {
+	const filter = new CourseLastAccessFilter();
 	const data = {
-		courseLastAccessDates: [1, 3, 4, 2, 4, 3]
+		getFilter: id => (id === filter.id ? filter : null),
+		getRecordsInView: id => (id === filter.id ? records : null)
 	};
 
 	describe('constructor', () => {
@@ -29,7 +31,7 @@ describe('d2l-insights-course-last-access-card', () => {
 			await new Promise(resolve => setTimeout(resolve, 200)); // allow fetch to run
 			const title = (el.shadowRoot.querySelectorAll('div.d2l-insights-course-last-access-title'));
 			expect(title[0].innerText).to.equal('Course Access');
-			expect(el._preparedBarChartData.toString()).to.equal(data.courseLastAccessDates.toString());
+			expect(el._preparedBarChartData.toString()).to.equal([39, 7, 0, 0, 1, 1].toString());
 		});
 	});
 

--- a/test/components/current-final-grade-card.test.js
+++ b/test/components/current-final-grade-card.test.js
@@ -1,76 +1,9 @@
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { CurrentFinalGradesFilter } from '../../components/current-final-grade-card';
+import { records } from '../model/mocks';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
 
-const mockRoleIds = {
-	admin: 100,
-	instructor: 200,
-	student: 300
-};
-
 describe('d2l-insights-current-final-grade-card', () => {
-	const records = [
-		[6606, 100, mockRoleIds.student, 0, 22, 2000, 10293819283], // this user has a cascading admin role on dept and sem levels
-		[6606, 200, mockRoleIds.student, 0, 33, 2500, 10293819283],
-		[6606, 300, mockRoleIds.student, 0, 44, 4000, 10293819283],
-		[6606, 400, mockRoleIds.student, 0, 55, 4500, 10293819283], // this user has a cascading admin role on dept and sem levels
-
-		// semesters
-		[11, 100, mockRoleIds.admin, 0, null, 0, null],
-		[12, 100, mockRoleIds.admin, 0, null, 0, null],
-		[13, 100, mockRoleIds.admin, 0, null, 0, null],
-
-		[11, 200, mockRoleIds.student, 0, 33, 0, null],
-		[12, 200, mockRoleIds.instructor, 0, null, 0, null],
-
-		[11, 300, mockRoleIds.student, 0, 100, 0, null],
-		[12, 300, mockRoleIds.student, 0, 100, 0, null],
-		[13, 300, mockRoleIds.student, 0, 100, 0, null],
-
-		[11, 400, mockRoleIds.admin, 0, null, 0, 12392838182],
-		[12, 400, mockRoleIds.admin, 0, null, 0, 12392838182],
-		[13, 400, mockRoleIds.admin, 0, null, 0, null],
-
-		// dept 1
-		[1001, 100, mockRoleIds.admin, 0, null, 0, null],
-		[1001, 200, mockRoleIds.student, 0, 73, 0, null],
-		[1001, 300, mockRoleIds.student, 0, 73, 0, null],
-		// courses
-		[1, 100, mockRoleIds.admin, 0, null, 0, null],
-		[1, 200, mockRoleIds.instructor, 0, null, 0, null],
-		[1, 300, mockRoleIds.student, 1, 41, 3500, null],
-		[2, 100, mockRoleIds.admin, 0, null, 0, null],
-		[2, 200, mockRoleIds.student, 0, 55, 5000, null],
-		[2, 300, mockRoleIds.student, 0, 39, 3000, null],
-		// course 1 offerings
-		[111, 100, mockRoleIds.admin, 0, null, 0, null],
-		[111, 200, mockRoleIds.student, 1, 93, 7000, null],
-		[112, 100, mockRoleIds.admin, 0, null, 0, null],
-		[112, 200, mockRoleIds.instructor, 0, null, 0, null], // this person was promoted from student to instructor
-		[113, 100, mockRoleIds.admin, 0, null, 0, null],
-		[113, 300, mockRoleIds.student, 0, 75, 6000, null],
-		// course 2 offerings
-		[212, 100, mockRoleIds.admin, 0, null, 0, 0],
-		[212, 200, mockRoleIds.student, 0, 84, 4000, null],
-		[212, 300, mockRoleIds.instructor, 0, null, 0, null],
-
-		// dept 2
-		[1002, 200, mockRoleIds.student, 0, 98, 0, null],
-		[1002, 300, mockRoleIds.student, 0, 89, 0, null],
-		[1002, 400, mockRoleIds.admin, 0, null, 0, null],
-		[3, 200, mockRoleIds.student, 0, 98, 0, Date.now() - 299],
-		[3, 300, mockRoleIds.student, 0, 88, 0, Date.now() - 86500000],
-		[3, 400, mockRoleIds.admin, 0, null, 0, null],
-		[311, 200, mockRoleIds.student, 0, 99, 0, null],
-		[311, 300, mockRoleIds.student, 0, 42, 0, null],
-		[311, 400, mockRoleIds.admin, 0, null, 0, null],
-		[313, 300, mockRoleIds.student, 0, 66, 0, null],
-		[313, 400, mockRoleIds.admin, 0, null, 0, null],
-		[6606, 100, mockRoleIds.student, 0, null, 0, null], // this user has a cascading admin role on dept and sem levels
-		[6606, 200, mockRoleIds.student, 0, null, 0, null],
-		[6606, 300, mockRoleIds.student, 0, null, 0, null],
-		[6606, 400, mockRoleIds.student, 0, null, 0, null], // this user has a cascading admin role on dept and sem levels
-	];
 	const filter = new CurrentFinalGradesFilter();
 	const data = {
 		getFilter: id => (id === filter.id ? filter : null),

--- a/test/model/data.test.js
+++ b/test/model/data.test.js
@@ -450,13 +450,6 @@ describe('Data', () => {
 		});
 	});
 
-	describe('courseLastAccess', () => {
-		it('should return the correct current final grade bucket counts', async() => {
-			const expected = [39, 7, 0, 0, 1, 1];
-			expect(sut.courseLastAccessDates.toString()).to.deep.equal(expected.toString());
-		});
-	});
-
 	describe('overdueAssignments', () => {
 		it('should return a number of users with overdue assignments', async() => {
 			const expected = 2;

--- a/test/model/mocks.js
+++ b/test/model/mocks.js
@@ -1,0 +1,76 @@
+export const mockOuTypes = {
+	organization: 0,
+	department: 1,
+	course: 2,
+	courseOffering: 3,
+	semester: 5
+};
+
+export const mockRoleIds = {
+	admin: 100,
+	instructor: 200,
+	student: 300
+};
+
+export const records = [
+	[6606, 100, mockRoleIds.student, 0, 22, 2000, 10293819283], // this user has a cascading admin role on dept and sem levels
+	[6606, 200, mockRoleIds.student, 0, 33, 2500, 10293819283],
+	[6606, 300, mockRoleIds.student, 0, 44, 4000, 10293819283],
+	[6606, 400, mockRoleIds.student, 0, 55, 4500, 10293819283], // this user has a cascading admin role on dept and sem levels
+
+	// semesters
+	[11, 100, mockRoleIds.admin, 0, null, 0, null],
+	[12, 100, mockRoleIds.admin, 0, null, 0, null],
+	[13, 100, mockRoleIds.admin, 0, null, 0, null],
+
+	[11, 200, mockRoleIds.student, 0, 33, 0, null],
+	[12, 200, mockRoleIds.instructor, 0, null, 0, null],
+
+	[11, 300, mockRoleIds.student, 0, 100, 0, null],
+	[12, 300, mockRoleIds.student, 0, 100, 0, null],
+	[13, 300, mockRoleIds.student, 0, 100, 0, null],
+
+	[11, 400, mockRoleIds.admin, 0, null, 0, 12392838182],
+	[12, 400, mockRoleIds.admin, 0, null, 0, 12392838182],
+	[13, 400, mockRoleIds.admin, 0, null, 0, null],
+
+	// dept 1
+	[1001, 100, mockRoleIds.admin, 0, null, 0, null],
+	[1001, 200, mockRoleIds.student, 0, 73, 0, null],
+	[1001, 300, mockRoleIds.student, 0, 73, 0, null],
+	// courses
+	[1, 100, mockRoleIds.admin, 0, null, 0, null],
+	[1, 200, mockRoleIds.instructor, 0, null, 0, null],
+	[1, 300, mockRoleIds.student, 1, 41, 3500, null],
+	[2, 100, mockRoleIds.admin, 0, null, 0, null],
+	[2, 200, mockRoleIds.student, 0, 55, 5000, null],
+	[2, 300, mockRoleIds.student, 0, 39, 3000, null],
+	// course 1 offerings
+	[111, 100, mockRoleIds.admin, 0, null, 0, null],
+	[111, 200, mockRoleIds.student, 1, 93, 7000, null],
+	[112, 100, mockRoleIds.admin, 0, null, 0, null],
+	[112, 200, mockRoleIds.instructor, 0, null, 0, null], // this person was promoted from student to instructor
+	[113, 100, mockRoleIds.admin, 0, null, 0, null],
+	[113, 300, mockRoleIds.student, 0, 75, 6000, null],
+	// course 2 offerings
+	[212, 100, mockRoleIds.admin, 0, null, 0, 0],
+	[212, 200, mockRoleIds.student, 0, 84, 4000, null],
+	[212, 300, mockRoleIds.instructor, 0, null, 0, null],
+
+	// dept 2
+	[1002, 200, mockRoleIds.student, 0, 98, 0, null],
+	[1002, 300, mockRoleIds.student, 0, 89, 0, null],
+	[1002, 400, mockRoleIds.admin, 0, null, 0, null],
+	[3, 200, mockRoleIds.student, 0, 98, 0, Date.now() - 299],
+	[3, 300, mockRoleIds.student, 0, 88, 0, Date.now() - 86500000],
+	[3, 400, mockRoleIds.admin, 0, null, 0, null],
+	[311, 200, mockRoleIds.student, 0, 99, 0, null],
+	[311, 300, mockRoleIds.student, 0, 42, 0, null],
+	[311, 400, mockRoleIds.admin, 0, null, 0, null],
+	[313, 300, mockRoleIds.student, 0, 66, 0, null],
+	[313, 400, mockRoleIds.admin, 0, null, 0, null],
+	[6606, 100, mockRoleIds.student, 0, null, 0, null], // this user has a cascading admin role on dept and sem levels
+	[6606, 200, mockRoleIds.student, 0, null, 0, null],
+	[6606, 300, mockRoleIds.student, 0, null, 0, null],
+	[6606, 400, mockRoleIds.student, 0, null, 0, null], // this user has a cascading admin role on dept and sem levels
+];


### PR DESCRIPTION
Regression testing (local e2e):
  * load page; use role and grade filter and confirm last access chart updates
  * w. dummy data for last access, apply filter and confirm other views update

FYI @anhill-D2L @bemailloux @NicholasHallman @rohitvinnakota 