### PR TITLE
DE41152 Fix cards skeleton

### DIFF
--- a/components/card-overlay.js
+++ b/components/card-overlay.js
@@ -27,7 +27,7 @@ class CardOverlay extends SkeletonMixin(LitElement) {
 				display: none;
 			}
 
-			.d2l-insights-card-overlay {
+			.d2l-insights-card-overlay-container {
 				background-color: white;
 				border-radius: 15px;
 				display: flex;
@@ -76,7 +76,7 @@ class CardOverlay extends SkeletonMixin(LitElement) {
 		}
 
 		return html`
-			<div class="d2l-insights-card-overlay" aria-hidden="true">
+			<div class="d2l-insights-card-overlay-container" aria-hidden="true">
 				<div class="d2l-insights-card-overlay-title d2l-skeletize d2l-skeletize-45 d2l-body-standard">A title. Do not localize.</div>
 				<div class="d2l-insights-card-overlay-body">
 					<div class="d2l-skeletize"></div>

--- a/components/card-overlay.js
+++ b/components/card-overlay.js
@@ -32,10 +32,10 @@ class CardOverlay extends SkeletonMixin(LitElement) {
 				border-radius: 15px;
 				display: flex;
 				flex-direction: column;
-				height: calc(100% - 10px);
+				height: calc(100% - 20px);
 				justify-content: center;
 				padding-left: 10px;
-				padding-top: 10px;
+				padding-top: 20px;
 				width: calc(100% - 15px);
 			}
 

--- a/components/card-overlay.js
+++ b/components/card-overlay.js
@@ -36,11 +36,11 @@ class CardOverlay extends SkeletonMixin(LitElement) {
 				justify-content: center;
 				padding-left: 7px;
 				padding-top: 20px;
-				width: calc(100% - 15px);
+				width: calc(100% - 28px);
 			}
 
 			.d2l-insights-card-overlay-title {
-				margin-left: 10px;
+				margin-left: 15px;
 				margin-top: 10px;
 				width: 100%;
 			}
@@ -55,7 +55,7 @@ class CardOverlay extends SkeletonMixin(LitElement) {
 			.d2l-insights-card-overlay-body > div {
 				flex-shrink: 0;
 				height: 70px;
-				margin: 0 10px;
+				margin: 0 15px;
 				width: 70px;
 			}
 
@@ -65,6 +65,7 @@ class CardOverlay extends SkeletonMixin(LitElement) {
 				line-height: 1rem;
 				margin: 10px;
 				margin-left: 5px;
+				margin-right: 0px;
 				vertical-align: middle;
 			}
 		`];

--- a/components/card-overlay.js
+++ b/components/card-overlay.js
@@ -65,7 +65,7 @@ class CardOverlay extends SkeletonMixin(LitElement) {
 				line-height: 1rem;
 				margin: 10px;
 				margin-left: 5px;
-				margin-right: 0px;
+				margin-right: 0;
 				vertical-align: middle;
 			}
 		`];

--- a/components/card-overlay.js
+++ b/components/card-overlay.js
@@ -1,0 +1,89 @@
+import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
+
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+
+/**
+ * Requires that parent element has non-static position property. For instance, position: relative;
+ *
+ * @property {Boolean} loading
+ */
+class CardOverlay extends SkeletonMixin(LitElement) {
+
+	static get styles() {
+		return [super.styles, bodyStandardStyles, css`
+			:host {
+				display: block;
+				left: 0;
+				position: absolute;
+				top: 0;
+			}
+			:host([skeleton]) {
+				height: 100%;
+				width: 100%;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+
+			.d2l-insights-card-overlay {
+				background-color: white;
+				border-radius: 15px;
+				display: flex;
+				flex-direction: column;
+				height: calc(100% - 10px);
+				justify-content: center;
+				padding-left: 10px;
+				padding-top: 10px;
+				width: calc(100% - 15px);
+			}
+
+			.d2l-insights-card-overlay-title {
+				margin-left: 10px;
+				margin-top: 10px;
+				width: 100%;
+			}
+
+			.d2l-insights-card-overlay-body {
+				align-items: center;
+				display: flex;
+				height: 100%;
+				margin-bottom: 25px;
+			}
+
+			.d2l-insights-card-overlay-body > div {
+				flex-shrink: 0;
+				height: 70px;
+				margin: 0 10px;
+				width: 70px;
+			}
+
+			.d2l-insights-card-overlay-message {
+				display: inline-block;
+				font-size: 14px;
+				line-height: 1rem;
+				margin: 10px;
+				margin-left: 5px;
+				vertical-align: middle;
+			}
+		`];
+	}
+
+	render() {
+		if (!this.skeleton) {
+			return html``;
+		}
+
+		return html`
+			<div class="d2l-insights-card-overlay" aria-hidden="true">
+				<div class="d2l-insights-card-overlay-title d2l-skeletize d2l-skeletize-45 d2l-body-standard">A title. Do not localize.</div>
+				<div class="d2l-insights-card-overlay-body">
+					<div class="d2l-skeletize"></div>
+					<span class="d2l-insights-card-overlay-message d2l-body-standard d2l-skeletize-paragraph-3">A text that triggers CSS styling. Do not localize.</span>
+				</div>
+			</div>`;
+	}
+
+}
+customElements.define('d2l-insights-card-overlay', CardOverlay);

--- a/components/card-overlay.js
+++ b/components/card-overlay.js
@@ -34,7 +34,7 @@ class CardOverlay extends SkeletonMixin(LitElement) {
 				flex-direction: column;
 				height: calc(100% - 20px);
 				justify-content: center;
-				padding-left: 10px;
+				padding-left: 7px;
 				padding-top: 20px;
 				width: calc(100% - 15px);
 			}

--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -35,7 +35,8 @@ class Chart extends SkeletonMixin(LitElement) {
 			constructorType: { type: String },
 			highcharts: { type: Object, attribute: false },
 			immutable: { type: Boolean },
-			updateArgs: { type: Array, attribute: false }
+			updateArgs: { type: Array, attribute: false },
+			doNotUseOverlay: {type: Boolean, attribute: 'do-not-use-overlay' }
 		};
 	}
 
@@ -112,7 +113,7 @@ class Chart extends SkeletonMixin(LitElement) {
 
 		return html`
 			<div id="chart-container" tabindex="${this.skeleton ? -1 : 0}"></div>
-			<d2l-insights-overlay spinner-size="150" ?loading="${this.skeleton}"></d2l-insights-overlay>
+			<d2l-insights-overlay spinner-size="150" ?loading="${this.skeleton && !this.doNotUseOverlay}"></d2l-insights-overlay>
 		`;
 	}
 

--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -36,7 +36,7 @@ class Chart extends SkeletonMixin(LitElement) {
 			highcharts: { type: Object, attribute: false },
 			immutable: { type: Boolean },
 			updateArgs: { type: Array, attribute: false },
-			doNotUseOverlay: {type: Boolean, attribute: 'do-not-use-overlay' }
+			doNotUseOverlay: { type: Boolean, attribute: 'do-not-use-overlay' }
 		};
 	}
 

--- a/components/discussion-activity-card.js
+++ b/components/discussion-activity-card.js
@@ -119,6 +119,7 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 
 			:host([skeleton]) .d2l-insights-discussion-activity-card-skeleton-message {
 				display: inline-block;
+				font-size: 14px;
 				line-height: 1rem;
 				margin: 10px;
 				vertical-align: middle;

--- a/components/discussion-activity-card.js
+++ b/components/discussion-activity-card.js
@@ -93,7 +93,6 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 				display: flex;
 				height: 100%;
 				margin-bottom: 25px;
-				position: relative;
 			}
 
 			.d2l-insights-discussion-activity-card-title {
@@ -101,6 +100,39 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 				font-size: smaller;
 				font-weight: bold;
 				text-indent: 3%;
+			}
+
+			:host([skeleton]) .d2l-insights-discussion-activity-card-title {
+				margin-left: 10px;
+			}
+
+			:host([skeleton]) .d2l-insights-discussion-activity-card-skeleton-body > div {
+				flex-shrink: 0;
+				height: 70px;
+				margin: 0 10px;
+				width: 70px;
+			}
+
+			:host([skeleton]) .d2l-insights-discussion-activity-card-body {
+				display: none;
+			}
+
+			:host([skeleton]) .d2l-insights-discussion-activity-card-skeleton-message {
+				display: inline-block;
+				line-height: 1rem;
+				margin: 10px;
+				vertical-align: middle;
+			}
+
+			.d2l-insights-discussion-activity-card-skeleton-body {
+				display: none;
+			}
+
+			:host([skeleton]) .d2l-insights-discussion-activity-card-skeleton-body {
+				align-items: center;
+				display: flex;
+				height: 100%;
+				margin-bottom: 25px;
 			}
 		`];
 	}
