### PR TITLE
US119012: fix grades card selection colouring

### DIFF
--- a/test/components/current-final-grade-card.test.js
+++ b/test/components/current-final-grade-card.test.js
@@ -33,6 +33,24 @@ describe('d2l-insights-current-final-grade-card', () => {
 			expect(title[0].innerText).to.equal('Current Grade');
 			const expected = [20, 30, 40, 50, 30, 90, 90, 90, 70, 70, 40, 50, 30, 90, 70, 80, 90, 80, 90, 80, 90, 40, 60];
 			expect(el._preparedHistogramData).to.deep.equal(expected);
+			expect(el._colours).to.deep.equal(['var(--d2l-color-amethyst)']);
+		});
+
+		it('should colour selected bars', async() => {
+			filter.selectCategory(30);
+			filter.selectCategory(50);
+			const el = await fixture(html`<d2l-insights-current-final-grade-card .data="${data}"></d2l-insights-current-final-grade-card>`);
+			// only the first 8 colours matter (from 20 to 90)
+			expect(el._colours.slice(0, 8)).to.deep.equal([
+				'var(--d2l-color-mica)',
+				'var(--d2l-color-amethyst)',
+				'var(--d2l-color-mica)',
+				'var(--d2l-color-amethyst)',
+				'var(--d2l-color-mica)',
+				'var(--d2l-color-mica)',
+				'var(--d2l-color-mica)',
+				'var(--d2l-color-mica)'
+			]);
 		});
 
 		it('should exclude chart form tabindex when data is loading', async() => {


### PR DESCRIPTION
The problem was that selections weren't triggering a change because `filter.selectedCategories` was not accessed inside `render()`, but in a callback that happened later.

Pattern that seems to avoid this kind of problem: whenever possible, the full state of the chart should be a function of the mobx state, with callbacks doing nothing but altering that state (which forces a call to render).

This would be easier if we weren't using the histogram module at all (it doesn't buy us much), but I didn't want to fiddle with the layout in switching to a column chart.

Quality Notes:
* functional
  * e2e with canned and local LMS data
  * select individual and multiple bars and check colouring
  * clear and check colouring
  * with canned data not including extremes (note: the histogram module only renders 0 bars in-between non-zero ones)
  * select 0 bars
* devops, security, ux/docs: no change, except last-clicked bar no longer gets an outline (keyboard nav is not affected by this)
* perf: confirmed no extra calls to `_preparedHistogramData()`

FYI @bemailloux @MykolaGalian @NicholasHallman @Vitalii-Misechko 