### PR TITLE
US120050: screen reader support for summary cards

### DIFF
--- a/components/last-access-card.js
+++ b/components/last-access-card.js
@@ -67,7 +67,7 @@ class LastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 		return html`
 			<d2l-labs-summary-card
 				id="d2l-insights-engagement-last-access"
-				is-value-clickable
+				value-clickable
 				card-title="${this._cardTitle}"
 				card-value="${this._cardValue}"
 				card-message="${this._cardMessage}"

--- a/components/overdue-assignments-card.js
+++ b/components/overdue-assignments-card.js
@@ -63,7 +63,7 @@ class OverdueAssignmentsCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 		return html`
 			<d2l-labs-summary-card
 				id="d2l-insights-engagement-overdue-assignments"
-				is-value-clickable
+				value-clickable
 				card-title="${this._cardTitle}"
 				card-value="${this._cardValue}"
 				card-message="${this._cardMessage}"

--- a/components/summary-card.js
+++ b/components/summary-card.js
@@ -1,6 +1,8 @@
+import '@brightspace-ui/core/components/offscreen/offscreen.js';
 import './overlay';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import { Localizer } from '../locales/localizer';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
 /**
@@ -9,13 +11,13 @@ import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton
  * @property {string} message
  * @fires d2l-labs-summary-card-value-click
  */
-class SummaryCard extends SkeletonMixin(LitElement) {
+class SummaryCard extends SkeletonMixin(Localizer(LitElement)) {
 	static get properties() {
 		return {
 			title: { type: String, attribute: 'card-title' },
 			value: { type: String, attribute: 'card-value' },
 			message: { type: String, attribute: 'card-message' },
-			isValueClickable: { type: Boolean, attribute: 'is-value-clickable' }
+			isValueClickable: { type: Boolean, attribute: 'value-clickable' }
 		};
 	}
 
@@ -71,7 +73,9 @@ class SummaryCard extends SkeletonMixin(LitElement) {
 				margin-inline-start: 30px;
 			}
 
-			.d2l-insights-summary-card-value[is-value-clickable] {
+			.d2l-insights-summary-card-button {
+				background: inherit;
+				border: none;
 				color: var(--d2l-color-celestine);
 				cursor: pointer;
 				font-size: 22px;
@@ -104,6 +108,10 @@ class SummaryCard extends SkeletonMixin(LitElement) {
 		this.dispatchEvent(new CustomEvent('d2l-labs-summary-card-value-click'));
 	}
 
+	get summaryLabel() {
+		return this.localize('components.insights-summary-card.label', { value: this.value, message: this.message });
+	}
+
 	render() {
 		// NB: relying on mobx rather than lit-element properties to handle update detection: it will trigger a redraw for
 		// any change to a relevant observed property of the Data object
@@ -111,11 +119,24 @@ class SummaryCard extends SkeletonMixin(LitElement) {
 			<div class="d2l-insights-summary-card-title d2l-skeletize d2l-skeletize-45 d2l-body-standard">${this.title}</div>
 			<div class="d2l-insights-summary-card-body" aria-hidden="${this.skeleton}">
 				<div class="d2l-skeletize">
-					${this.isValueClickable ?
-						html`<span class="d2l-insights-summary-card-value d2l-insights-summary-card-field" ?is-value-clickable=${this.isValueClickable} @click=${this._valueClickHandler}>${this.value}</span>` :
-						html`<span class="d2l-insights-summary-card-value d2l-insights-summary-card-field">${this.value}</span>`}
+					${this.isValueClickable ? html`<button
+ 						class="d2l-insights-summary-card-button d2l-insights-summary-card-field"
+ 						@click=${this._valueClickHandler}
+ 					>
+ 						<span aria-hidden="true">${this.value}</span>
+ 						<d2l-offscreen>${this.summaryLabel}</d2l-offscreen>
+ 					</button>` : html`<span
+ 						class="d2l-insights-summary-card-value d2l-insights-summary-card-field"
+ 						aria-label="${this.summaryLabel}"
+ 					>
+ 						<span aria-hidden="true">${this.value}</span>
+ 						<d2l-offscreen>${this.summaryLabel}</d2l-offscreen>
+ 					</span>`}
 				</div>
-			<span class="d2l-insights-summary-card-message d2l-insights-summary-card-field d2l-skeletize-paragraph-3">${this.message}</span>
+				<span
+					class="d2l-insights-summary-card-message d2l-insights-summary-card-field d2l-skeletize-paragraph-3"
+					aria-hidden="true"
+				>${this.message}</span>
 			</div>
 		</div>`;
 	}

--- a/locales/en.js
+++ b/locales/en.js
@@ -61,6 +61,8 @@ export default {
 
 	"components.insights-table.selectAll": "Select all",
 
+	"components.insights-summary-card.label": "{value} {message}",
+
 	"components.insights-time-in-content-vs-grade-card.timeInContentVsGrade": "Time in Content vs. Grade",
 	"components.insights-time-in-content-vs-grade-card.currentGrade": "Current Grade (%)",
 	"components.insights-time-in-content-vs-grade-card.timeInContent": "Time in Content (mins)",


### PR DESCRIPTION
Quality Notes:
* functional
  * w. Narrator and keyboard, navigate page
    * tabbing to clickable summary number reads all the card text
    * using up and down arrows to reach both clickable and non-clickable summary numbers reads all the card text
    * screen reader does not read out any duplicate text in the summary body
    * summary cards with filters can be enabled using the keyboard
* devops, perf, ux/docs, security: n/a

FYI @anhill-D2L @MykolaGalian @NicholasHallman @rohitvinnakota 