@@ -156,11 +188,14 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 			<div class="d2l-insights-discussion-activity-card-title d2l-skeletize d2l-skeletize-45 d2l-body-standard">${this._cardTitle}</div>
 			<div class="d2l-insights-discussion-activity-card-body">
 				<d2l-labs-chart
-					class="d2l-insights-discussion-activity-card-body"
 					.options="${this.chartOptions}"
 					.globalOptions="${this.globalHighchartsOptions}"
-					?skeleton="${this.skeleton}">
+				>
 				</d2l-labs-chart>
+			</div>
+			<div class="d2l-insights-discussion-activity-card-skeleton-body" aria-hidden="true">
+				<div class="d2l-skeletize"></div>
+				<span class="d2l-insights-discussion-activity-card-skeleton-message d2l-body-standard d2l-skeletize-paragraph-3">A text that triggers CSS styling. Do not localize.</span>
 			</div>
 		</div>`;
 	}

--- a/components/discussion-activity-card.js
+++ b/components/discussion-activity-card.js
@@ -86,7 +86,7 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 				margin-top: 10px;
 				padding: 15px 4px;
 				position: relative;
-				width: 279px;
+				width: 280px;
 			}
 
 			.d2l-insights-discussion-activity-card-body {

--- a/components/discussion-activity-card.js
+++ b/components/discussion-activity-card.js
@@ -1,4 +1,4 @@
-import './overlay';
+import './card-overlay';
 import 'highcharts';
 import { computed, decorate } from 'mobx';
 import { css, html } from 'lit-element/lit-element.js';
@@ -85,6 +85,7 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 				height: 121px;
 				margin-top: 10px;
 				padding: 15px 4px;
+				position: relative;
 				width: 279px;
 			}
 
@@ -95,45 +96,11 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 				margin-bottom: 25px;
 			}
 
-			:host([skeleton]) .d2l-insights-discussion-activity-card-body {
-				display: none;
-			}
-
 			.d2l-insights-discussion-activity-card-title {
 				color: var(--d2l-color-ferrite);
 				font-size: smaller;
 				font-weight: bold;
 				text-indent: 3%;
-			}
-
-			:host([skeleton]) .d2l-insights-discussion-activity-card-title {
-				margin-left: 10px;
-			}
-
-			.d2l-insights-discussion-activity-card-skeleton-body {
-				display: none;
-			}
-
-			:host([skeleton]) .d2l-insights-discussion-activity-card-skeleton-body {
-				align-items: center;
-				display: flex;
-				height: 100%;
-				margin-bottom: 25px;
-			}
-
-			:host([skeleton]) .d2l-insights-discussion-activity-card-skeleton-body > div {
-				flex-shrink: 0;
-				height: 70px;
-				margin: 0 10px;
-				width: 70px;
-			}
-
-			:host([skeleton]) .d2l-insights-discussion-activity-card-skeleton-message {
-				display: inline-block;
-				font-size: 14px;
-				line-height: 1rem;
-				margin: 10px;
-				vertical-align: middle;
 			}
 		`];
 	}
