### PR TITLE
US118258 Link to documentation 

### DIFF
--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -71,6 +71,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					font-weight: normal;	/* default for h1 is bold */
 					margin: 0.67em 0;		/* required to be explicitly defined for Edge Legacy */
 					padding: 0;				/* required to be explicitly defined for Edge Legacy */
+					width: 65%;
 				}
 
 				h2.d2l-heading-3 {
@@ -86,6 +87,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				.d2l-button-group {
 					flex-grow: 1;
 					margin: 0.7em;
+					width: 25%;
 				}
 
 				@media screen and (max-width: 615px) {

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -52,7 +52,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 
 				d2l-action-button-group {
 					float: right;
-					margin: 0.9em;
+					margin: 2em;
 				}
 
 				.d2l-insights-chart-container {
@@ -72,11 +72,9 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				}
 
 				h1.d2l-heading-1 {
-					float: left;
 					font-weight: normal;	/* default for h1 is bold */
 					margin: 0.67em 0;		/* required to be explicitly defined for Edge Legacy */
 					padding: 0;				/* required to be explicitly defined for Edge Legacy */
-					width: 70%;
 				}
 
 				h2.d2l-heading-3 {
@@ -101,8 +99,6 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 		return html`
 				<d2l-insights-aria-loading-progress .data="${this._data}"></d2l-insights-aria-loading-progress>
 
-				<h1 class="d2l-heading-1">${this.localize('components.insights-engagement-dashboard.title')}</h1>
-
 				<d2l-action-button-group min-to-show="1" max-to-show="4">
 					<d2l-button-subtle
 						icon="d2l-tier1:help"
@@ -110,6 +106,8 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 						onclick="location.href='https://community.brightspace.com/s/article/Brightspace-Performance-Plus-Analytics-Administrator-Guide';">
 					</d2l-button-subtle>
 				</d2l-action-button-group>
+
+				<h1 class="d2l-heading-1">${this.localize('components.insights-engagement-dashboard.title')}</h1>
 
 				<div class="view-filters-container">
 					<d2l-insights-ou-filter

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -52,7 +52,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 
 				d2l-action-button-group {
 					float: right;
-					margin: 0.67em 0;
+					margin: 0.7em;
 				}
 
 				.d2l-insights-chart-container {
@@ -71,7 +71,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					width: 100%;
 				}
 
-				.title-container {
+				.d2l-insights-title-container {
 					float: left;
 					width: 80%;
 				}
@@ -103,7 +103,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 	render() {
 		return html`
 				<d2l-insights-aria-loading-progress .data="${this._data}"></d2l-insights-aria-loading-progress>
-				<div class="title-container">
+				<div class="d2l-insights-title-container">
 					<h1 class="d2l-heading-1">${this.localize('components.insights-engagement-dashboard.title')}</h1>
 				</div>
 				<d2l-action-button-group min-to-show="1" max-to-show="4">

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -77,15 +77,15 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					margin-bottom: 1rem; /* default for d2l h3 style is 1.5 rem */
 				}
 
-				.heading-button-group {
+				.d2l-heading-button-group {
 					display: flex;
 					flex-direction: row;
 					flex-wrap: wrap;
 				}
 
-				.button-group {
-					margin: 0.7em;
+				.d2l-button-group {
 					flex-grow: 1;
+					margin: 0.7em;
 				}
 
 				@media screen and (max-width: 615px) {
@@ -106,9 +106,9 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 		return html`
 				<d2l-insights-aria-loading-progress .data="${this._data}"></d2l-insights-aria-loading-progress>
 
-				<div class="heading-button-group">
+				<div class="d2l-heading-button-group">
 					<h1 class="d2l-heading-1">${this.localize('components.insights-engagement-dashboard.title')}</h1>
-					<div class="button-group">
+					<div class="d2l-button-group">
 						<d2l-action-button-group min-to-show="0" max-to-show="2" opener-type="more">
 							<d2l-button-subtle
 								icon="d2l-tier1:print"

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -84,7 +84,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					flex-wrap: wrap;
 				}
 
-				.d2l-button-group {
+				d2l-action-button-group {
 					flex-grow: 1;
 					margin: 0.7em;
 					width: 25%;
@@ -110,19 +110,17 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 
 				<div class="d2l-heading-button-group">
 					<h1 class="d2l-heading-1">${this.localize('components.insights-engagement-dashboard.title')}</h1>
-					<div class="d2l-button-group">
-						<d2l-action-button-group min-to-show="0" max-to-show="2" opener-type="more">
-							<d2l-button-subtle
-								icon="d2l-tier1:export"
-								text=${this.localize('components.insights-engagement-dashboard.exportToCsv')}>
-							</d2l-button-subtle>
-							<d2l-button-subtle
-								icon="d2l-tier1:help"
-								text=${this.localize('components.insights-engagement-dashboard.learMore')}
-								onclick="location.href='https://community.brightspace.com/s/article/Brightspace-Performance-Plus-Analytics-Administrator-Guide';">
-							</d2l-button-subtle>
-						</d2l-action-button-group>
-					</div>
+					<d2l-action-button-group min-to-show="0" max-to-show="2" opener-type="more">
+						<d2l-button-subtle
+							icon="d2l-tier1:export"
+							text=${this.localize('components.insights-engagement-dashboard.exportToCsv')}>
+						</d2l-button-subtle>
+						<d2l-button-subtle
+							icon="d2l-tier1:help"
+							text=${this.localize('components.insights-engagement-dashboard.learMore')}
+							onclick="location.href='https://community.brightspace.com/s/article/Brightspace-Performance-Plus-Analytics-Administrator-Guide';">
+						</d2l-button-subtle>
+					</d2l-action-button-group>
 				</div>
 
 				<div class="view-filters-container">

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -111,8 +111,8 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					<div class="d2l-button-group">
 						<d2l-action-button-group min-to-show="0" max-to-show="2" opener-type="more">
 							<d2l-button-subtle
-								icon="d2l-tier1:print"
-								text=${this.localize('components.insights-engagement-dashboard.print')}>
+								icon="d2l-tier1:export"
+								text=${this.localize('components.insights-engagement-dashboard.exportToCsv')}>
 							</d2l-button-subtle>
 							<d2l-button-subtle
 								icon="d2l-tier1:help"

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -51,7 +51,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				}
 
 				d2l-action-button-group {
-					float:right;
+					float: right;
 					margin: 0.67em 0;
 				}
 
@@ -69,6 +69,11 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				.d2l-insights-summary-container-applied-filters {
 					height: auto;
 					width: 100%;
+				}
+
+				.title-container {
+					float: left;
+					width: 80%;
 				}
 
 				h1.d2l-heading-1 {
@@ -90,11 +95,6 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 						display: block;
 						padding: 0 18px;
 					}
-				}
-
-				.title-container {
-					float:left;
-					width: 80%;
 				}
 			`
 		];

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -50,6 +50,11 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					display: none;
 				}
 
+				d2l-action-button-group {
+					float:right;
+					margin: 0.67em 0;
+				}
+
 				.d2l-insights-chart-container {
 					display: flex;
 					flex-wrap: wrap;
@@ -86,6 +91,11 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 						padding: 0 18px;
 					}
 				}
+
+				.title-container {
+					float:left;
+					width: 80%;
+				}
 			`
 		];
 	}
@@ -93,8 +103,15 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 	render() {
 		return html`
 				<d2l-insights-aria-loading-progress .data="${this._data}"></d2l-insights-aria-loading-progress>
-
-				<h1 class="d2l-heading-1">${this.localize('components.insights-engagement-dashboard.title')}</h1>
+				<div class="title-container">
+					<h1 class="d2l-heading-1">${this.localize('components.insights-engagement-dashboard.title')}</h1>
+				</div>
+				<d2l-action-button-group min-to-show="1" max-to-show="4">
+					<d2l-button-subtle
+					icon="d2l-tier1:help"
+					text="Help"
+					onclick="location.href='https://community.brightspace.com/s/article/Brightspace-Performance-Plus-Analytics-Administrator-Guide';"></d2l-button-subtle>
+				</d2l-action-button-group>
 
 				<div class="view-filters-container">
 					<d2l-insights-ou-filter

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -52,7 +52,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 
 				d2l-action-button-group {
 					float: right;
-					margin: 0.7em;
+					margin: 0.9em;
 				}
 
 				.d2l-insights-chart-container {
@@ -71,15 +71,12 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					width: 100%;
 				}
 
-				.d2l-insights-title-container {
-					float: left;
-					width: 80%;
-				}
-
 				h1.d2l-heading-1 {
+					float: left;
 					font-weight: normal;	/* default for h1 is bold */
 					margin: 0.67em 0;		/* required to be explicitly defined for Edge Legacy */
 					padding: 0;				/* required to be explicitly defined for Edge Legacy */
+					width: 70%;
 				}
 
 				h2.d2l-heading-3 {
@@ -103,13 +100,13 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 	render() {
 		return html`
 				<d2l-insights-aria-loading-progress .data="${this._data}"></d2l-insights-aria-loading-progress>
-				<div class="d2l-insights-title-container">
-					<h1 class="d2l-heading-1">${this.localize('components.insights-engagement-dashboard.title')}</h1>
-				</div>
+
+				<h1 class="d2l-heading-1">${this.localize('components.insights-engagement-dashboard.title')}</h1>
+
 				<d2l-action-button-group min-to-show="1" max-to-show="4">
 					<d2l-button-subtle
 					icon="d2l-tier1:help"
-					text="Help"
+					text="Learn More"
 					onclick="location.href='https://community.brightspace.com/s/article/Brightspace-Performance-Plus-Analytics-Administrator-Guide';"></d2l-button-subtle>
 				</d2l-action-button-group>
 

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -105,9 +105,10 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 
 				<d2l-action-button-group min-to-show="1" max-to-show="4">
 					<d2l-button-subtle
-					icon="d2l-tier1:help"
-					text="Learn More"
-					onclick="location.href='https://community.brightspace.com/s/article/Brightspace-Performance-Plus-Analytics-Administrator-Guide';"></d2l-button-subtle>
+						icon="d2l-tier1:help"
+						text=${this.localize('components.insights-engagement-dashboard.learMore')}
+						onclick="location.href='https://community.brightspace.com/s/article/Brightspace-Performance-Plus-Analytics-Administrator-Guide';">
+					</d2l-button-subtle>
 				</d2l-action-button-group>
 
 				<div class="view-filters-container">

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -11,6 +11,7 @@ import './components/applied-filters';
 import './components/aria-loading-progress';
 import './components/course-last-access-card.js';
 import './components/discussion-activity-card.js';
+import 'd2l-button-group/d2l-action-button-group';
 
 import './components/default-view-popup.js';
 import './components/last-access-card';
@@ -50,11 +51,6 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					display: none;
 				}
 
-				d2l-action-button-group {
-					float: right;
-					margin: 2em;
-				}
-
 				.d2l-insights-chart-container {
 					display: flex;
 					flex-wrap: wrap;
@@ -81,6 +77,17 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					margin-bottom: 1rem; /* default for d2l h3 style is 1.5 rem */
 				}
 
+				.heading-button-group {
+					display: flex;
+					flex-direction: row;
+					flex-wrap: wrap;
+				}
+
+				.button-group {
+					margin: 0.7em;
+					flex-grow: 1;
+				}
+
 				@media screen and (max-width: 615px) {
 					h1 {
 						line-height: 2rem;
@@ -99,15 +106,22 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 		return html`
 				<d2l-insights-aria-loading-progress .data="${this._data}"></d2l-insights-aria-loading-progress>
 
-				<d2l-action-button-group min-to-show="1" max-to-show="4">
-					<d2l-button-subtle
-						icon="d2l-tier1:help"
-						text=${this.localize('components.insights-engagement-dashboard.learMore')}
-						onclick="location.href='https://community.brightspace.com/s/article/Brightspace-Performance-Plus-Analytics-Administrator-Guide';">
-					</d2l-button-subtle>
-				</d2l-action-button-group>
-
-				<h1 class="d2l-heading-1">${this.localize('components.insights-engagement-dashboard.title')}</h1>
+				<div class="heading-button-group">
+					<h1 class="d2l-heading-1">${this.localize('components.insights-engagement-dashboard.title')}</h1>
+					<div class="button-group">
+						<d2l-action-button-group min-to-show="0" max-to-show="2" opener-type="more">
+							<d2l-button-subtle
+								icon="d2l-tier1:print"
+								text=${this.localize('components.insights-engagement-dashboard.print')}>
+							</d2l-button-subtle>
+							<d2l-button-subtle
+								icon="d2l-tier1:help"
+								text=${this.localize('components.insights-engagement-dashboard.learMore')}
+								onclick="location.href='https://community.brightspace.com/s/article/Brightspace-Performance-Plus-Analytics-Administrator-Guide';">
+							</d2l-button-subtle>
+						</d2l-action-button-group>
+					</div>
+				</div>
 
 				<div class="view-filters-container">
 					<d2l-insights-ou-filter

--- a/locales/en.js
+++ b/locales/en.js
@@ -8,6 +8,7 @@ export default {
 	"components.insights-engagement-dashboard.overdueAssignmentsHeading": "Overdue Assignments",
 	"components.insights-engagement-dashboard.lastSystemAccess": "Users have no system access in the last 14 days.",
 	"components.insights-engagement-dashboard.lastSystemAccessHeading": "System Access",
+	"components.insights-engagement-dashboard.learMore": "Learn More",
 
 	"components.insights-role-filter.name": "Role",
 

--- a/locales/en.js
+++ b/locales/en.js
@@ -9,6 +9,7 @@ export default {
 	"components.insights-engagement-dashboard.lastSystemAccess": "Users have no system access in the last 14 days.",
 	"components.insights-engagement-dashboard.lastSystemAccessHeading": "System Access",
 	"components.insights-engagement-dashboard.learMore": "Learn More",
+	"components.insights-engagement-dashboard.print": "Print",
 
 	"components.insights-role-filter.name": "Role",
 

--- a/locales/en.js
+++ b/locales/en.js
@@ -9,7 +9,7 @@ export default {
 	"components.insights-engagement-dashboard.lastSystemAccess": "Users have no system access in the last 14 days.",
 	"components.insights-engagement-dashboard.lastSystemAccessHeading": "System Access",
 	"components.insights-engagement-dashboard.learMore": "Learn More",
-	"components.insights-engagement-dashboard.print": "Print",
+	"components.insights-engagement-dashboard.exportToCsv": "Export to CSV",
 
 	"components.insights-role-filter.name": "Role",
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "highcharts": "^8.1.2",
     "lit-element": "^2",
     "lit-html": "^1.3.0",
-    "mobx": "^5.15.4"
+    "mobx": "^5.15.4",
+    "d2l-button-group": "BrightspaceUI/button-group#semver:^3"
   }
 }


### PR DESCRIPTION


[US118258](https://rally1.rallydev.com/#/detail/userstory/402800588876?fdp=true): [Engagement] Link to documentation
AC:
Hyperlink called "Learn More" and "Export to CSV" button.
Link out to https://community.brightspace.com/s/article/Brightspace-Performance-Plus-Analytics-Administrator-Guide in another tab.

![1d](https://user-images.githubusercontent.com/27500223/97051848-9ab1a100-1588-11eb-969b-c409402a8438.gif)

UX demo: in progress


FYI @anhill-D2L @NicholasHallman @rohitvinnakota @johngwilkinson 