### PR TITLE
Font for summary cards

### DIFF
--- a/components/summary-card.js
+++ b/components/summary-card.js
@@ -79,7 +79,7 @@ class SummaryCard extends SkeletonMixin(Localizer(LitElement)) {
 				border: none;
 				color: var(--d2l-color-celestine);
 				cursor: pointer;
-				font-family: 'Lato', sans-serif;;
+				font-family: 'Lato', sans-serif;
 				font-size: 22px;
 				font-weight: bold;
 				margin: 10px;

--- a/components/summary-card.js
+++ b/components/summary-card.js
@@ -79,6 +79,7 @@ class SummaryCard extends SkeletonMixin(Localizer(LitElement)) {
 				border: none;
 				color: var(--d2l-color-celestine);
 				cursor: pointer;
+				font-family: 'Lato';
 				font-size: 22px;
 				font-weight: bold;
 				margin: 10px;

--- a/components/summary-card.js
+++ b/components/summary-card.js
@@ -79,7 +79,7 @@ class SummaryCard extends SkeletonMixin(Localizer(LitElement)) {
 				border: none;
 				color: var(--d2l-color-celestine);
 				cursor: pointer;
-				font-family: 'Lato';
+				font-family: 'Lato', sans-serif;;
 				font-size: 22px;
 				font-weight: bold;
 				margin: 10px;


### PR DESCRIPTION
[DE41200](https://rally1.rallydev.com/#/detail/defect/450971805256?fdp=true): [Engagement] Font for clickable summary cards is wrong

A.C.
Font for clickable summary cards should be Lato

Tested in browsers (Windows 10 Chrome, Firefox, Edge)

@bemailloux  @hyehayes @Vitalii-Misechko @anhill-D2L @johngwilkinson 