### PR TITLE
Add hover text for discussion activity

### DIFF
--- a/components/discussion-activity-card.js
+++ b/components/discussion-activity-card.js
@@ -131,6 +131,16 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 						enabled: false
 					},
 					showInLegend: true
+				},
+				series: {
+					states: {
+						hover: {
+							enabled: true,
+							halo: {
+								size: 0
+							}
+						}
+					}
 				}
 			},
 			legend: {
@@ -166,7 +176,7 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 						const ix = that._legendLabels[point.index];
 						return `${ix}, ${point.y}.`;
 					}
-				},
+				}
 			},
 			accessibility: {
 				screenReaderSection: {
@@ -189,7 +199,8 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 				style: {
 					color: 'white',
 				},
-				followPointer: false
+				followPointer: false,
+				width: 40
 			},
 			credits: {
 				enabled: false,

--- a/components/discussion-activity-card.js
+++ b/components/discussion-activity-card.js
@@ -84,6 +84,18 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 		return this.localize('components.insights-discussion-activity-card.textLabel');
 	}
 
+	toolTipTextThreads(numberOfUsers) {
+		return this.localize('components.insights-discussion-activity-card.toolTipThreads', { numberOfUsers });
+	}
+
+	toolTipTextReplies(numberOfUsers) {
+		return this.localize('components.insights-discussion-activity-card.toolTipReplies', { numberOfUsers });
+	}
+
+	toolTipTextReads(numberOfUsers) {
+		return this.localize('components.insights-discussion-activity-card.toolTipReads', { numberOfUsers });
+	}
+
 	render() {
 		// NB: relying on mobx rather than lit-element properties to handle update detection: it will trigger a redraw for
 		// any change to a relevant observed property of the Data object
@@ -160,6 +172,24 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 				screenReaderSection: {
 					beforeChartFormat: BEFORE_CHART_FORMAT
 				}
+			},
+			tooltip: {
+				formatter: function() {
+					const seriesIndex = that._legendLabels.indexOf(this.key);
+					if (seriesIndex === 0) {
+						return that.toolTipTextThreads(this.point.y);
+					} else if (seriesIndex === 1) {
+						return that.toolTipTextReplies(this.point.y);
+					}
+					return that.toolTipTextReads(this.point.y);
+				},
+				backgroundColor: 'var(--d2l-color-ferrite)',
+				borderColor: 'var(--d2l-color-ferrite)',
+				borderRadius: 12,
+				style: {
+					color: 'white',
+				},
+				followPointer: false
 			},
 			credits: {
 				enabled: false,

--- a/locales/en.js
+++ b/locales/en.js
@@ -97,6 +97,10 @@ export default {
 	"components.insights-discussion-activity-card.reads": "Reads",
 	"components.insights-discussion-activity-card.textLabel": "This chart displays the total number of threads, replies, and reads in discussion forums for all users in the selected courses",
 
+	"components.insights-discussion-activity-card.toolTipThreads": "{numberOfUsers} threads have been created by the returned users",
+	"components.insights-discussion-activity-card.toolTipReplies": "{numberOfUsers} posts have been replied to by the returned users",
+	"components.insights-discussion-activity-card.toolTipReads": "{numberOfUsers} posts have been read by the returned users",
+
 	"components.insights-applied-filters.clear-all": "Clear all",
 
 	"components.insights-aria-loading-progress.loading-start": "Loading is in progress",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21348406/96723691-dc6dfc00-137c-11eb-9f65-9d2b4751cc96.png)

[US118261](https://rally1.rallydev.com/#/detail/userstory/402806086044?fdp=true): [Engagement][Cards] Discussion Activity Hover Text

Quality Notes
-> Changed hover behavior so it doesn't create generate a ~shadow thing~ halo when hovering over slices to match the design here:
https://xd.adobe.com/view/cf5c5823-d1c3-47eb-45b6-8297bf92f944-b96d/screen/e6aa869d-2268-4f7f-a405-1d3c9f9a879b/

Functional testing
Tested the following cases
-> Tested on edge, chrome, and firefox
-> Data changes with filters
-> Data changes when filtering by clicking on legend

Accessibility
->No impact on accessibility. We have separate options for those 

Security: n/a

 Perf testing
Devops: n/a
UX: 
- [x] demo to kevin 

fyi: @Vitalii-Misechko @MykolaGalian @NicholasHallman @hyehayes @anhill-D2L 