### PR TITLE
US119022 Page load telemetry

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -19,7 +19,7 @@
 					console.dir(body);
 
 					// verifies that only telemetry is sent on demo page
-					const endpoint = 'https://endpoint.com/api/events/';
+					const endpoint = 'https://example.com/api/events/';
 					console.assert(url === endpoint, { endpoint, body });
 					return true;
 				},
@@ -37,7 +37,7 @@
 		<d2l-demo-page page-title="d2l-insights-engagement-dashboard">
 			<h2>d2l-insights-engagement-dashboard</h2>
 			<d2l-demo-snippet>
-				<d2l-insights-engagement-dashboard demo telemetry-endpoint="https://endpoint.com/api/events/" telemetry-id="cfc669e0-509e-4ed0-b932-4a7ec5c2d8c7"></d2l-insights-engagement-dashboard>
+				<d2l-insights-engagement-dashboard demo telemetry-endpoint="https://example.com/api/events/" telemetry-id="cfc669e0-509e-4ed0-b932-4a7ec5c2d8c7"></d2l-insights-engagement-dashboard>
 			</d2l-demo-snippet>
 		</d2l-demo-page>
 	</body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,6 +6,27 @@
 		<script type="module">
 			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../engagement-dashboard.js';
+			import fetchMock from 'fetch-mock/esm/client';
+
+			// setup fetchMock to print network comunication for demo purposes
+			const fetch = fetchMock.sandbox();
+
+			fetch.mock(
+				async(url, opts) => {
+					console.log(`${opts.method} ${url}`);
+					console.dir('Body: ');
+					const body = JSON.parse(await opts.body);
+					console.dir(body);
+
+					// verifies that only telemetry is sent on demo page
+					const endpoint = 'https://endpoint.com/api/events/';
+					console.assert(url === endpoint, { endpoint, body });
+					return true;
+				},
+				200
+			);
+
+			window.d2lfetch = { fetch };
 		</script>
 		<title>d2l-insights-engagement-dashboard</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -16,7 +37,7 @@
 		<d2l-demo-page page-title="d2l-insights-engagement-dashboard">
 			<h2>d2l-insights-engagement-dashboard</h2>
 			<d2l-demo-snippet>
-				<d2l-insights-engagement-dashboard demo></d2l-insights-engagement-dashboard>
+				<d2l-insights-engagement-dashboard demo telemetry-endpoint="https://endpoint.com/api/events/" telemetry-id="cfc669e0-509e-4ed0-b932-4a7ec5c2d8c7"></d2l-insights-engagement-dashboard>
 			</d2l-demo-snippet>
 		</d2l-demo-page>
 	</body>

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -295,7 +295,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 		});
 	}
 
