### PR TITLE
US120286 Table Sort Accessibility

### DIFF
--- a/components/table.js
+++ b/components/table.js
@@ -216,8 +216,8 @@ class Table extends SkeletonMixin(Localizer(RtlMixin(LitElement))) {
 		return html`
 			<th role="button" class="${classMap(styles)}" scope="col" @keydown="${this._handleHeaderKey}" @click="${this._handleHeaderClicked}" tabindex="${this.skeleton ? -1 : 0}">
 				${info.headerText}
-				${!isSortedColumn ? html`` : html`<d2l-icon icon="tier1:${arrowDirection}" class="${classMap(spaceArrow)}"></d2l-icon>`}
-				${isSortedColumn ? html`<p class="d2l-insights-table-visuallyhidden">${arrowDirection === 'arrow-toggle-up' ? 'Sorted Ascending' : 'Sorted Descending'}</p>` : '' }
+				${!isSortedColumn ? html`` : html`<d2l-icon role="img" aria-label="${arrowDirection === 'arrow-toggle-up' ? 'Sorted Ascending' : 'Sorted Descending'}" icon="tier1:${arrowDirection}" class="${classMap(spaceArrow)}"></d2l-icon>`}
+
 			</th>
 		`;
 	}

--- a/components/table.js
+++ b/components/table.js
@@ -153,6 +153,9 @@ class Table extends SkeletonMixin(Localizer(RtlMixin(LitElement))) {
 			.d2l-insights-table-arrow-spacing {
 				padding-right: 30px;
 			}
+			.d2l-insights-table-visuallyhidden {
+				display: none;
+			}
 		`];
 	}
 
@@ -211,9 +214,10 @@ class Table extends SkeletonMixin(Localizer(RtlMixin(LitElement))) {
 		const arrowDirection = isSortedColumn ? this.sortOrder === 'desc' ? 'arrow-toggle-down' : 'arrow-toggle-up' : '';
 
 		return html`
-			<th class="${classMap(styles)}" scope="col" @keydown="${this._handleHeaderKey}" @click="${this._handleHeaderClicked}" tabindex="${this.skeleton ? -1 : 0}">
+			<th role="button" class="${classMap(styles)}" scope="col" @keydown="${this._handleHeaderKey}" @click="${this._handleHeaderClicked}" tabindex="${this.skeleton ? -1 : 0}">
 				${info.headerText}
 				${!isSortedColumn ? html`` : html`<d2l-icon icon="tier1:${arrowDirection}" class="${classMap(spaceArrow)}"></d2l-icon>`}
+				${isSortedColumn ? html`<p class="d2l-insights-table-visuallyhidden">${arrowDirection === 'arrow-toggle-up' ? 'Sorted Ascending' : 'Sorted Descending'}</p>` : '' }
 			</th>
 		`;
 	}

--- a/components/table.js
+++ b/components/table.js
@@ -153,9 +153,6 @@ class Table extends SkeletonMixin(Localizer(RtlMixin(LitElement))) {
 			.d2l-insights-table-arrow-spacing {
 				padding-right: 30px;
 			}
-			.d2l-insights-table-visuallyhidden {
-				display: none;
-			}
 		`];
 	}
 


### PR DESCRIPTION
Added screen reader accessibility to the user table sort arrows, reads out the sort order when the column header is focused if the header is sorted.