@@ -186,7 +153,7 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 		// NB: relying on mobx rather than lit-element properties to handle update detection: it will trigger a redraw for
 		// any change to a relevant observed property of the Data object
 		return html`<div class="d2l-insights-summary-discussion-activity-card">
-			<div class="d2l-insights-discussion-activity-card-title d2l-skeletize d2l-skeletize-45 d2l-body-standard">${this._cardTitle}</div>
+			<div class="d2l-insights-discussion-activity-card-title d2l-body-standard">${this._cardTitle}</div>
 			<div class="d2l-insights-discussion-activity-card-body">
 				<d2l-labs-chart
 					.options="${this.chartOptions}"
@@ -194,10 +161,7 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 				>
 				</d2l-labs-chart>
 			</div>
-			<div class="d2l-insights-discussion-activity-card-skeleton-body" aria-hidden="true">
-				<div class="d2l-skeletize"></div>
-				<span class="d2l-insights-discussion-activity-card-skeleton-message d2l-body-standard d2l-skeletize-paragraph-3">A text that triggers CSS styling. Do not localize.</span>
-			</div>
+			<d2l-insights-card-overlay ?skeleton="${this.skeleton}"></d2l-insights-card-overlay>
 		</div>`;
 	}
 

--- a/components/discussion-activity-card.js
+++ b/components/discussion-activity-card.js
@@ -158,6 +158,8 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 				<d2l-labs-chart
 					.options="${this.chartOptions}"
 					.globalOptions="${this.globalHighchartsOptions}"
+					?skeleton="${this.skeleton}"
+					do-not-use-overlay
 				>
 				</d2l-labs-chart>
 			</div>

--- a/components/discussion-activity-card.js
+++ b/components/discussion-activity-card.js
@@ -95,6 +95,10 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 				margin-bottom: 25px;
 			}
 
