### PR TITLE
Add no results error message

### DIFF
--- a/components/message-container.js
+++ b/components/message-container.js
@@ -27,7 +27,18 @@ class MessageContainer extends Localizer(MobxLitElement) {
 				display: none;
 			}
 
-			.d2l-insights-message-container-body {
+			.d2l-insights-message-container-body-noResultsAvailable {
+				background-color: var(--d2l-color-regolith);
+				border: 1px solid var(--d2l-color-gypsum);
+				border-radius: 8px;
+				color: var(--d2l-color-ferrite);
+				display: flex;
+				height: 130px;
+				margin-bottom: 20px;
+				width: 73vw;
+			}
+
+			.d2l-insights-message-container-body-tooManyResults {
 				background-color: var(--d2l-color-regolith);
 				border: 1px solid var(--d2l-color-gypsum);
 				border-radius: 8px;
@@ -50,15 +61,29 @@ class MessageContainer extends Localizer(MobxLitElement) {
 		return this.data._data.serverData.isRecordsTruncated;
 	}
 
+	get _isNoDataReturned() {
+		return this.data.users.length === 0 && !this.data.isLoading;
+	}
+
 	get _messageContainerTextTooManyResults() {
 		return this.localize('components.insights-engagement-dashboard.tooManyResults');
 	}
 
+	get _messageContainerTextNoResultsAvailable() {
+		return this.localize('components.insights-engagement-dashboard.noResultsAvailable');
+	}
+
 	render() {
 		// conditinally render message text and body
-		if (this._isRecordsTruncated) {
+		if (this._isNoDataReturned) { //overwrite too many results case
 			return html`
-				<div class="d2l-insights-message-container-body">
+				<div class="d2l-insights-message-container-body-noResultsAvailable">
+					<span class="d2l-insights-message-container-value">${this._messageContainerTextNoResultsAvailable}</span>
+				</div>
+			`;
+		} else if (this._isRecordsTruncated) {
+			return html`
+				<div class="d2l-insights-message-container-body-tooManyResults">
 					<span class="d2l-insights-message-container-value">${this._messageContainerTextTooManyResults}</span>
 				</div>
 			`;

--- a/components/message-container.js
+++ b/components/message-container.js
@@ -7,7 +7,8 @@ class MessageContainer extends Localizer(MobxLitElement) {
 
 	static get properties() {
 		return {
-			data: { type: Object, attribute: false }
+			data: { type: Object, attribute: false },
+			isNoDataReturned: { type: Boolean, attribute: false }
 		};
 	}
 
@@ -61,10 +62,6 @@ class MessageContainer extends Localizer(MobxLitElement) {
 		return this.data._data.serverData.isRecordsTruncated;
 	}
 
-	get _isNoDataReturned() {
-		return this.data.users.length === 0 && !this.data.isLoading;
-	}
-
 	get _messageContainerTextTooManyResults() {
 		return this.localize('components.insights-engagement-dashboard.tooManyResults');
 	}
@@ -75,7 +72,7 @@ class MessageContainer extends Localizer(MobxLitElement) {
 
 	render() {
 		// conditinally render message text and body
-		if (this._isNoDataReturned) { //overwrite too many results case
+		if (this.isNoDataReturned) { //overwrite too many results case
 			return html`
 				<div class="d2l-insights-message-container-body-noResultsAvailable">
 					<span class="d2l-insights-message-container-value">${this._messageContainerTextNoResultsAvailable}</span>

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -158,33 +158,31 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 						?demo="${this.isDemo}"
 					></d2l-insights-role-filter>
 				</div>
-				<d2l-insights-message-container .data="${this._data}"></d2l-insights-message-container>
-				<span class="${this._isNoUserResults ? 'd2l-insights-noDisplay' : 'd2l-insights-display'}">
-					<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.summaryHeading')}</h2>
-					<div class="d2l-insights-summary-container-applied-filters">
-						<d2l-insights-applied-filters .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-applied-filters>
-					</div>
-					<div class="d2l-insights-summary-container">
-						<d2l-insights-results-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-results-card>
-						<d2l-insights-overdue-assignments-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-overdue-assignments-card>
-						<d2l-insights-discussion-activity-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-discussion-activity-card>
-						<d2l-insights-last-access-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-last-access-card>
-					</div>
-					<div class="d2l-insights-chart-container">
-						<div><d2l-insights-current-final-grade-card	.data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-current-final-grade-card></div>
-						<div><d2l-insights-time-in-content-vs-grade-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-time-in-content-vs-grade-card></div>
-						<div><d2l-insights-course-last-access-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-course-last-access-card></div>
-					</div>
+				<d2l-insights-message-container .data="${this._data}" .isNoDataReturned="${this._isNoUserResults}"></d2l-insights-message-container>
+				<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.summaryHeading')}</h2>
+				<div class="d2l-insights-summary-container-applied-filters">
+					<d2l-insights-applied-filters .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-applied-filters>
+				</div>
+				<div class="d2l-insights-summary-container">
+					<d2l-insights-results-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-results-card>
+					<d2l-insights-overdue-assignments-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-overdue-assignments-card>
+					<d2l-insights-discussion-activity-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-discussion-activity-card>
+					<d2l-insights-last-access-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-last-access-card>
+				</div>
+				<div class="d2l-insights-chart-container">
+					<div><d2l-insights-current-final-grade-card	.data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-current-final-grade-card></div>
+					<div><d2l-insights-time-in-content-vs-grade-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-time-in-content-vs-grade-card></div>
+					<div><d2l-insights-course-last-access-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-course-last-access-card></div>
+				</div>
 
-					<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.resultsHeading')}</h2>
-				<d2l-action-button-group class="d2l-table-action-button-group" min-to-show="0" max-to-show="2" opener-type="more">
-					<d2l-button-subtle
-						icon="d2l-tier1:email"
-						text="${this.localize('components.insights-engagement-dashboard.emailButton')}"
-						@click="${this._handleEmailButtonPress}">
-					</d2l-button-subtle>
-				</d2l-action-button-group>
-				</span>
+				<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.resultsHeading')}</h2>
+			<d2l-action-button-group class="d2l-table-action-button-group" min-to-show="0" max-to-show="2" opener-type="more">
+				<d2l-button-subtle
+					icon="d2l-tier1:email"
+					text="${this.localize('components.insights-engagement-dashboard.emailButton')}"
+					@click="${this._handleEmailButtonPress}">
+				</d2l-button-subtle>
+			</d2l-action-button-group>
 				<d2l-insights-users-table
 					.data="${this._data}"
 					?skeleton="${this._isLoading}"
@@ -230,7 +228,10 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 	}
 
 	get _isNoUserResults() {
-		return this.__data.users.length === 0 && !this._data.isLoading;
+		if (!this.isDemo) {
+			return this._data.records.length === 0 && !this._data.isLoading;
+		}
+		return false;
 	}
 
 	get _serverData() {

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -98,6 +98,11 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					margin-bottom: 1rem;
 				}
 
+				.d2l-insights-noDisplay {
+					display: none;
+					padding: 50px;
+				}
+
 				@media screen and (max-width: 615px) {
 					h1 {
 						line-height: 2rem;
@@ -154,24 +159,24 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					></d2l-insights-role-filter>
 				</div>
 				<d2l-insights-message-container .data="${this._data}"></d2l-insights-message-container>
-				<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.summaryHeading')}</h2>
-				<div class="d2l-insights-summary-container-applied-filters">
-					<d2l-insights-applied-filters .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-applied-filters>
-				</div>
-				<div class="d2l-insights-summary-container">
-					<d2l-insights-results-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-results-card>
-					<d2l-insights-overdue-assignments-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-overdue-assignments-card>
-					<d2l-insights-discussion-activity-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-discussion-activity-card>
-					<d2l-insights-last-access-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-last-access-card>
-				</div>
-				<div class="d2l-insights-chart-container">
-					<div><d2l-insights-current-final-grade-card	.data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-current-final-grade-card></div>
-					<div><d2l-insights-time-in-content-vs-grade-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-time-in-content-vs-grade-card></div>
-					<div><d2l-insights-course-last-access-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-course-last-access-card></div>
-				</div>
+				<span class="${this._isNoUserResults ? 'd2l-insights-noDisplay' : 'd2l-insights-display'}">
+					<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.summaryHeading')}</h2>
+					<div class="d2l-insights-summary-container-applied-filters">
+						<d2l-insights-applied-filters .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-applied-filters>
+					</div>
+					<div class="d2l-insights-summary-container">
+						<d2l-insights-results-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-results-card>
+						<d2l-insights-overdue-assignments-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-overdue-assignments-card>
+						<d2l-insights-discussion-activity-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-discussion-activity-card>
+						<d2l-insights-last-access-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-last-access-card>
+					</div>
+					<div class="d2l-insights-chart-container">
+						<div><d2l-insights-current-final-grade-card	.data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-current-final-grade-card></div>
+						<div><d2l-insights-time-in-content-vs-grade-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-time-in-content-vs-grade-card></div>
+						<div><d2l-insights-course-last-access-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-course-last-access-card></div>
+					</div>
 
-				<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.resultsHeading')}</h2>
-
+					<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.resultsHeading')}</h2>
 				<d2l-action-button-group class="d2l-table-action-button-group" min-to-show="0" max-to-show="2" opener-type="more">
 					<d2l-button-subtle
 						icon="d2l-tier1:email"
@@ -179,7 +184,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 						@click="${this._handleEmailButtonPress}">
 					</d2l-button-subtle>
 				</d2l-action-button-group>
-
+				</span>
 				<d2l-insights-users-table
 					.data="${this._data}"
 					?skeleton="${this._isLoading}"
@@ -222,6 +227,10 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 		}
 
 		return this.__data;
+	}
+
+	get _isNoUserResults() {
+		return this.__data.users.length === 0 && !this._data.isLoading;
 	}
 
 	get _serverData() {

--- a/locales/en.js
+++ b/locales/en.js
@@ -14,6 +14,7 @@ export default {
 	"components.insights-engagement-dashboard.exportToCsv": "Export to CSV",
 	"components.insights-engagement-dashboard.emailButton": "Email",
 	"components.insights-engagement-dashboard.noUsersSelectedDialogText": "Please select one or more users to email.",
+	"components.insights-engagement-dashboard.noResultsAvailable": "There are no results available that match your filters.",
 
 	"components.insights-role-filter.name": "Role",
 

--- a/test/components/message-container.test.js
+++ b/test/components/message-container.test.js
@@ -22,7 +22,6 @@ describe('d2l-insights-message-container', () => {
 			},
 		},
 		users: [],
-		isLoading: false
 	};
 
 	describe('constructor', () => {
@@ -33,19 +32,19 @@ describe('d2l-insights-message-container', () => {
 
 	describe('accessibility', () => {
 		it('should pass all axe tests', async() => {
-			const el = await fixture(html`<d2l-insights-message-container .data="${dataWithTruncatedRecords}"></d2l-insights-message-container>`);
+			const el = await fixture(html`<d2l-insights-message-container .data="${dataWithTruncatedRecords}" .isNoDataReturned="${1 === 2}"></d2l-insights-message-container>`);
 			await expect(el).to.be.accessible();
 		});
 	});
 
 	describe('render', () => {
 		it('should render as expected with truncated records', async() => {
-			const el = await fixture(html`<d2l-insights-message-container .data="${dataWithTruncatedRecords}"></d2l-insights-message-container>`);
+			const el = await fixture(html`<d2l-insights-message-container .data="${dataWithTruncatedRecords}" .isNoDataReturned="${1 === 2}"></d2l-insights-message-container>`);
 			expect(el.shadowRoot.querySelector('span.d2l-insights-message-container-value').innerText).to.equal('There are too many results in your filters. Please refine your selection.');
 		});
 
 		it('should not render without truncated records', async() => {
-			const el = await fixture(html`<d2l-insights-message-container .data="${dataWithoutTruncatedRecords}"></d2l-insights-message-container>`);
+			const el = await fixture(html`<d2l-insights-message-container .data="${dataWithoutTruncatedRecords}" .isNoDataReturned=${1 === 1}></d2l-insights-message-container>`);
 			expect(el.shadowRoot.querySelector('.d2l-insights-message-container-value').innerText).to.equal('There are no results available that match your filters.');
 		});
 	});

--- a/test/components/message-container.test.js
+++ b/test/components/message-container.test.js
@@ -32,19 +32,19 @@ describe('d2l-insights-message-container', () => {
 
 	describe('accessibility', () => {
 		it('should pass all axe tests', async() => {
-			const el = await fixture(html`<d2l-insights-message-container .data="${dataWithTruncatedRecords}" .isNoDataReturned="${1 === 2}"></d2l-insights-message-container>`);
+			const el = await fixture(html`<d2l-insights-message-container .data="${dataWithTruncatedRecords}" .isNoDataReturned="${Boolean(0)}"></d2l-insights-message-container>`);
 			await expect(el).to.be.accessible();
 		});
 	});
 
 	describe('render', () => {
 		it('should render as expected with truncated records', async() => {
-			const el = await fixture(html`<d2l-insights-message-container .data="${dataWithTruncatedRecords}" .isNoDataReturned="${1 === 2}"></d2l-insights-message-container>`);
+			const el = await fixture(html`<d2l-insights-message-container .data="${dataWithTruncatedRecords}" .isNoDataReturned="${Boolean(0)}"></d2l-insights-message-container>`);
 			expect(el.shadowRoot.querySelector('span.d2l-insights-message-container-value').innerText).to.equal('There are too many results in your filters. Please refine your selection.');
 		});
 
 		it('should not render without truncated records', async() => {
-			const el = await fixture(html`<d2l-insights-message-container .data="${dataWithoutTruncatedRecords}" .isNoDataReturned=${1 === 1}></d2l-insights-message-container>`);
+			const el = await fixture(html`<d2l-insights-message-container .data="${dataWithoutTruncatedRecords}" .isNoDataReturned=${Boolean(1)}></d2l-insights-message-container>`);
 			expect(el.shadowRoot.querySelector('.d2l-insights-message-container-value').innerText).to.equal('There are no results available that match your filters.');
 		});
 	});

--- a/test/components/message-container.test.js
+++ b/test/components/message-container.test.js
@@ -8,15 +8,21 @@ describe('d2l-insights-message-container', () => {
 			serverData : {
 				isRecordsTruncated: true
 			}
-		}
+		},
+		users: [
+			[100, 'John', 'Lennon', 'jlennon',  1600295350000],
+			[200, 'Paul', 'McCartney', 'pmccartney', null]
+		]
 	};
 
 	const dataWithoutTruncatedRecords = {
 		_data: {
 			serverData : {
 				isRecordsTruncated: false
-			}
-		}
+			},
+		},
+		users: [],
+		isLoading: false
 	};
 
 	describe('constructor', () => {
@@ -40,7 +46,7 @@ describe('d2l-insights-message-container', () => {
 
 		it('should not render without truncated records', async() => {
 			const el = await fixture(html`<d2l-insights-message-container .data="${dataWithoutTruncatedRecords}"></d2l-insights-message-container>`);
-			expect(el.shadowRoot.querySelector('.d2l-insights-message-container-value')).to.equal(null);
+			expect(el.shadowRoot.querySelector('.d2l-insights-message-container-value').innerText).to.equal('There are no results available that match your filters.');
 		});
 	});
 });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21348406/97656769-a268be00-1a3e-11eb-99b0-68ce3494cc07.png)

[US117901](https://rally1.rallydev.com/#/detail/userstory/399910079036?fdp=true): [Engagement] Errors - No data in filtered range

Based on earlier discussion during our meetings, I have the cards and charts not rendering when 0 users are returned. ~~It seems that we have some default functionality for the user table when no users are returned so I left that as is.~~ 
Demoed to Kevin and we agreed upon rendering just the message and no user table when there are 0 users returned. 

**Quality notes**
Tested on edge, firefox, chrome
Changing filters removes or recreates dialog as expected
LTR to RTL works as expected
Responsiveness works as expected

Accessibility: Text picked up by screen reader

Perf testing: n/a
Devops: n/a

- [x]  Demo to Kevin

fyi: @Vitalii-Misechko @MykolaGalian @NicholasHallman @hyehayes @anhill-D2L


