### PR TITLE
US121773 [UserDrill] Create the page

### DIFF
--- a/components/user-drill-view.js
+++ b/components/user-drill-view.js
@@ -1,0 +1,144 @@
+import '@brightspace-ui/core/components/icons/icon.js';
+import '@brightspace-ui/core/components/button/button.js';
+import { bodySmallStyles, heading2Styles } from '@brightspace-ui/core/components/typography/styles.js';
+import { css, html } from 'lit-element/lit-element.js';
+import { Localizer } from '../locales/localizer';
+import { MobxLitElement } from '@adobe/lit-mobx';
+
+/**
+ * @property {Object} user - {firstName, lastName, username, userId}
+ * @fires d2l-insights-user-drill-view-back
+ */
+class UserDrill extends Localizer(MobxLitElement) {
+	static get properties() {
+		return {
+			user: { type: Object, attribute: false }
+		};
+	}
+
+	static get styles() {
+		return [
+			bodySmallStyles, heading2Styles,
+			css`
+			:host {
+				display: block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+
+			.d2l-insights-user-drill-view-container {
+				width: 100%;
+				padding-top: 30px;
+			}
+
+			.d2l-insights-user-drill-view-container > d2l-button {
+				margin-top: 24px;
+			}
+
+			.d2l-insights-user-drill-view-header-panel {
+				width: 100%;
+				display: flex;
+				flex-direction: row;
+				justify-content: space-between;
+			}
+
+			.d2l-insights-user-drill-view-profile {
+				display: flex;
+			}
+
+			.d2l-insights-user-drill-view-profile-pic {
+				--d2l-icon-height: 100px;
+				--d2l-icon-width: 100px;
+				margin-right: 12px;
+			}
+
+			.d2l-insights-user-drill-view-profile-name {
+				display: flex;
+    			flex-direction: column;
+			}
+
+			.d2l-insights-user-drill-view-profile-name > div.d2l-heading-2 {
+				margin: 0;
+				margin-top: 18px;
+			}
+
+			.d2l-insights-user-drill-view-profile-name > div.d2l-body-small {
+				margin: 0;
+				margin-top: 12px;
+			}
+
+			.d2l-insights-user-drill-view-content {
+				width: 100;
+			}
+
+			.d2l-main-action-button-group {
+				flex-grow: 1;
+				margin: 0.7em;
+				max-width: 300px;
+			}
+		`];
+	}
+
+	_exportToCsvHandler() {
+		// outside the scope of the story
+	}
+
+	_printHandler() {
+		// outside the scope of the story
+	}
+
+	_composeEmailHandler() {
+		// outside the scope of the story
+		/**
+		 * @event d2l-insights-user-drill-view-back
+		 */
+		this.dispatchEvent(new CustomEvent('d2l-insights-user-drill-view-back'));
+	}
+
+	render() {
+		return html`<div class="d2l-insights-user-drill-view-container">
+
+			<div class="d2l-insights-user-drill-view-header-panel">
+
+				<div class="d2l-insights-user-drill-view-profile">
+					<d2l-icon class="d2l-insights-user-drill-view-profile-pic" icon="tier3:profile-pic"></d2l-icon>
+					<div class="d2l-insights-user-drill-view-profile-name">
+						<div class="d2l-heading-2">${this.user.firstName}, ${this.user.lastName}</div>
+						<div class="d2l-body-small">${this.user.username} - ${this.user.userId}</div>
+					</div>
+				</div>
+
+				<d2l-action-button-group
+						class="d2l-main-action-button-group"
+						min-to-show="0"
+						max-to-show="2"
+						opener-type="more"
+					>
+					<d2l-button-subtle
+						icon="d2l-tier1:export"
+						text=${this.localize('components.insights-user-drill-view.exportToCsv')}
+						@click="${this._exportToCsvHandler}">
+					</d2l-button-subtle>
+					<d2l-button-subtle
+						icon="d2l-tier1:print"
+						text=${this.localize('components.insights-user-drill-view.print')}
+						@click="${this._printHandler}">
+					</d2l-button-subtle>
+				</d2l-action-button-group>
+
+			</div>
+
+			<d2l-button
+				primary
+				@click="${this._composeEmailHandler}"
+			>${this.localize('components.insights-user-drill-view.emailButton')}</d2l-button>
+
+			<div class="d2l-insights-user-drill-view-content">
+				<!-- put your tables here -->
+			</div>
+
+		</div>`;
+	}
+}
+customElements.define('d2l-insights-user-drill-view', UserDrill);