+			:host([skeleton]) .d2l-insights-discussion-activity-card-body {
+				display: none;
+			}
+
 			.d2l-insights-discussion-activity-card-title {
 				color: var(--d2l-color-ferrite);
 				font-size: smaller;
@@ -106,25 +110,6 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 				margin-left: 10px;
 			}
 
-			:host([skeleton]) .d2l-insights-discussion-activity-card-skeleton-body > div {
-				flex-shrink: 0;
-				height: 70px;
-				margin: 0 10px;
-				width: 70px;
-			}
-
-			:host([skeleton]) .d2l-insights-discussion-activity-card-body {
-				display: none;
-			}
-
-			:host([skeleton]) .d2l-insights-discussion-activity-card-skeleton-message {
-				display: inline-block;
-				font-size: 14px;
-				line-height: 1rem;
-				margin: 10px;
-				vertical-align: middle;
-			}
-
 			.d2l-insights-discussion-activity-card-skeleton-body {
 				display: none;
 			}
@@ -134,6 +119,21 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 				display: flex;
 				height: 100%;
 				margin-bottom: 25px;
+			}
+
+			:host([skeleton]) .d2l-insights-discussion-activity-card-skeleton-body > div {
+				flex-shrink: 0;
+				height: 70px;
+				margin: 0 10px;
+				width: 70px;
+			}
+
+			:host([skeleton]) .d2l-insights-discussion-activity-card-skeleton-message {
+				display: inline-block;
+				font-size: 14px;
+				line-height: 1rem;
+				margin: 10px;
+				vertical-align: middle;
 			}
 		`];
 	}

--- a/components/overlay.js
+++ b/components/overlay.js
@@ -32,8 +32,9 @@ class Overlay extends LitElement {
 				display: none;
 			}
 
-			.d2l-insights-overlay {
+			.d2l-insights-overlay-container {
 				align-items: center;
+				background-color: var( --d2l-color-white );
 				border-radius: 15px;
 				display: flex;
 				height: 100%;
@@ -50,7 +51,7 @@ class Overlay extends LitElement {
 		}
 
 		return html`
-			<div class="d2l-insights-overlay">
+			<div class="d2l-insights-overlay-container">
 				<d2l-loading-spinner size="${this.spinnerSize}"></d2l-loading-spinner>
 			</div>`;
 	}

--- a/components/overlay.js
+++ b/components/overlay.js
@@ -34,7 +34,7 @@ class Overlay extends LitElement {
 
 			.d2l-insights-overlay-container {
 				align-items: center;
-				background-color: var( --d2l-color-white );
+				background-color: var(--d2l-color-white);
 				border-radius: 15px;
 				display: flex;
 				height: 100%;

--- a/components/summary-card.js
+++ b/components/summary-card.js
@@ -93,9 +93,14 @@ class SummaryCard extends SkeletonMixin(Localizer(LitElement)) {
 			}
 
 			:host([skeleton]) .d2l-insights-summary-card-body > div {
+				flex-shrink: 0;
 				height: 70px;
-				margin-right: 10px;
+				margin: 0 10px;
 				width: 70px;
+			}
+
+			:host([skeleton]) .d2l-insights-summary-card-title {
+				margin-left: 10px;
 			}
 		`];
 	}

--- a/components/summary-card.js
+++ b/components/summary-card.js
@@ -1,5 +1,5 @@
 import '@brightspace-ui/core/components/offscreen/offscreen.js';
-import './overlay';
+import './card-overlay';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { Localizer } from '../locales/localizer';
@@ -40,6 +40,7 @@ class SummaryCard extends SkeletonMixin(Localizer(LitElement)) {
 				height: 121px;
 				margin-top: 10px;
 				padding: 15px 4px;
+				position: relative;
 				width: 280px;
 			}
 
