### PR TITLE
Add margin to expander button

### DIFF
--- a/components/default-view-popup.js
+++ b/components/default-view-popup.js
@@ -3,12 +3,13 @@ import '@brightspace-ui/core/components/button/button';
 import './expander-with-control';
 import { css, html, LitElement } from 'lit-element';
 import { Localizer } from '../locales/localizer';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin';
 
 /**
  * @property {Array} data - [{id: orgUnitId, name: orgUnitName}]
  * @property {Boolean} opened - whether or not the dialog should be opened
  */
-class DefaultViewPopup extends Localizer(LitElement) {
+class DefaultViewPopup extends RtlMixin(Localizer(LitElement)) {
 
 	static get properties() {
 		return {

--- a/components/expander-with-control.js
+++ b/components/expander-with-control.js
@@ -28,6 +28,10 @@ class ExpanderWithControl extends Localizer(LitElement) {
 				margin: 1em 0 0.5em 0;
 			}
 
+			.d2l-insights-expand-collapse-control-button {
+				margin-left: 10px;
+			}
+
 			.d2l-insights-expand-collapse-control-text {
 				color: var(--d2l-color-celestine);
 				display: inline-flex;
@@ -58,6 +62,7 @@ class ExpanderWithControl extends Localizer(LitElement) {
 
 				<p class="d2l-insights-expand-collapse-control-text">${ controlText }</p>
 				<d2l-button-icon
+					class="d2l-insights-expand-collapse-control-button"
 					icon="tier1:${ this.expanded ? 'arrow-collapse' : 'arrow-expand' }"
 					aria-label="${ controlText }"
 					aria-expanded="${this.expanded}">

--- a/components/expander-with-control.js
+++ b/components/expander-with-control.js
@@ -3,13 +3,14 @@ import '@brightspace-ui/core/components/button/button-icon';
 
 import { css, html, LitElement } from 'lit-element';
 import { Localizer } from '../locales/localizer';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin';
 
 /**
  * @property {String} controlExpandedText - The text to display in the control div when the control is expanded
  * @property {String} controlCollapsedText - The text to display in the control div when the control is collapsed
  * @property {Boolean} expanded - whether the content is expanded or not
  */
-class ExpanderWithControl extends Localizer(LitElement) {
+class ExpanderWithControl extends RtlMixin(Localizer(LitElement)) {
 
 	static get properties() {
 		return {
@@ -30,6 +31,12 @@ class ExpanderWithControl extends Localizer(LitElement) {
 
 			.d2l-insights-expand-collapse-control-button {
 				margin-left: 10px;
+				margin-right: 0;
+			}
+
+			.d2l-insights-expand-collapse-control-button[dir="rtl"] {
+				margin-left: 0;
+				margin-right: 10px;
 			}
 
 			.d2l-insights-expand-collapse-control-text {


### PR DESCRIPTION
So the text doesn't get too close to the button.

Before:
![image](https://user-images.githubusercontent.com/11587338/97613886-a02b4300-19ef-11eb-8230-816d27add69a.png)

After: 
![image](https://user-images.githubusercontent.com/11587338/97613917-a91c1480-19ef-11eb-85fa-1d59550bb73a.png)

(Yes the language in the rest of the dialog is wrong - I was just testing quickly)

FYI @NicholasHallman @Vitalii-Misechko @MykolaGalian @rohitvinnakota 