-	_handlePerfomanceMeasure(event) {
+	_handlePerformanceMeasure(event) {
 		if (!this._telemetryHelper) {
 			return;
 		}
@@ -317,13 +317,13 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 		this._boundHandlePageLoad = this._handlePageLoad.bind(this);
 		window.addEventListener('load', this._boundHandlePageLoad);
 
-		this._boundHandlePerfomanceMeasure = this._handlePerfomanceMeasure.bind(this);
-		document.addEventListener('d2l-performance-measure', this._boundHandlePerfomanceMeasure);
+		this._boundHandlePerformanceMeasure = this._handlePerformanceMeasure.bind(this);
+		document.addEventListener('d2l-performance-measure', this._boundHandlePerformanceMeasure);
 	}
 
 	disconnectedCallback() {
 		window.removeEventListener('load', this._boundHandlePageLoad);
-		document.removeEventListener('d2l-performance-measure', this._boundHandlePerfomanceMeasure);
+		document.removeEventListener('d2l-performance-measure', this._boundHandlePerformanceMeasure);
 
 		super.disconnectedCallback();
 	}

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -16,6 +16,7 @@ import 'd2l-button-group/d2l-action-button-group';
 import './components/default-view-popup.js';
 
 import { css, html } from 'lit-element/lit-element.js';
+import { getPerformanceLoadPageMeasures, TelemetryHelper } from './model/telemetry-helper';
 import { CourseLastAccessFilter } from './components/course-last-access-card';
 import { CurrentFinalGradesFilter } from './components/current-final-grade-card';
 import { Data } from './model/data.js';
@@ -28,7 +29,6 @@ import { LastAccessFilter } from './components/last-access-card';
 import { Localizer } from './locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { OverdueAssignmentsFilter } from './components/overdue-assignments-card';
-import { TelemetryHelper } from './model/telemetry-helper';
 import { TimeInContentVsGradeFilter } from './components/time-in-content-vs-grade-card';
 
 /**
@@ -239,10 +239,9 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 			return;
 		}
 
-		const measures = this._telemetryHelper.getPerformanceLoadPageMeasures();
 		this._telemetryHelper.logPerformanceEvent({
 			id: this.telemetryId,
-			measures,
+			measures: getPerformanceLoadPageMeasures(),
 			action: 'PageLoad'
 		});
 	}
@@ -256,7 +255,6 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 			return;
 		}
 
-		console.log(this.telemetryId);
 		this._telemetryHelper.logPerformanceEvent({
 			id: this.telemetryId,
 			measures: [event.detail.value],

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -36,7 +36,7 @@ import { TimeInContentVsGradeFilter } from './components/time-in-content-vs-grad
 /**
  * @property {Boolean} isDemo - if true, use canned data; otherwise call the LMS
  * @property {String} telemetryEndpoint - endpoint for gathering telemetry performance data
- * @property {String} telemetryId - GUID that is used to group performance metrics for each separate load
+ * @property {String} telemetryId - GUID that is used to group performance metrics for each separate page load
  */
 class EngagementDashboard extends Localizer(MobxLitElement) {
 

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -239,7 +239,6 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 		return this.__serverData;
 	}
 
-
 	get _telemetryHelper() {
 		if (!this.telemetryEndpoint) {
 			return null;

--- a/model/telemetry-helper.js
+++ b/model/telemetry-helper.js
@@ -15,14 +15,6 @@ export class TelemetryHelper {
 			.setBody(eventBody);
 	}
 
-	getPerformanceLoadPageMeasures() {
-		if (!window.performance || !window.performance.getEntriesByName) {
-			return [];
-		}
-
-		return window.performance.getEntriesByType('measure');
-	}
-
 	logPerformanceEvent({ id, measures, action }) {
 		if (!this._client || !window.location) {
 			return;
@@ -42,4 +34,12 @@ export class TelemetryHelper {
 
 		this._client.logUserEvent(event);
 	}
+}
+
+export function getPerformanceLoadPageMeasures() {
+	if (!window.performance || !window.performance.getEntriesByName) {
+		return [];
+	}
+
+	return window.performance.getEntriesByType('measure');
 }

--- a/model/telemetry-helper.js
+++ b/model/telemetry-helper.js
@@ -1,0 +1,45 @@
+import d2lTelemetryBrowserClient from 'd2l-telemetry-browser-client';
+
+export class TelemetryHelper {
+	constructor(endpoint) {
+		if (endpoint) {
+			this._client = new d2lTelemetryBrowserClient.Client({ endpoint });
+		}
+	}
+
+	_createEvent(eventType, eventBody) {
+		return new d2lTelemetryBrowserClient.TelemetryEvent()
+			.setDate(new Date())
+			.setType(eventType)
+			.setSourceId('insights')
+			.setBody(eventBody);
+	}
+
+	getPerformanceLoadPageMeasures() {
+		if (!window.performance || !window.performance.getEntriesByName) {
+			return [];
+		}
+
+		return window.performance.getEntriesByType('measure');
+	}
+
+	logPerformanceEvent({ id, measures, action }) {
+		if (!this._client || !window.location) {
+			return;
+		}
+
+		if (measures.lenght < 1) {
+			return;
+		}
+
+		const eventBody = new d2lTelemetryBrowserClient.PerformanceEventBody()
+			.setAction(action)
+			.setObject(id, 'engagement', window.location.href)
+			.addCustom('Source', 'engagement')
+			.addUserTiming(measures);
+
+		const event = this._createEvent('PerformanceEvent', eventBody);
+
+		this._client.logUserEvent(event);
+	}
+}

--- a/model/telemetry-helper.js
+++ b/model/telemetry-helper.js
@@ -20,7 +20,7 @@ export class TelemetryHelper {
 			return;
 		}
 
-		if (measures.lenght < 1) {
+		if (measures.length < 1) {
 			return;
 		}
 

--- a/package.json
+++ b/package.json
@@ -49,11 +49,12 @@
     "@brightspace-ui/intl": "^3.0.11",
     "@webcomponents/webcomponentsjs": "^2",
     "array-flat-polyfill": "^1.0.1",
+    "d2l-button-group": "BrightspaceUI/button-group#semver:^3",
     "d2l-facet-filter-sort": "BrightspaceUI/facet-filter-sort#semver:^3",
+    "d2l-telemetry-browser-client": "Brightspace/d2l-telemetry-browser-client#semver:^1",
     "highcharts": "^8.1.2",
     "lit-element": "^2",
     "lit-html": "^1.3.0",
-    "mobx": "^5.15.4",
-    "d2l-button-group": "BrightspaceUI/button-group#semver:^3"
+    "mobx": "^5.15.4"
   }
 }

--- a/test/model/telemetry-helper.test.js
+++ b/test/model/telemetry-helper.test.js
@@ -1,0 +1,84 @@
+import { getPerformanceLoadPageMeasures, TelemetryHelper } from '../../model/telemetry-helper';
+import { expect } from '@open-wc/testing';
+import fetchMock from 'fetch-mock/esm/client';
+
+describe('TelemetryHelper', () => {
+
+	let fetchSandbox;
+
+	beforeEach(() => {
+		fetchSandbox = fetchMock.sandbox();
+		fetchSandbox.mock(() => { return true; }, 200);
+		window.d2lfetch = { fetch : fetchSandbox };
+	});
+
+	describe('logPerformanceEvent', () => {
+		const measure = {};
+
+		it('does nothing if endpoint is not provided', () => {
+			const telemetryHelper = new TelemetryHelper(null);
+
+			telemetryHelper.logPerformanceEvent({ id: 'ID', measures: [measure], action: 'Action' });
+
+			expect(fetchSandbox.lastCall()).to.be.undefined;
+		});
+
+		it('does nothing if no measures provided', () => {
+			const telemetryHelper = new TelemetryHelper(null);
+
+			telemetryHelper.logPerformanceEvent({ id: 'ID', measures: [], action: 'Action' });
+
+			expect(fetchSandbox.lastCall()).to.be.undefined;
+		});
+
+		it('sends timings with a performance event', async() => {
+			const telemetryHelper = new TelemetryHelper('http://endpoint.com/');
+
+			telemetryHelper.logPerformanceEvent({ id: 'ID', measures: [{ name: 'name1' }, { name: 'name2' }], action: 'Action' });
+
+			console.dir(fetchSandbox.lastCall());
+			const lastCall = fetchSandbox.lastCall();
+
+			expect(lastCall[0]).to.equal('http://endpoint.com/');
+			const event = JSON.parse(await lastCall[1].body);
+
+			delete event.ts;
+			delete event.name;
+			delete event.EventBody.Object.Url;
+			delete event.Date;
+
+			expect(event).to.be.deep.equal({
+				SourceId: 'insights',
+				EventType: 'PerformanceEvent',
+				EventBody: {
+					EventTypeGuid: '02a00ca0-e67d-4a6c-908b-ee80b8a61eec',
+					Action: 'Action',
+					Object: {
+						Id: 'ID',
+						Type: 'engagement'
+					},
+					Custom: [{
+						name: 'Source',
+						value: 'engagement'
+					}],
+					UserTiming: [
+						{ name: 'name1' },
+						{ name: 'name2' }
+					]
+				}
+			});
+		});
+	});
+
+	describe('getPerformanceLoadPageMeasures', () => {
+		it('returns performance entries for "measure" type', () => {
+			performance.measure('measure 1');
+			performance.measure('measure 2');
+			performance.measure('measure 3');
+
+			const measures = getPerformanceLoadPageMeasures();
+
+			expect(measures.map(m => m.name)).to.deep.equal(['measure 1', 'measure 2', 'measure 3']);
+		});
+	});
+});

--- a/test/model/telemetry-helper.test.js
+++ b/test/model/telemetry-helper.test.js
@@ -24,7 +24,7 @@ describe('TelemetryHelper', () => {
 		});
 
 		it('does nothing if no measures provided', () => {
-			const telemetryHelper = new TelemetryHelper(null);
+			const telemetryHelper = new TelemetryHelper('http://example.com/');
 
 			telemetryHelper.logPerformanceEvent({ id: 'ID', measures: [], action: 'Action' });
 
@@ -32,14 +32,14 @@ describe('TelemetryHelper', () => {
 		});
 
 		it('sends timings with a performance event', async() => {
-			const telemetryHelper = new TelemetryHelper('http://endpoint.com/');
+			const telemetryHelper = new TelemetryHelper('http://example.com/');
 
 			telemetryHelper.logPerformanceEvent({ id: 'ID', measures: [{ name: 'name1' }, { name: 'name2' }], action: 'Action' });
 
 			console.dir(fetchSandbox.lastCall());
 			const lastCall = fetchSandbox.lastCall();
 
-			expect(lastCall[0]).to.equal('http://endpoint.com/');
+			expect(lastCall[0]).to.equal('http://example.com/');
 			const event = JSON.parse(await lastCall[1].body);
 
 			delete event.ts;


### PR DESCRIPTION
[US119022](https://rally1.rallydev.com/#/detail/userstory/408922032584?fdp=true): [Engagement] Page Load Telemetry

Each page load causes 4 API calls to Production Telemetry Service. Each event contains `EventBody.Object.Id` which is the same across these 4 calls. Telemetry records following metrics.
```JSON
[
  "first-paint",
  "first-contentful-paint",
  "d2l.page.preFetch",
  "d2l.page.timeToClient",
  "d2l.page.webComponentsReady",
  "d2l.page.domInteractive",
  "d2l.page.load",
  "d2l.page.server",
  "d2l.page.download",
  "d2l.page.domContentLoadedHandlers",
  "d2l.page.tti"
]
```
 [GRID web performance](https://docs.dev.d2l/index.php/GRID:_Web_Performance) especially pays attention to First Contentful Paint(_first-contentful-paint_) and Time to Interactive(_d2l.page.tti_).
[Examples of performance events](https://github.com/Brightspace/insights-engagement-dashboard/files/5453985/Performance.Events.From.Client.txt)  that are sent to telemetry service

### Functional Testing - N/A
* Unit tests
* API calls to telemetry endpoint returns 200 HTTP Code
### Security Testing - N/A
### Performance Testing
* Telemetry API calls are executed asynchronously, therefore, these calls do not affect UI .
### Devops - N/A
### UX and docs - N/A

- [x] Simple queries to the telemetry data

FYI @rohitvinnakota @MykolaGalian @johngwilkinson @NicholasHallman