@@ -47,8 +48,6 @@ class SummaryCard extends SkeletonMixin(Localizer(LitElement)) {
 				align-items: center;
 				display: flex;
 				height: 100%;
-				position: relative;
-
 			}
 
 			.d2l-insights-summary-card-title {
@@ -91,17 +90,6 @@ class SummaryCard extends SkeletonMixin(Localizer(LitElement)) {
 				margin-inline-start: 2%;
 				max-width: 180px;
 			}
-
-			:host([skeleton]) .d2l-insights-summary-card-body > div {
-				flex-shrink: 0;
-				height: 70px;
-				margin: 0 10px;
-				width: 70px;
-			}
-
-			:host([skeleton]) .d2l-insights-summary-card-title {
-				margin-left: 10px;
-			}
 		`];
 	}
 
@@ -120,9 +108,8 @@ class SummaryCard extends SkeletonMixin(Localizer(LitElement)) {
 		// NB: relying on mobx rather than lit-element properties to handle update detection: it will trigger a redraw for
 		// any change to a relevant observed property of the Data object
 		return html`<div class="d2l-insights-summary-card">
-			<div class="d2l-insights-summary-card-title d2l-skeletize d2l-skeletize-45 d2l-body-standard">${this.title}</div>
+			<div class="d2l-insights-summary-card-title d2l-body-standard">${this.title}</div>
 			<div class="d2l-insights-summary-card-body" aria-hidden="${this.skeleton}">
-				<div class="d2l-skeletize">
 					${this.isValueClickable ? html`<button
  						class="d2l-insights-summary-card-button d2l-insights-summary-card-field"
  						@click=${this._valueClickHandler}
@@ -136,12 +123,12 @@ class SummaryCard extends SkeletonMixin(Localizer(LitElement)) {
  						<span aria-hidden="true">${this.value}</span>
  						<d2l-offscreen>${this.summaryLabel}</d2l-offscreen>
  					</span>`}
-				</div>
 				<span
-					class="d2l-insights-summary-card-message d2l-insights-summary-card-field d2l-skeletize-paragraph-3"
+					class="d2l-insights-summary-card-message d2l-insights-summary-card-field"
 					aria-hidden="true"
 				>${this.message}</span>
 			</div>
+			<d2l-insights-card-overlay ?skeleton="${this.skeleton}"></d2l-insights-card-overlay>
 		</div>`;
 	}
 }

--- a/test/components/card-overlay.test.js
+++ b/test/components/card-overlay.test.js
@@ -1,0 +1,34 @@
+import '../../components/card-overlay';
+
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
+
+describe('d2l-insights-card-overlay', () => {
+	describe('constructor', () => {
+		it('should construct', () => {
+			runConstructor('d2l-insights-card-overlay');
+		});
+	});
+
+	describe('accessibility', () => {
+		it('should pass all axe tests', async() => {
+			const el = await fixture(html`<d2l-insights-card-overlay skeleton></d2l-insights-card-overlay>`);
+			await expect(el).to.be.accessible();
+		});
+	});
+
+	describe('render', () => {
+		it('should render overlay in front of parent div with the size of parent div', async() => {
+			const parentNode = document.createElement('div');
+			parentNode.setAttribute('style', 'height: 100px; width: 100px; position: relative;');
+			const el = await fixture(html`<d2l-insights-card-overlay skeleton></d2l-insights-card-overlay>`, { parentNode });
+
+			expect(el.clientHeight).to.equal(100);
+			expect(el.clientWidth).to.equal(100);
+
+			el.removeAttribute('skeleton');
+			await elementUpdated(el);
+			expect(el.skeleton).to.equal(false);
+		});
+	});
+});

--- a/test/engagement-dashboard.test.js
+++ b/test/engagement-dashboard.test.js
@@ -6,7 +6,7 @@ describe('d2l-insights-engagement-dashboard', () => {
 
 	describe('accessibility', () => {
 		it('should pass all axe tests', async function() {
-			this.timeout(5000);
+			this.timeout(7000);
 
 			const el = await fixture(html`<d2l-insights-engagement-dashboard demo></d2l-insights-engagement-dashboard>`);
 			// need for this delay might be tied to the mock data async loading in engagement-dashboard.js


### PR DESCRIPTION
[DE41152](https://rally1.rallydev.com/#/detail/defect/450306771184?fdp=true): [Engage] Discussion Activity shows spinner shifted to the left edge of the card

This PR introduces `d2l-insights-card-overlay`. This way we can show consistent skeletons for different card types

### Functional Testing
* Unit tests pass
* Verify look of the dashboard when it's loading
* Verify look of the dashboard when it's finished loading
### Security Testing - N/A
### Performance Testing - N/A
### Devops - N/A
### UX and docs
* Responsive UI works
* Accessible (screen reader / keyboard nav)
* Browsers
  * Chrome
  * FF
  * Edgium
  * ~Edge Legacy N/A~

Before
![image](https://user-images.githubusercontent.com/9429561/98252190-4d6b0180-1f82-11eb-840a-87f00a0e6381.png)

After
![image](https://user-images.githubusercontent.com/9429561/98397096-7b764180-2067-11eb-9cd8-c51015aea9c9.png)




FYI @anhill-D2L @MykolaGalian @rohitvinnakota @hyehayes @johngwilkinson 