### PR TITLE
US122260: show loading indicators when going back to the server for data

### DIFF
--- a/model/data.js
+++ b/model/data.js
@@ -44,6 +44,7 @@ export class Data {
 	}
 
 	loadData({ newRoleIds = null, newSemesterIds = null, newOrgUnitIds = null, defaultView = false }) {
+		this.isLoading = true;
 		const filters = {
 			roleIds: newRoleIds || this._selectorFilters.role.selected,
 			semesterIds: newSemesterIds || this._selectorFilters.semester.selected,


### PR DESCRIPTION
I realized this was a one-liner. :)

Quality:
* functional
  * first page load
  * clear ou filter (no server hit): no skeletons/spinners
  * clear semester filter: cards go to skeletons and spinners until load completes
  * clear semesters first, then add and clear ous (all server hits): spinners and skeletons on each change
* ux/docs/devops/perf/security: n/a

FYI @bemailloux @MykolaGalian @NicholasHallman @rohitvinnakota 