### PR TITLE
US121459: fix broken osx test

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ npm run test:headless
 npm run test:headless:watch
 ```
 
+#### Note on Sauce Labs tests
+
+Pull requests run cross-browser tests using Sauce. For troubleshooting,
+see https://wiki.saucelabs.com/pages/viewpage.action?pageId=70072943.
+
 ### Visual Diff Testing
 
 This repo uses the [@brightspace-ui/visual-diff utility](https://github.com/BrightspaceUI/visual-diff/) to compare current snapshots against a set of golden snapshots stored in source control.

--- a/test/components/expander-with-control.test.js
+++ b/test/components/expander-with-control.test.js
@@ -73,7 +73,7 @@ describe('d2l-insights-expander-with-control', () => {
 
 		// This test fails on Chrome/OSX and it seems to sometimes crash Safari as well. I don't understand why, but
 		// collapsing and expanding does work on a real LMS
-		it.skip('should fire collapsed event if element is expanded and control is clicked', async function() {
+		it('should fire collapsed event if element is expanded and control is clicked', async function() {
 			this.timeout(3000);
 
 			const controlDiv = elExpanded.shadowRoot.querySelector('div');

--- a/test/components/expander-with-control.test.js
+++ b/test/components/expander-with-control.test.js
@@ -1,6 +1,6 @@
 import '../../components/expander-with-control';
 
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper';
 
 describe('d2l-insights-expander-with-control', () => {
@@ -71,26 +71,30 @@ describe('d2l-insights-expander-with-control', () => {
 
 	describe('interactions/eventing', () => {
 
+		// This test fails on Chrome/OSX and it seems to sometimes crash Safari as well. I don't understand why, but
+		// collapsing and expanding does work on a real LMS
 		it('should fire collapsed event if element is expanded and control is clicked', async function() {
 			this.timeout(3000);
 
-			const controlDiv = elExpanded.shadowRoot.querySelector('div');
-			const promise = new Promise(resolve => {
-				elExpanded.addEventListener('d2l-insights-expander-with-control-collapsed', (e => resolve(e)), { once: true });
-			});
+			const listener = oneEvent(elExpanded, 'd2l-insights-expander-with-control-collapsed');
+
+			const controlDiv = elExpanded.shadowRoot.querySelector('d2l-button-icon');
 			controlDiv.click();
-			await promise;
+
+			const event = await listener;
+			expect(event.target).to.equal(elExpanded);
 		});
 
 		it('should fire expanded event if element is collapsed and control is clicked', async function() {
 			this.timeout(3000);
 
-			const controlDiv = elCollapsed.shadowRoot.querySelector('div');
-			const promise = new Promise(resolve => {
-				elCollapsed.addEventListener('d2l-insights-expander-with-control-expanded', (e => resolve(e)), { once: true });
-			});
+			const listener = oneEvent(elCollapsed, 'd2l-insights-expander-with-control-expanded');
+
+			const controlDiv = elCollapsed.shadowRoot.querySelector('d2l-button-icon');
 			controlDiv.click();
-			await promise;
+
+			const event = await listener;
+			expect(event.target).to.equal(elCollapsed);
 		});
 	});
 });

--- a/test/components/expander-with-control.test.js
+++ b/test/components/expander-with-control.test.js
@@ -71,8 +71,6 @@ describe('d2l-insights-expander-with-control', () => {
 
 	describe('interactions/eventing', () => {
 
-		// This test fails on Chrome/OSX and it seems to sometimes crash Safari as well. I don't understand why, but
-		// collapsing and expanding does work on a real LMS
 		it('should fire collapsed event if element is expanded and control is clicked', async function() {
 			this.timeout(3000);
 

--- a/test/components/expander-with-control.test.js
+++ b/test/components/expander-with-control.test.js
@@ -1,6 +1,6 @@
 import '../../components/expander-with-control';
 
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper';
 
 describe('d2l-insights-expander-with-control', () => {
@@ -76,22 +76,25 @@ describe('d2l-insights-expander-with-control', () => {
 		it('should fire collapsed event if element is expanded and control is clicked', async function() {
 			this.timeout(3000);
 
+			const listener = oneEvent(elExpanded, 'd2l-insights-expander-with-control-collapsed');
+
 			const controlDiv = elExpanded.shadowRoot.querySelector('div');
-			const promise = new Promise(resolve => {
-				elExpanded.addEventListener('d2l-insights-expander-with-control-collapsed', (e => resolve(e)), { once: true });
-			});
 			controlDiv.click();
-			await promise;
+
+			const event = await listener;
+			expect(event.target).to.equal(elExpanded);
 		});
 
 		it('should fire expanded event if element is collapsed and control is clicked', async function() {
 			this.timeout(3000);
 
+			const listener = oneEvent(elCollapsed, 'd2l-insights-expander-with-control-expanded');
+
 			const controlDiv = elCollapsed.shadowRoot.querySelector('div');
-			setTimeout(() => controlDiv.click());
-			await new Promise(resolve => {
-				elCollapsed.addEventListener('d2l-insights-expander-with-control-expanded', (e => resolve(e)), { once: true });
-			});
+			controlDiv.click();
+
+			const event = await listener;
+			expect(event.target).to.equal(elCollapsed);
 		});
 	});
 });

--- a/test/components/expander-with-control.test.js
+++ b/test/components/expander-with-control.test.js
@@ -1,6 +1,6 @@
 import '../../components/expander-with-control';
 
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper';
 
 describe('d2l-insights-expander-with-control', () => {
@@ -74,25 +74,23 @@ describe('d2l-insights-expander-with-control', () => {
 		it('should fire collapsed event if element is expanded and control is clicked', async function() {
 			this.timeout(3000);
 
-			const listener = oneEvent(elExpanded, 'd2l-insights-expander-with-control-collapsed');
-
 			const controlDiv = elExpanded.shadowRoot.querySelector('div');
+			const promise = new Promise(resolve => {
+				elExpanded.addEventListener('d2l-insights-expander-with-control-collapsed', (e => resolve(e)), { once: true });
+			});
 			controlDiv.click();
-
-			const event = await listener;
-			expect(event.target).to.equal(elExpanded);
+			await promise;
 		});
 
 		it('should fire expanded event if element is collapsed and control is clicked', async function() {
 			this.timeout(3000);
 
-			const listener = oneEvent(elCollapsed, 'd2l-insights-expander-with-control-expanded');
-
 			const controlDiv = elCollapsed.shadowRoot.querySelector('div');
+			const promise = new Promise(resolve => {
+				elCollapsed.addEventListener('d2l-insights-expander-with-control-expanded', (e => resolve(e)), { once: true });
+			});
 			controlDiv.click();
-
-			const event = await listener;
-			expect(event.target).to.equal(elCollapsed);
+			await promise;
 		});
 	});
 });

--- a/test/components/expander-with-control.test.js
+++ b/test/components/expander-with-control.test.js
@@ -71,10 +71,10 @@ describe('d2l-insights-expander-with-control', () => {
 
 	describe('interactions/eventing', () => {
 
-		// This test fails on Chrome/OSX and it seems to sometimes crash Safari as well. I don't understand why, but
-		// collapsing and expanding does work on a real LMS
 		it('should fire collapsed event if element is expanded and control is clicked', async function() {
-			this.timeout(3000);
+			// during Sauce tests, on Chrome for Mac, the wait for next animation frame in the d2l-expand-collapse-content
+			// sometimes takes over ten seconds - this is presumably an artifact of that test environment
+			this.timeout(15000);
 
 			const listener = oneEvent(elExpanded, 'd2l-insights-expander-with-control-collapsed');
 
@@ -86,7 +86,7 @@ describe('d2l-insights-expander-with-control', () => {
 		});
 
 		it('should fire expanded event if element is collapsed and control is clicked', async function() {
-			this.timeout(3000);
+			this.timeout(15000);
 
 			const listener = oneEvent(elCollapsed, 'd2l-insights-expander-with-control-expanded');
 

--- a/test/components/expander-with-control.test.js
+++ b/test/components/expander-with-control.test.js
@@ -77,10 +77,11 @@ describe('d2l-insights-expander-with-control', () => {
 			this.timeout(3000);
 
 			const controlDiv = elExpanded.shadowRoot.querySelector('div');
-			setTimeout(() => controlDiv.click());
-			await new Promise(resolve => {
+			const promise = new Promise(resolve => {
 				elExpanded.addEventListener('d2l-insights-expander-with-control-collapsed', (e => resolve(e)), { once: true });
 			});
+			controlDiv.click();
+			await promise;
 		});
 
 		it('should fire expanded event if element is collapsed and control is clicked', async function() {


### PR DESCRIPTION
The test used to create an event-handler after a setTimeout call which attempted to make sure the click happened after the event-handler was attached. This looks like a possible race condition, and straightening it out by creating the promise before clicking (then awaiting it after) did fix the issue (see earlier commit). But there's also a utility, `oneEvent` we use elsewhere for this purpose, so I updated the code to use that.

Quality Notes: test change only

FYI @anhill-D2L @MykolaGalian @rohitvinnakota @Vitalii-Misechko 