### PR TITLE
US121664: clear button for ou filter

### DIFF
--- a/components/tree-filter.js
+++ b/components/tree-filter.js
@@ -180,6 +180,10 @@ export class Tree {
 		this._ancestors = new Map();
 	}
 
+	clearSelection() {
+		this._state.clear();
+	}
+
 	getAncestorIds(id) {
 		if (id === 0) return new Set();
 
@@ -409,6 +413,7 @@ decorate(Tree, {
 	_hasMore: observable,
 	selected: computed,
 	addNodes: action,
+	clearSelection: action,
 	setAncestorFilter: action,
 	setLoading: action,
 	setOpen: action,
@@ -514,7 +519,9 @@ class TreeFilter extends Localizer(MobxLitElement) {
 		return html`<d2l-insights-tree-selector
 				name="${openerText}"
 				?search="${this._isSearch}"
+				?selected="${this.tree.selected.length > 0}"
 				@d2l-insights-tree-selector-search="${this._onSearch}"
+				@d2l-insights-tree-selector-clear="${this._onClear}"
 			>
 				${this._renderSearchResults()}
 				${this._renderSearchLoadingControls()}
@@ -627,6 +634,12 @@ class TreeFilter extends Localizer(MobxLitElement) {
 			});
 	}
 
+	_onClear(event) {
+		event.stopPropagation();
+		this.tree.clearSelection();
+		this._fireSelectEvent();
+	}
+
 	_onOpen(event) {
 		event.stopPropagation();
 		this._needResize = true;
@@ -669,7 +682,10 @@ class TreeFilter extends Localizer(MobxLitElement) {
 	_onSelect(event) {
 		event.stopPropagation();
 		this.tree.setSelected(event.detail.id, event.detail.isSelected);
+		this._fireSelectEvent();
+	}
 
+	_fireSelectEvent() {
 		/**
 		 * @event d2l-insights-tree-filter-select
 		 */

--- a/components/tree-selector.js
+++ b/components/tree-selector.js
@@ -47,9 +47,9 @@ class TreeSelector extends Localizer(LitElement) {
 				.d2l-insights-tree-selector-search {
 					display: flex;
 					flex-wrap: nowrap;
-					width: 334px;
-					padding-top: 4px;
 					padding-bottom: 26px;
+					padding-top: 4px;
+					width: 334px;
 				}
 
 				:host([search]) d2l-dropdown d2l-dropdown-content .d2l-insights-tree-selector-tree {

--- a/components/tree-selector.js
+++ b/components/tree-selector.js
@@ -11,14 +11,17 @@ import { selectStyles } from '@brightspace-ui/core/components/inputs/input-selec
 /**
  * @property {String} name
  * @property {Boolean} isSearch - if true, show "search-results" slot instead of "tree" slot
+ * @property {Boolean} isSelected - if true, show a "Clear" button in the header
  * @fires d2l-insights-tree-selector-search - user requested or cleared a search; search string is event.detail.value
+ * @fires d2l-insights-tree-selector-clear - user requested that all selections be cleared
  */
 class TreeSelector extends Localizer(LitElement) {
 
 	static get properties() {
 		return {
 			name: { type: String },
-			isSearch: { type: Boolean, attribute: 'search', reflect: true }
+			isSearch: { type: Boolean, attribute: 'search', reflect: true },
+			isSelected: { type: Boolean, attribute: 'selected', reflect: true }
 		};
 	}
 
@@ -33,10 +36,20 @@ class TreeSelector extends Localizer(LitElement) {
 					display: none;
 				}
 
+				.d2l-filter-dropdown-content-header {
+					display: flex;
+					justify-content: space-between;
+				}
+				.d2l-filter-dropdown-content-header > span {
+					align-self: center;
+				}
+
 				.d2l-insights-tree-selector-search {
 					display: flex;
 					flex-wrap: nowrap;
 					width: 334px;
+					padding-top: 4px;
+					padding-bottom: 26px;
 				}
 
 				:host([search]) d2l-dropdown d2l-dropdown-content .d2l-insights-tree-selector-tree {
@@ -75,7 +88,15 @@ class TreeSelector extends Localizer(LitElement) {
 			<d2l-dropdown>
 				<d2l-dropdown-button-subtle text="${this.name}">
 					<d2l-dropdown-content align="start" no-auto-fit>
-						<div class="d2l-insights-tree-selector-search" slot="header">
+						<div class="d2l-filter-dropdown-content-header" slot="header">
+							<span>${this.localize('components.tree-selector.filterBy')}</span>
+							<d2l-button-subtle
+							 	text="${this.localize('components.tree-selector.clear-label')}"
+							 	?hidden="${!this.isSelected}"
+							 	@click="${this._onClear}"
+							></d2l-button-subtle>
+						</div>
+						<div class="d2l-insights-tree-selector-search">
 							<d2l-input-search
 								label="${this.localize('components.tree-selector.search-label')}"
 								placeholder="${this.localize('components.tree-selector.search-placeholder')}"
@@ -106,6 +127,19 @@ class TreeSelector extends Localizer(LitElement) {
 		await this.treeUpdateComplete;
 		const content = this.shadowRoot.querySelector('d2l-dropdown-content');
 		content && await content.resize();
+	}
+
+	_onClear() {
+		/**
+		 * @event d2l-insights-tree-selector-clear
+		 */
+		this.dispatchEvent(new CustomEvent(
+			'd2l-insights-tree-selector-clear',
+			{
+				bubbles: true,
+				composed: false
+			}
+		));
 	}
 
 	_onSearch(event) {

--- a/locales/en.js
+++ b/locales/en.js
@@ -29,6 +29,8 @@ export default {
 
 	"components.tree-filter.node-name": "{orgUnitName} (Id: {id})",
 	"components.tree-filter.node-name.root": "root",
+	"components.tree-selector.filterBy": "Filter By",
+	"components.tree-selector.clear-label": "Clear",
 	"components.tree-selector.search-label": "Search",
 	"components.tree-selector.load-more-label": "Load More",
 	"components.tree-selector.parent-load-more.aria-label": "Load more child org units",

--- a/test/components/tree-filter.test.js
+++ b/test/components/tree-filter.test.js
@@ -123,6 +123,11 @@ describe('Tree', () => {
 			expect(tree.selected.sort()).to.deep.equal([1002, 111]);
 		});
 
+		it('should clear selection', () => {
+			dynamicTree.clearSelection();
+			expect(dynamicTree.selected).to.be.empty;
+		});
+
 		it('should set selected nodes', () => {
 			const tree = new Tree({ nodes, invisibleTypes });
 			tree.setSelected(111, true);
@@ -808,6 +813,17 @@ describe('d2l-insights-tree-filter', () => {
 
 		it('should fire d2l-insights-tree-selector-change on deselection', async() => {
 			await expectEvent(3);
+		});
+
+		it('should clear and fire d2l-insights-tree-filter-select on clear', async() => {
+			const listener = oneEvent(el, 'd2l-insights-tree-filter-select');
+			const selector = el.shadowRoot.querySelector('d2l-insights-tree-selector');
+			const button = selector.shadowRoot.querySelector('d2l-dropdown-content d2l-button-subtle');
+			button.click();
+			const event = await listener;
+			expect(event.type).to.equal('d2l-insights-tree-filter-select');
+			expect(event.target).to.equal(el);
+			expect(el.tree.selected).to.be.empty;
 		});
 
 		it('should immediately fire d2l-insights-tree-filter-request-children for root of dynamic tree', async() => {

--- a/test/components/tree-selector.test.js
+++ b/test/components/tree-selector.test.js
@@ -69,5 +69,15 @@ describe('d2l-insights-tree-selector', () => {
 				value: 'asdf'
 			});
 		});
+
+		it('should fire d2l-insights-tree-selector-clear on clear', async() => {
+			const el = await fixture(html`<d2l-insights-tree-selector name="choose!" selected></d2l-insights-tree-selector>`);
+			const listener = oneEvent(el, 'd2l-insights-tree-selector-clear');
+			const button = el.shadowRoot.querySelector('d2l-dropdown-content d2l-button-subtle');
+			button.click();
+			const event = await listener;
+			expect(event.type).to.equal('d2l-insights-tree-selector-clear');
+			expect(event.target).to.equal(el);
+		});
 	});
 });


### PR DESCRIPTION
Quality Notes
* functional
  * clear default view: semesters first, ou first
  * select ous then clear (not default view)
  * select ous deeper in three, then clear
  * clear button is visible only when items are selected
* security, perf, devops: n/a
* ux/docs
  - [x] designer approval
  - keyboard nav & screen-reader works
  - [x] cross-browser testing

FYI @anhill-D2L @MykolaGalian @NicholasHallman @Vitalii-Misechko 

![image](https://user-images.githubusercontent.com/11181217/97462960-a2b96a00-1915-11eb-95b7-3c73a540d989.png)
