### PR TITLE
US119012: fix last course access selection colouring

### DIFF
--- a/components/course-last-access-card.js
+++ b/components/course-last-access-card.js
@@ -117,6 +117,17 @@ class CourseLastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 		return dateBucketCounts;
 	}
 
+	get _colours() {
+		if (!this.isApplied) return ['var(--d2l-color-celestine)'];
+
+		return [0, 1, 2, 3, 4, 5]
+			.map(category =>
+				(this.category.has(category) ?
+					'var(--d2l-color-celestine)' :
+					'var(--d2l-color-mica)')
+			);
+	}
+
 	get _accessibilityLessThanOneLabel() {
 		return this.localize('components.insights-course-last-access-card.accessibilityLessThanOne');
 	}
@@ -170,26 +181,6 @@ class CourseLastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 		return this.filter.selectedCategories;
 	}
 
-	_colorNonSelectedPoints(seriesData, color) {
-		seriesData.forEach(point => {
-			if (!this.category.has(point.index)) this._pointUpdateColor(point, color);
-		});
-	}
-
-	_colorSelectedPoints(seriesData, color) {
-		seriesData.forEach(point => {
-			if (this.category.has(point.index)) this._pointUpdateColor(point, color);
-		});
-	}
-
-	_colorAllPoints(seriesData, color) {
-		seriesData.forEach(point => this._pointUpdateColor(point, color));
-	}
-
-	_pointUpdateColor(point, colorForPoint) {
-		point.update({ color: colorForPoint }, false);
-	}
-
 	render() {
 		// NB: relying on mobx rather than lit-element properties to handle update detection: it will trigger a redraw for
 		// any change to a relevant observed property of the Data object
@@ -204,21 +195,7 @@ class CourseLastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 		return {
 			chart: {
 				type: 'bar',
-				height: '250px',
-				events: {
-					render: function() {
-						//after redrawing the chart as a result of updating (for example, when the user disable any of the filters),
-						// we need to keep the color of the selected/nonselected bars
-						if (that.isApplied) {
-							that._colorNonSelectedPoints(this.series[0].data, 'var(--d2l-color-mica)');
-							that._colorSelectedPoints(this.series[0].data, 'var(--d2l-color-celestine)');
-						} else {
-							that._colorAllPoints(this.series[0].data, 'var(--d2l-color-celestine)');
-						}
-						// noinspection JSPotentiallyInvalidUsageOfClassThis
-						this.render(false);
-					}
-				}
+				height: '250px'
 			},
 			animation: false,
 			tooltip: {
@@ -299,18 +276,12 @@ class CourseLastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 							return `${that._cardCategoriesText[point.x]}, ${that._horizontalLabel}, ${val}.`;
 						}
 					},
-					allowPointSelect: true,
-					color: 'var(--d2l-color-celestine)',
-					states: {
-						select: {
-							color: 'var(--d2l-color-celestine)'
-						}
-					},
+					colorByPoint: true,
+					colors: this._colours,
 					point: {
 						events: {
-							select: function() {
+							click: function() {
 								that.addToCategory(this.index);
-								that._colorSelectedPoints(this.series.data, 'var(--d2l-color-celestine)');
 							}
 						}
 					}

--- a/test/components/course-last-access-card.test.js
+++ b/test/components/course-last-access-card.test.js
@@ -32,6 +32,21 @@ describe('d2l-insights-course-last-access-card', () => {
 			const title = (el.shadowRoot.querySelectorAll('div.d2l-insights-course-last-access-title'));
 			expect(title[0].innerText).to.equal('Course Access');
 			expect(el._preparedBarChartData.toString()).to.equal([39, 7, 0, 0, 1, 1].toString());
+			expect(el._colours).to.deep.equal(['var(--d2l-color-celestine)']);
+		});
+
+		it('should render selected colours', async() => {
+			filter.selectCategory(1);
+			filter.selectCategory(5);
+			const el = await fixture(html`<d2l-insights-course-last-access-card .data="${data}"></d2l-insights-course-last-access-card>`);
+			expect(el._colours).to.deep.equal([
+				'var(--d2l-color-mica)',
+				'var(--d2l-color-celestine)',
+				'var(--d2l-color-mica)',
+				'var(--d2l-color-mica)',
+				'var(--d2l-color-mica)',
+				'var(--d2l-color-celestine)'
+			]);
 		});
 	});
 


### PR DESCRIPTION
See #111 for general notes.

Quality Notes
* functional
  * e2e and demo data
  * select 0-valued and non-zero bars
  * select single and several, including extremes
  * with another filter on, select a bar that has a zero value, then clear the other filter so it is non-zero
* devops, security, perf: n/a
* ux/docs: last-clicked bar is not outlined anymore; does not affect keyboard navigation

FYI @anhill-D2L @bemailloux @MykolaGalian @rohitvinnakota 