### PR TITLE
DE41206 [Engage] Fix cards' and charts' skeleton look

### DIFF
--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -2,6 +2,7 @@ import 'highcharts';
 import 'highcharts/modules/histogram-bellcurve';
 import 'highcharts/modules/accessibility';
 import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
+import '../overlay';
 
 import { css, html, LitElement } from 'lit-element';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
@@ -113,7 +114,7 @@ class Chart extends SkeletonMixin(LitElement) {
 
 		return html`
 			<div id="chart-container" tabindex="${this.skeleton ? -1 : 0}"></div>
-			<d2l-insights-overlay spinner-size="150" ?loading="${this.skeleton && !this.doNotUseOverlay}"></d2l-insights-overlay>
+			<d2l-insights-overlay spinner-size="150" ?skeleton="${this.skeleton && !this.doNotUseOverlay}"></d2l-insights-overlay>
 		`;
 	}
 

--- a/components/course-last-access-card.js
+++ b/components/course-last-access-card.js
@@ -93,6 +93,10 @@ class CourseLastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 				font-weight: bold;
 				text-indent: 3%;
 			}
+
+			:host([skeleton]) .d2l-insights-course-last-access-title {
+				margin-left: 19px;
+			}
 		`];
 	}
 

--- a/components/current-final-grade-card.js
+++ b/components/current-final-grade-card.js
@@ -72,6 +72,10 @@ class CurrentFinalGradeCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 				font-weight: bold;
 				text-indent: 3%;
 			}
+
+			:host([skeleton]) .d2l-insights-current-final-grade-title {
+				margin-left: 19px;
+			}
 		`];
 	}
 

--- a/components/overlay.js
+++ b/components/overlay.js
@@ -1,30 +1,30 @@
 import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
 
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
 /**
  * Requires that parent element has non-static position property. For instance, position: relative;
  *
  * @property {Number} spinner-size
- * @property {Boolean} loading
  */
-class Overlay extends LitElement {
+class Overlay extends SkeletonMixin(LitElement) {
 	static get properties() {
 		return {
-			spinnerSize: { type: Number, attribute: 'spinner-size' },
-			isLoading: { type: Boolean, attribute: 'loading' }
+			spinnerSize: { type: Number, attribute: 'spinner-size' }
 		};
 	}
 
 	static get styles() {
-		return css`
+		return [super.styles, bodyStandardStyles, css`
 			:host {
 				display: block;
 				left: 0;
 				position: absolute;
 				top: 0;
 			}
-			:host([loading]) {
+			:host([skeleton]) {
 				height: 100%;
 				width: 100%;
 			}
@@ -42,11 +42,11 @@ class Overlay extends LitElement {
 				margin: 1 1 1 1;
 				width: 100%;
 			}
-		`;
+		`];
 	}
 
 	render() {
-		if (!this.isLoading) {
+		if (!this.skeleton) {
 			return html``;
 		}
 

--- a/components/overlay.js
+++ b/components/overlay.js
@@ -1,7 +1,6 @@
 import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
 
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
 /**
@@ -17,7 +16,7 @@ class Overlay extends SkeletonMixin(LitElement) {
 	}
 
 	static get styles() {
-		return [super.styles, bodyStandardStyles, css`
+		return [super.styles, css`
 			:host {
 				display: block;
 				left: 0;

--- a/components/summary-card.js
+++ b/components/summary-card.js
@@ -116,7 +116,7 @@ class SummaryCard extends SkeletonMixin(Localizer(LitElement)) {
 		return html`<div class="d2l-insights-summary-card">
 			<div class="d2l-insights-summary-card-title d2l-body-standard">${this.title}</div>
 			<div class="d2l-insights-summary-card-body" aria-hidden="${this.skeleton}">
-					${this.isValueClickable ? html`<button
+					${this.isValueClickable ? html`<button tabindex="${this.skeleton ? -1 : 0}"
  						class="d2l-insights-summary-card-button d2l-insights-summary-card-field"
  						@click=${this._valueClickHandler}
  					>

--- a/components/time-in-content-vs-grade-card.js
+++ b/components/time-in-content-vs-grade-card.js
@@ -138,6 +138,10 @@ class TimeInContentVsGradeCard extends SkeletonMixin(Localizer(MobxLitElement)) 
 				font-weight: bold;
 				text-indent: 3%;
 			}
+
+			:host([skeleton]) .d2l-insights-time-in-content-vs-grade-title {
+				margin-left: 19px;
+			}
 		`];
 	}
 

--- a/test/components/overlay.test.js
+++ b/test/components/overlay.test.js
@@ -12,7 +12,7 @@ describe('d2l-insights-overlay', () => {
 
 	describe('accessibility', () => {
 		it('should pass all axe tests', async() => {
-			const el = await fixture(html`<d2l-insights-overlay loading spinner-size='50'></d2l-insights-overlay>`);
+			const el = await fixture(html`<d2l-insights-overlay skeleton spinner-size='50'></d2l-insights-overlay>`);
 			await expect(el).to.be.accessible();
 		});
 	});
@@ -21,14 +21,14 @@ describe('d2l-insights-overlay', () => {
 		it('should render overlay in front of parent div with the size of parent div', async() => {
 			const parentNode = document.createElement('div');
 			parentNode.setAttribute('style', 'height: 100px; width: 100px; position: relative;');
-			const el = await fixture(html`<d2l-insights-overlay loading spinner-size='10'></d2l-insights-overlay>`, { parentNode });
+			const el = await fixture(html`<d2l-insights-overlay skeleton spinner-size='10'></d2l-insights-overlay>`, { parentNode });
 
 			expect(el.clientHeight).to.equal(100);
 			expect(el.clientWidth).to.equal(100);
 
-			el.removeAttribute('loading');
+			el.removeAttribute('skeleton');
 			await elementUpdated(el);
-			expect(el.isLoading).to.equal(false);
+			expect(el.skeleton).to.equal(false);
 		});
 	});
 });


### PR DESCRIPTION
[DE41206](https://rally1.rallydev.com/#/detail/defect/451146798800?fdp=true): [Engage] Fix cards' and charts' skeleton look

FYI @anhill-D2L @MykolaGalian @rohitvinnakota @hyehayes @johngwilkinson 

### Functional Testing
* Unit tests pass
* Verify look of the dashboard when it's loading
* Verify look of the dashboard when it's finished loading
### Security Testing - N/A
### Performance Testing - N/A
### Devops - N/A
### UX and docs
* Responsive UI works
* Accessible (screen reader / keyboard nav)
* Browsers
  * Chrome
  * FF
  * Edgium
  * ~Edge Legacy N/A~

- [x] Demo to Kevin

## Before
![image](https://user-images.githubusercontent.com/9429561/98553423-44db3980-22a8-11eb-931c-71943baf0f8a.png)

## After

![image](https://user-images.githubusercontent.com/9429561/98553492-57557300-22a8-11eb-878c-5d883689f11d.png)


