### PR TITLE
Ignore  `button-name` axe rule violation

### DIFF
--- a/test/components/table.test.js
+++ b/test/components/table.test.js
@@ -47,7 +47,10 @@ describe('d2l-insights-table', () => {
 			// or disable this rule and make sure no other issues were introduced
 			// during future development.
 			await expect(el).to.be.accessible({
-				ignoredRules: ['aria-hidden-focus']
+				ignoredRules: [
+					'aria-hidden-focus',
+					'button-name' // d2l-scroll-wrapper draws button at the right edge of the table. This button does not have a label.
+				]
 			});
 		});
 	});

--- a/test/components/users-table.test.js
+++ b/test/components/users-table.test.js
@@ -97,7 +97,10 @@ describe('d2l-insights-users-table', () => {
 			// or disable this rule and make sure no other issues were introduced
 			// during future development.
 			await expect(el).to.be.accessible({
-				ignoredRules: ['aria-hidden-focus']
+				ignoredRules: [
+					'aria-hidden-focus',
+					'button-name' // d2l-scroll-wrapper draws button at the right edge of the table. This button does not have a label.
+				]
 			});
 		});
 	});

--- a/test/engagement-dashboard.test.js
+++ b/test/engagement-dashboard.test.js
@@ -25,7 +25,10 @@ describe('d2l-insights-engagement-dashboard', () => {
 			// or disable this rule and make sure no other issues were introduced
 			// during future development.
 			await expect(el).to.be.accessible({
-				ignoredRules: ['aria-hidden-focus']
+				ignoredRules: [
+					'aria-hidden-focus',
+					'button-name' // d2l-scroll-wrapper draws button at the right edge of the table. This button does not have a label.
+				]
 			});
 		});
 	});


### PR DESCRIPTION
Ignore  `button-name` axe rule violation.

```
   Rule: button-name
      Impact: critical
      Buttons must have discernible text (https://dequeuniversity.com/rules/axe/3.5/button-name?application=axeAPI)
      
      Issue target: d2l-insights-engagement-dashboard,d2l-insights-users-table,d2l-insights-table,d2l-scroll-wrapper,.right,.d2l-table-circle-button
      Context: <button class="d2l-table-circle-button" type="button"><d2l-icon icon="d2l-tier1:chevron-right"></d2l-icon></button>
      Fix any of the following:
        Element does not have inner text that is visible to screen readers
        aria-label attribute does not exist or is empty
        aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
        Element's default semantics were not overridden with role="presentation"
        Element's default semantics were not overridden with role="none"
        Element has no title attribute or the title attribute is empty
      ---
      processResults@node_modules/chai-a11y-axe/src/accessible.js:98:24
      promiseReactionJob@[native code]
```

FYI @anhill-D2L @MykolaGalian @rohitvinnakota @hyehayes @johngwilkinson 