### PR TITLE
Enable all card animations

### DIFF
--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -6,6 +6,11 @@ import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
 import { css, html, LitElement } from 'lit-element';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
+const easeOut = (t) => (1 - (--t) * t * t * t);
+const defaultAnimationOptions = {
+	duration: 500,
+	easing: easeOut,
+};
 // use default highcharts's template but with <h3> instead of <h4> to fix axe heading-order error
 export const BEFORE_CHART_FORMAT = '<h3>{chartTitle}</h3>' +
 	'<div>{typeDescription}</div>' +
@@ -57,6 +62,11 @@ class Chart extends SkeletonMixin(LitElement) {
 		 */
 		this.immutable = false;
 		/**
+		 * Checks accessibility preferences and enables or disables them accordingly.
+		 */
+		this.showAnimations = !window.matchMedia('(prefers-reduced-motion: reduce)').matches ?
+			defaultAnimationOptions : false;
+		/**
 		 * Array of update()'s function optional arguments.
 		 * Parameters should be defined in the same order like in
 		 * native Highcharts function: [redraw, oneToOne, animation].
@@ -65,7 +75,7 @@ class Chart extends SkeletonMixin(LitElement) {
 		this.updateArgs = [
 			true,
 			true,
-			true
+			this.showAnimations
 		];
 		this.globalOptions = null;
 	}
@@ -80,6 +90,10 @@ class Chart extends SkeletonMixin(LitElement) {
 				display: none;
 			}
 		`;
+	}
+
+	defaultOptions() {
+		this.options.plotOptions.series.animation = this.showAnimations
 	}
 
 	render() {
@@ -116,6 +130,8 @@ class Chart extends SkeletonMixin(LitElement) {
 			console.warn('The "options" property was not passed.');
 		}
 		else {
+			// accessible options overload
+			this.defaultOptions();
 			// Create a chart
 			H.setOptions({
 				lang: {

--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -93,7 +93,14 @@ class Chart extends SkeletonMixin(LitElement) {
 	}
 
 	defaultOptions() {
-		this.options.plotOptions.series.animation = this.showAnimations
+		// check for series and plotOptions because we could have a column instead.
+		if (this.options.plotOptions === undefined) return;
+		else if (this.options.plotOptions.series !== undefined) {
+			this.options.plotOptions.series.animation = this.showAnimations;
+		}
+		else if (this.options.plotOptions.column !== undefined) {
+			this.options.plotOptions.column.animation = this.showAnimations;
+		}
 	}
 
 	render() {

--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -92,13 +92,15 @@ class Chart extends SkeletonMixin(LitElement) {
 		`;
 	}
 
-	defaultOptions() {
+	setDefaultOptions() {
 		// check for series and plotOptions because we could have a column instead.
-		if (this.options.plotOptions === undefined) return;
-		else if (this.options.plotOptions.series !== undefined) {
+		if (!this.options.plotOptions) {
+			return;
+		}
+		else if (this.options.plotOptions.series) {
 			this.options.plotOptions.series.animation = this.showAnimations;
 		}
-		else if (this.options.plotOptions.column !== undefined) {
+		else if (this.options.plotOptions.column) {
 			this.options.plotOptions.column.animation = this.showAnimations;
 		}
 	}
@@ -138,7 +140,7 @@ class Chart extends SkeletonMixin(LitElement) {
 		}
 		else {
 			// accessible options overload
-			this.defaultOptions();
+			this.setDefaultOptions();
 			// Create a chart
 			H.setOptions({
 				lang: {

--- a/components/course-last-access-card.js
+++ b/components/course-last-access-card.js
@@ -220,7 +220,6 @@ class CourseLastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 					}
 				}
 			},
-			animation: false,
 			tooltip: {
 				formatter: function() {
 					if (this.point.y === 1) {
@@ -286,7 +285,6 @@ class CourseLastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 				series: {
 					minPointLength: 2, // visualize 0 points
 					pointStart: 0,
-					animation: false,
 					pointWidth: 16,
 					pointPadding: 0.60,
 					accessibility: {

--- a/components/current-final-grade-card.js
+++ b/components/current-final-grade-card.js
@@ -92,7 +92,8 @@ class CurrentFinalGradeCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 			.map(record => [record[RECORD.TIME_IN_CONTENT], record[RECORD.CURRENT_FINAL_GRADE]])
 			.filter(item => item[0] || item[1])
 			.map(item => gradeCategory(item[1]))
-			.forEach(gradeCategory => bins[gradeCategory / 10] += 1);
+			.map(gradeCategory => (gradeCategory / 10 > 9 ? 9 : gradeCategory / 10))
+			.forEach(gradeCategory => bins[gradeCategory] += 1);
 		return bins;
 	}
 
@@ -102,12 +103,9 @@ class CurrentFinalGradeCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 			return ['var(--d2l-color-amethyst)'];
 		}
 
-		// the histogram module only renders zeroes for points between non-zero points,
-		// so we provide colours for all points starting with the minimum non-zero value
-		// (extra colours will be ignored)
-		const min = Math.min(...data);
+		// Go through all of the bins and assign the correct color.
 		return [0, 10, 20, 30, 40, 50, 60, 70, 80, 90].map(category =>
-			(this.category.has(category + min) ?
+			(this.category.has(category) ?
 				'var(--d2l-color-amethyst)' :
 				'var(--d2l-color-mica)')
 		);

--- a/components/current-final-grade-card.js
+++ b/components/current-final-grade-card.js
@@ -221,7 +221,6 @@ class CurrentFinalGradeCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 					reserveSpace: true,
 					x: -30,
 				},
-				//width: '108%', // move extra space at end of x-axis out of the container
 			},
 			yAxis: {
 				tickAmount: 4,

--- a/components/histogram-card.js
+++ b/components/histogram-card.js
@@ -63,7 +63,6 @@ const sparklineOptions = function(options) {
 		},
 		plotOptions: {
 			series: {
-				animation: false,
 				lineWidth: 1,
 				shadow: false,
 				states: {

--- a/components/time-in-content-vs-grade-card.js
+++ b/components/time-in-content-vs-grade-card.js
@@ -229,7 +229,6 @@ class TimeInContentVsGradeCard extends SkeletonMixin(Localizer(MobxLitElement)) 
 					}
 				}
 			},
-			animation: false,
 			tooltip: {
 				formatter: function() {
 					if (this.series.name === 'midPoint') {

--- a/test/components/current-final-grade-card.test.js
+++ b/test/components/current-final-grade-card.test.js
@@ -31,7 +31,7 @@ describe('d2l-insights-current-final-grade-card', () => {
 			await new Promise(resolve => setTimeout(resolve, 200)); // allow fetch to run
 			const title = (el.shadowRoot.querySelectorAll('div.d2l-insights-current-final-grade-title'));
 			expect(title[0].innerText).to.equal('Current Grade');
-			const expected = [20, 30, 40, 50, 30, 90, 90, 90, 70, 70, 40, 50, 30, 90, 70, 80, 90, 80, 90, 80, 90, 40, 60];
+			const expected = [ 0, 0, 1, 3, 3, 2, 1, 3, 3, 7 ];
 			expect(el._preparedHistogramData).to.deep.equal(expected);
 			expect(el._colours).to.deep.equal(['var(--d2l-color-amethyst)']);
 		});
@@ -41,7 +41,7 @@ describe('d2l-insights-current-final-grade-card', () => {
 			filter.selectCategory(50);
 			const el = await fixture(html`<d2l-insights-current-final-grade-card .data="${data}"></d2l-insights-current-final-grade-card>`);
 			// only the first 8 colours matter (from 20 to 90)
-			expect(el._colours.slice(0, 8)).to.deep.equal([
+			expect(el._colours.slice(2, 10)).to.deep.equal([
 				'var(--d2l-color-mica)',
 				'var(--d2l-color-amethyst)',
 				'var(--d2l-color-mica)',

--- a/test/components/current-final-grade-card.test.js
+++ b/test/components/current-final-grade-card.test.js
@@ -40,8 +40,9 @@ describe('d2l-insights-current-final-grade-card', () => {
 			filter.selectCategory(30);
 			filter.selectCategory(50);
 			const el = await fixture(html`<d2l-insights-current-final-grade-card .data="${data}"></d2l-insights-current-final-grade-card>`);
-			// only the first 8 colours matter (from 20 to 90)
-			expect(el._colours.slice(2, 10)).to.deep.equal([
+			expect(el._colours).to.deep.equal([
+				'var(--d2l-color-mica)',
+				'var(--d2l-color-mica)',
 				'var(--d2l-color-mica)',
 				'var(--d2l-color-amethyst)',
 				'var(--d2l-color-mica)',


### PR DESCRIPTION
- Changed easing function to quadric easeOut
- Added reduced motion accessibility
- Converted histogram chart to column chart to fix animation problems (may be due to multiple data series?)

The grade card was converted from a histogram to a column chart because of animation troubles. Couldn't get them working for most of yesterday and decided to use Highcharts second example for histograms. 

Testing
 - Verified using unit tests 
- And Manual testing to make sure that converting the table didn't break any of the mobx state management.
 Performance
 - N/A css and svg animations are hardware accelerated, and they don't run very often
UX
- Pending Demo, showed kevin propositions for different easing functions.

@johngwilkinson @anhill-D2L @bemailloux @rohitvinnakota @hyehayes 