--- a/components/user-drill-view.js
+++ b/components/user-drill-view.js
@@ -28,8 +28,8 @@ class UserDrill extends Localizer(MobxLitElement) {
 			}
 
 			.d2l-insights-user-drill-view-container {
-				width: 100%;
 				padding-top: 30px;
+				width: 100%;
 			}
 
 			.d2l-insights-user-drill-view-container > d2l-button {
@@ -37,10 +37,10 @@ class UserDrill extends Localizer(MobxLitElement) {
 			}
 
 			.d2l-insights-user-drill-view-header-panel {
-				width: 100%;
 				display: flex;
 				flex-direction: row;
 				justify-content: space-between;
+				width: 100%;
 			}
 
 			.d2l-insights-user-drill-view-profile {
@@ -55,7 +55,7 @@ class UserDrill extends Localizer(MobxLitElement) {
 
 			.d2l-insights-user-drill-view-profile-name {
 				display: flex;
-    			flex-direction: column;
+				flex-direction: column;
 			}
 
 			.d2l-insights-user-drill-view-profile-name > div.d2l-heading-2 {

--- a/demo/index.html
+++ b/demo/index.html
@@ -34,11 +34,19 @@
 		<meta charset="UTF-8">
 	</head>
 	<style>
+		html, body {
+			height: 100%;
+		}
 		body {
 			background-color: white;
 		}
 	</style>
 	<body>
-		<d2l-insights-engagement-dashboard demo telemetry-endpoint="https://example.com/api/events/" telemetry-id="cfc669e0-509e-4ed0-b932-4a7ec5c2d8c7"></d2l-insights-engagement-dashboard>
+		<d2l-insights-engagement-dashboard
+			view='user'
+			demo
+			telemetry-endpoint="https://example.com/api/events/"
+			telemetry-id="cfc669e0-509e-4ed0-b932-4a7ec5c2d8c7"
+		></d2l-insights-engagement-dashboard>
 	</body>
 </html>

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -16,6 +16,7 @@ import './components/course-last-access-card.js';
 import './components/discussion-activity-card.js';
 import './components/message-container.js';
 import './components/default-view-popup.js';
+import './components/user-drill-view.js';
 
 import { css, html } from 'lit-element/lit-element.js';
 import { getPerformanceLoadPageMeasures, TelemetryHelper } from './model/telemetry-helper';
@@ -38,6 +39,7 @@ import { toJS } from 'mobx';
 
 /**
  * @property {Boolean} isDemo - if true, use canned data; otherwise call the LMS
+ * @property {String} currentView - is the name of supported view. Valid values: home, user, settings
  * @property {String} telemetryEndpoint - endpoint for gathering telemetry performance data
  * @property {String} telemetryId - GUID that is used to group performance metrics for each separate page load
  */
@@ -46,9 +48,15 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 	static get properties() {
 		return {
 			isDemo: { type: Boolean, attribute: 'demo' },
+			currentView: { type: String, attribute: 'view', reflect: true },
 			telemetryEndpoint: { type: String, attribute: 'telemetry-endpoint' },
 			telemetryId: { type: String, attribute: 'telemetry-id' },
 		};
+	}
+
+	constructor() {
+		super();
+		this.currentView = 'home';
 	}
 
 	static get styles() {
@@ -149,6 +157,29 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 	}
 
 	render() {
+		switch (this.currentView) {
+			case 'home': return this._renderHomeView();
+			case 'user': return this._renderUserDrillView();
+		}
+	}
+
+	_renderUserDrillView() {
+		const user = {
+			firstName: 'Dane',
+			lastName: 'Clarie',
+			username: 'claire.dane',
+			userId: 887
+		};
+
+		return html`
+			<d2l-insights-user-drill-view
+				.user="${user}"
+				@d2l-insights-user-drill-view-back="${this._backToHomeHandler}"
+			></d2l-insights-user-drill-view>
+		`;
+	}
+
+	_renderHomeView() {
 		return html`
 
 				<d2l-insights-aria-loading-progress .data="${this._data}"></d2l-insights-aria-loading-progress>
@@ -234,6 +265,11 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					</d2l-button>
 				</d2l-dialog-confirm>
 		`;
+	}
+
+	_backToHomeHandler(event) {
+		event.stopPropagation();
+		this.currentView = 'home';
 	}
 
 	_exportToCsv() {

--- a/locales/en.js
+++ b/locales/en.js
@@ -135,5 +135,9 @@ export default {
 	"components.insights-default-view-popup.emptyResultsFromNRecentSemesters": "This dashboard is designed to look at portions of your organization's engagement. You do not have permission to review data in any courses in the most recently created {numDefaultSemesters} semesters.",
 	"components.insights-default-view-popup.expandDefaultCourseList": "Expand to see the courses included in your default view",
 	"components.insights-default-view-popup.collapseDefaultCourseList": "Collapse the list of courses included in your default view",
-	"components.insights-default-view-popup.buttonOk": "Ok"
+	"components.insights-default-view-popup.buttonOk": "Ok",
+
+	"components.insights-user-drill-view.exportToCsv": "Export to CSV",
+	"components.insights-user-drill-view.print": "Print",
+	"components.insights-user-drill-view.emailButton": "Back"
 };


### PR DESCRIPTION
[US121773](https://rally1.rallydev.com/#/detail/userstory/449082079828?fdp=true): [Engagement][UserDrill] Create the page

FYI @anhill-D2L @MykolaGalian @rohitvinnakota @hyehayes @NicholasHallman 

Minimal working solution that would allow other developers to work on UserDrill in demo page.

What is in-progress (separate PR/PRs):
 * ImmersiveNav as a part of engagement dashboard
 * Navigation to the new page by clicking on user name
 * Routing based on `page.js` that supports browser's Back button
 * Page design refining

### Functional Testing
* Unit tests pass
* Manual tests
  * The new page is available by default in demo page.
  * `d2l-insights-engagement-dashboard` behavior is not changed when it's invoked from LMS
### Security Testing - N/A
### Performance Testing - N/A
### Devops - N/A
### UX and docs - N/A

![image](https://user-images.githubusercontent.com/9429561/99539395-dc324200-29b6-11eb-952f-1e51db176b25.png)

