### PR TITLE
Us120701/move immersive nav

### DIFF
--- a/components/immersive-nav.js
+++ b/components/immersive-nav.js
@@ -1,0 +1,77 @@
+import 'd2l-navigation/d2l-navigation-immersive';
+import 'd2l-navigation/d2l-navigation-link-back';
+
+import { css, html, LitElement } from 'lit-element/lit-element';
+
+// Extends the standard immersive nav to resize the back link on small screens
+class InsightsImmersiveNav extends LitElement {
+	static get properties() {
+		return {
+			href: { type: String, attribute: true },
+			mainText: { type: String, attribute: 'main-text' },
+			backText: { type: String, attribute: 'back-text' },
+			backTextShort: { type: String, attribute: 'back-text-short' } // optional - will default to backText if unspecified
+		};
+	}
+
+	static get styles() {
+		return [css`
+			.d2l-insights-immersive-nav-title {
+				align-items: center;
+				display: flex;
+			}
+
+			.d2l-insights-link-back-default {
+				display: inline-block;
+			}
+
+			.d2l-insights-link-back-responsive {
+				display: none;
+			}
+
+			@media screen and (max-width: 615px) {
+				.d2l-insights-link-back-default {
+					display: none;
+				}
+
+				.d2l-insights-link-back-responsive {
+					display: inline-block;
+				}
+			}
+		`];
+	}
+
+	constructor() {
+		super();
+		this.href = '';
+		this.mainText = '';
+		this.backText = '';
+		this.backTextShort = '';
+	}
+
+	render() {
+		return html`
+			<d2l-navigation-immersive width-type="fullscreen">
+
+				<div slot="left">
+					<d2l-navigation-link-back
+						text="${this.backText}"
+						href="${this.href}"
+						class="d2l-insights-link-back-default">
+					</d2l-navigation-link-back>
+					<d2l-navigation-link-back
+						text="${this.backTextShort || this.backText}"
+						href="${this.href}"
+						class="d2l-insights-link-back-responsive">
+					</d2l-navigation-link-back>
+				</div>
+
+				<div slot="middle" class="d2l-insights-immersive-nav-title">
+					${this.mainText}
+				</div>
+
+			</d2l-navigation-immersive>
+		`;
+	}
+}
+customElements.define('d2l-insights-immersive-nav', InsightsImmersiveNav);

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -84,8 +84,8 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				}
 
 				.d2l-insights-immersive-nav-title {
+					align-items: center;
 					display: flex;
-  					align-items: center;
 				}
 
 				.d2l-insights-chart-container {
@@ -254,88 +254,88 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 	_renderHomeView() {
 		return html`
 
-				<d2l-insights-aria-loading-progress .data="${this._data}"></d2l-insights-aria-loading-progress>
+			<d2l-insights-aria-loading-progress .data="${this._data}"></d2l-insights-aria-loading-progress>
 
-				<div class="d2l-heading-button-group">
-					<h1 class="d2l-heading-1">${this.localize('components.insights-engagement-dashboard.title')}</h1>
-					<d2l-action-button-group
-						class="d2l-main-action-button-group"
-						min-to-show="0"
-						max-to-show="2"
-						opener-type="more"
-					>
-						<d2l-button-subtle
-							icon="d2l-tier1:export"
-							text=${this.localize('components.insights-engagement-dashboard.exportToCsv')}
-							@click="${this._exportToCsv}">
-						</d2l-button-subtle>
-						<d2l-button-subtle
-							icon="d2l-tier1:help"
-							text=${this.localize('components.insights-engagement-dashboard.learMore')}
-							@click="${this._openHelpLink}">
-						</d2l-button-subtle>
-					</d2l-action-button-group>
-				</div>
-
-				<div class="view-filters-container">
-					<d2l-insights-ou-filter
-						.data="${this._serverData}"
-						@d2l-insights-ou-filter-change="${this._orgUnitFilterChange}"
-					></d2l-insights-ou-filter>
-					<d2l-insights-semester-filter
-						page-size="10000"
-						?demo="${this.isDemo}"
-						.preSelected="${this._serverData.selectedSemesterIds}"
-						@d2l-insights-semester-filter-change="${this._semesterFilterChange}"
-					></d2l-insights-semester-filter>
-					<d2l-insights-role-filter
-						@d2l-insights-role-filter-change="${this._roleFilterChange}"
-						?demo="${this.isDemo}"
-					></d2l-insights-role-filter>
-				</div>
-				<d2l-insights-message-container .data="${this._data}" .isNoDataReturned="${this._isNoUserResults}"></d2l-insights-message-container>
-				<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.summaryHeading')}</h2>
-				<div class="d2l-insights-summary-container-applied-filters">
-					<d2l-insights-applied-filters .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-applied-filters>
-				</div>
-				<div class="d2l-insights-summary-chart-layout">
-					<div class="d2l-insights-summary-container">
-						<d2l-insights-results-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-results-card>
-						<d2l-insights-overdue-assignments-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-overdue-assignments-card>
-						<d2l-insights-discussion-activity-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-discussion-activity-card>
-						<d2l-insights-last-access-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-last-access-card>
-					</div>
-					<div><d2l-insights-current-final-grade-card	.data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-current-final-grade-card></div>
-					<div><d2l-insights-time-in-content-vs-grade-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-time-in-content-vs-grade-card></div>
-					<div><d2l-insights-course-last-access-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-course-last-access-card></div>
-				</div>
-				<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.resultsHeading')}</h2>
-				<d2l-action-button-group class="d2l-table-action-button-group" min-to-show="0" max-to-show="2" opener-type="more">
+			<div class="d2l-heading-button-group">
+				<h1 class="d2l-heading-1">${this.localize('components.insights-engagement-dashboard.title')}</h1>
+				<d2l-action-button-group
+					class="d2l-main-action-button-group"
+					min-to-show="0"
+					max-to-show="2"
+					opener-type="more"
+				>
 					<d2l-button-subtle
-						icon="d2l-tier1:email"
-						text="${this.localize('components.insights-engagement-dashboard.emailButton')}"
-						@click="${this._handleEmailButtonPress}">
+						icon="d2l-tier1:export"
+						text=${this.localize('components.insights-engagement-dashboard.exportToCsv')}
+						@click="${this._exportToCsv}">
+					</d2l-button-subtle>
+					<d2l-button-subtle
+						icon="d2l-tier1:help"
+						text=${this.localize('components.insights-engagement-dashboard.learMore')}
+						@click="${this._openHelpLink}">
 					</d2l-button-subtle>
 				</d2l-action-button-group>
+			</div>
 
-				<d2l-insights-users-table
-					.data="${this._data}"
-					?skeleton="${this._isLoading}"
-				></d2l-insights-users-table>
+			<div class="view-filters-container">
+				<d2l-insights-ou-filter
+					.data="${this._serverData}"
+					@d2l-insights-ou-filter-change="${this._orgUnitFilterChange}"
+				></d2l-insights-ou-filter>
+				<d2l-insights-semester-filter
+					page-size="10000"
+					?demo="${this.isDemo}"
+					.preSelected="${this._serverData.selectedSemesterIds}"
+					@d2l-insights-semester-filter-change="${this._semesterFilterChange}"
+				></d2l-insights-semester-filter>
+				<d2l-insights-role-filter
+					@d2l-insights-role-filter-change="${this._roleFilterChange}"
+					?demo="${this.isDemo}"
+				></d2l-insights-role-filter>
+			</div>
+			<d2l-insights-message-container .data="${this._data}" .isNoDataReturned="${this._isNoUserResults}"></d2l-insights-message-container>
+			<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.summaryHeading')}</h2>
+			<div class="d2l-insights-summary-container-applied-filters">
+				<d2l-insights-applied-filters .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-applied-filters>
+			</div>
+			<div class="d2l-insights-summary-chart-layout">
+				<div class="d2l-insights-summary-container">
+					<d2l-insights-results-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-results-card>
+					<d2l-insights-overdue-assignments-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-overdue-assignments-card>
+					<d2l-insights-discussion-activity-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-discussion-activity-card>
+					<d2l-insights-last-access-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-last-access-card>
+				</div>
+				<div><d2l-insights-current-final-grade-card	.data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-current-final-grade-card></div>
+				<div><d2l-insights-time-in-content-vs-grade-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-time-in-content-vs-grade-card></div>
+				<div><d2l-insights-course-last-access-card .data="${this._data}" ?skeleton="${this._isLoading}"></d2l-insights-course-last-access-card></div>
+			</div>
+			<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.resultsHeading')}</h2>
+			<d2l-action-button-group class="d2l-table-action-button-group" min-to-show="0" max-to-show="2" opener-type="more">
+				<d2l-button-subtle
+					icon="d2l-tier1:email"
+					text="${this.localize('components.insights-engagement-dashboard.emailButton')}"
+					@click="${this._handleEmailButtonPress}">
+				</d2l-button-subtle>
+			</d2l-action-button-group>
+
+			<d2l-insights-users-table
+				.data="${this._data}"
+				?skeleton="${this._isLoading}"
+			></d2l-insights-users-table>
 
 
-				<d2l-insights-default-view-popup
-					?opened=${Boolean(this._serverData.isDefaultView)}
-					.data="${this._serverData}">
-				</d2l-insights-default-view-popup>
+			<d2l-insights-default-view-popup
+				?opened=${Boolean(this._serverData.isDefaultView)}
+				.data="${this._serverData}">
+			</d2l-insights-default-view-popup>
 
-				<d2l-dialog-confirm
-					id="no-users-selected-dialog"
-					text="${this.localize('components.insights-engagement-dashboard.noUsersSelectedDialogText')}">
-					<d2l-button slot="footer" primary data-dialog-action>
-						${this.localize('components.insights-default-view-popup.buttonOk')}
-					</d2l-button>
-				</d2l-dialog-confirm>
+			<d2l-dialog-confirm
+				id="no-users-selected-dialog"
+				text="${this.localize('components.insights-engagement-dashboard.noUsersSelectedDialogText')}">
+				<d2l-button slot="footer" primary data-dialog-action>
+					${this.localize('components.insights-default-view-popup.buttonOk')}
+				</d2l-button>
+			</d2l-dialog-confirm>
 		`;
 	}
 

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -1,7 +1,5 @@
 import '@brightspace-ui/core/components/dialog/dialog-confirm';
 import 'd2l-button-group/d2l-action-button-group';
-import 'd2l-navigation/d2l-navigation-immersive';
-import 'd2l-navigation/d2l-navigation-link-back';
 
 import './components/histogram-card.js';
 import './components/ou-filter.js';
@@ -19,6 +17,7 @@ import './components/discussion-activity-card.js';
 import './components/message-container.js';
 import './components/default-view-popup.js';
 import './components/user-drill-view.js';
+import './components/immersive-nav.js';
 
 import { css, html } from 'lit-element/lit-element.js';
 import { getPerformanceLoadPageMeasures, TelemetryHelper } from './model/telemetry-helper';
@@ -40,6 +39,7 @@ import { TimeInContentVsGradeFilter } from './components/time-in-content-vs-grad
 import { toJS } from 'mobx';
 
 const insightsPortalEndpoint = '/d2l/ap/insightsPortal/main.d2l';
+const engagementDashboardEndpoint = '/d2l/ap/visualizations/dashboards/engagement';
 
 /**
  * @property {Boolean} isDemo - if true, use canned data; otherwise call the LMS
@@ -81,11 +81,6 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				}
 				:host([hidden]) {
 					display: none;
-				}
-
-				.d2l-insights-immersive-nav-title {
-					align-items: center;
-					display: flex;
 				}
 
 				.d2l-insights-chart-container {
@@ -154,14 +149,6 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					padding: 50px;
 				}
 
-				.d2l-insights-link-back-default {
-					display: inline-block;
-				}
-
-				.d2l-insights-link-back-responsive {
-					display: none;
-				}
-
 				@media screen and (max-width: 615px) {
 					h1 {
 						line-height: 2rem;
@@ -176,14 +163,6 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					.d2l-insights-summary-container {
 						margin-right: 0;
 					}
-
-					.d2l-insights-link-back-default {
-						display: none;
-					}
-
-					.d2l-insights-link-back-responsive {
-						display: inline-block;
-					}
 				}
 			`
 		];
@@ -192,46 +171,34 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 	firstUpdated() {
 		const linkToInsightsPortal = new URL(insightsPortalEndpoint, window.location.origin);
 		linkToInsightsPortal.searchParams.append('ou', this.orgUnitId);
-		this.linkToInsightsPortal = linkToInsightsPortal;
+		this.linkToInsightsPortal = linkToInsightsPortal.toString();
 	}
 
 	render() {
 		let innerView = html``;
+		let href = '';
+		let backLinkText = '';
 		switch (this.currentView) {
 			case 'home':
 				innerView = this._renderHomeView();
+				href = this.linkToInsightsPortal;
+				backLinkText = this.localize('components.insights-engagement-dashboard.backToInsightsPortal');
 				break;
 			case 'user':
 				innerView =  this._renderUserDrillView();
+				href = new URL(engagementDashboardEndpoint, window.location.origin).toString();
+				backLinkText = this.localize('components.insights-engagement-dashboard.backToEngagementDashboard');
 				break;
 		}
 
 		return html`
-			${ this._renderNavBar() }
+			<d2l-insights-immersive-nav
+				href="${href}"
+				main-text="${this.localize('components.insights-engagement-dashboard.title')}"
+				back-text="${backLinkText}"
+				back-text-short="${this.localize('components.insights-engagement-dashboard.backLinkTextShort')}"
+			></d2l-insights-immersive-nav>
 			${ innerView }
-		`;
-	}
-
-	_renderNavBar() {
-		return html`
-			<d2l-navigation-immersive
-				width-type="fullscreen">
-				<div slot="left">
-					<d2l-navigation-link-back
-						text="${this.localize('components.insights-engagement-dashboard.backLinkText')}"
-						href="${this.linkToInsightsPortal}"
-						class="d2l-insights-link-back-default">
-					</d2l-navigation-link-back>
-					<d2l-navigation-link-back
-						text="${this.localize('components.insights-engagement-dashboard.backLinkTextShort')}"
-						href="${this.linkToInsightsPortal}"
-						class="d2l-insights-link-back-responsive">
-					</d2l-navigation-link-back>
-				</div>
-				<div slot="middle" class="d2l-insights-immersive-nav-title">
-					${this.localize('components.insights-engagement-dashboard.title')}
-				</div>
-			</d2l-navigation-immersive>
 		`;
 	}
 

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -1,6 +1,7 @@
 import '@brightspace-ui/core/components/dialog/dialog-confirm';
 import 'd2l-button-group/d2l-action-button-group';
 import 'd2l-navigation/d2l-navigation-immersive';
+import 'd2l-navigation/d2l-navigation-link-back';
 
 import './components/histogram-card.js';
 import './components/ou-filter.js';
@@ -153,6 +154,14 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					padding: 50px;
 				}
 
+				.d2l-insights-link-back-default {
+					display: inline-block;
+				}
+
+				.d2l-insights-link-back-responsive {
+					display: none;
+				}
+
 				@media screen and (max-width: 615px) {
 					h1 {
 						line-height: 2rem;
@@ -166,6 +175,14 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 
 					.d2l-insights-summary-container {
 						margin-right: 0;
+					}
+
+					.d2l-insights-link-back-default {
+						display: none;
+					}
+
+					.d2l-insights-link-back-responsive {
+						display: inline-block;
 					}
 				}
 			`
@@ -190,15 +207,31 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 		}
 
 		return html`
+			${ this._renderNavBar() }
+			${ innerView }
+		`;
+	}
+
+	_renderNavBar() {
+		return html`
 			<d2l-navigation-immersive
-				back-link-href="${this.linkToInsightsPortal}"
-				back-link-text="${this.localize('components.insights-engagement-dashboard.backLinkText')}"
 				width-type="fullscreen">
+				<div slot="left">
+					<d2l-navigation-link-back
+						text="${this.localize('components.insights-engagement-dashboard.backLinkText')}"
+						href="${this.linkToInsightsPortal}"
+						class="d2l-insights-link-back-default">
+					</d2l-navigation-link-back>
+					<d2l-navigation-link-back
+						text="${this.localize('components.insights-engagement-dashboard.backLinkTextShort')}"
+						href="${this.linkToInsightsPortal}"
+						class="d2l-insights-link-back-responsive">
+					</d2l-navigation-link-back>
+				</div>
 				<div slot="middle" class="d2l-insights-immersive-nav-title">
 					${this.localize('components.insights-engagement-dashboard.title')}
 				</div>
 			</d2l-navigation-immersive>
-			${ innerView }
 		`;
 	}
 

--- a/locales/en.js
+++ b/locales/en.js
@@ -3,6 +3,7 @@
 export default {
 	"components.insights-engagement-dashboard.title": "Engagement Dashboard",
 	"components.insights-engagement-dashboard.backLinkText": "Back to Insights Portal",
+	"components.insights-engagement-dashboard.backLinkTextShort": "Back",
 	"components.insights-engagement-dashboard.summaryHeading": "Summary View",
 	"components.insights-engagement-dashboard.resultsHeading": "Results",
 	"components.insights-engagement-dashboard.resultsReturned": "Users returned within results.",

--- a/locales/en.js
+++ b/locales/en.js
@@ -2,7 +2,8 @@
 
 export default {
 	"components.insights-engagement-dashboard.title": "Engagement Dashboard",
-	"components.insights-engagement-dashboard.backLinkText": "Back to Insights Portal",
+	"components.insights-engagement-dashboard.backToInsightsPortal": "Back to Insights Portal",
+	"components.insights-engagement-dashboard.backToEngagementDashboard": "Back to Engagement Dashboard",
 	"components.insights-engagement-dashboard.backLinkTextShort": "Back",
 	"components.insights-engagement-dashboard.summaryHeading": "Summary View",
 	"components.insights-engagement-dashboard.resultsHeading": "Results",

--- a/locales/en.js
+++ b/locales/en.js
@@ -2,6 +2,7 @@
 
 export default {
 	"components.insights-engagement-dashboard.title": "Engagement Dashboard",
+	"components.insights-engagement-dashboard.backLinkText": "Back to Insights Portal",
 	"components.insights-engagement-dashboard.summaryHeading": "Summary View",
 	"components.insights-engagement-dashboard.resultsHeading": "Results",
 	"components.insights-engagement-dashboard.resultsReturned": "Users returned within results.",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "array-flat-polyfill": "^1.0.1",
     "d2l-button-group": "BrightspaceUI/button-group#semver:^3",
     "d2l-facet-filter-sort": "BrightspaceUI/facet-filter-sort#semver:^3",
+    "d2l-navigation": "BrightspaceUI/navigation#semver:^4",
     "d2l-table": "BrightspaceUI/table#semver:^2",
     "d2l-telemetry-browser-client": "Brightspace/d2l-telemetry-browser-client#semver:^1",
     "export-from-json": "^1.3.4",


### PR DESCRIPTION
Moves immersive nav component from the MVC component into the engagement dashboard itself.

Corresponding LMS changes: https://github.com/Brightspace/lms/pull/3671

**Quality notes**
* Testing
  * [x] Browsers (Chrome, FF, Edgium, Edgacy)
  * [x] Responsive
  * [x] Accessibility (keyboard nav / screen reader, NVDA + Chrome)
  * [x] Test cases (regressions)
    * It links back to the Insights Portal with the correct OU
      * Note: it always links back to insights portal with `ou=<rootOUId>`. This isn't a regression
    * On large screens it displays the full text: "Back to Insights Portal"
    * On small screens it displays short text: "Back"
    * Opt in/out fly-out component is still visible
* Security, perf, devops: N/A
* UX
  * Not demoing to Kevin - from a UX standpoint nothing has changed

**Screenshots**
\> 615px:
![image](https://user-images.githubusercontent.com/11587338/99711836-435ffd00-2a70-11eb-92dd-a83d255e8ffc.png)

< 615px:
![image](https://user-images.githubusercontent.com/11587338/99711865-4e1a9200-2a70-11eb-98fc-20d42ecfe902.png)

FYI @NicholasHallman @johngwilkinson @MykolaGalian @anhill-D2L 