### PR TITLE
relax pagination component version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@adobe/lit-mobx": "0.0.x",
-    "@brightspace-ui-labs/pagination": "^0.0.8",
+    "@brightspace-ui-labs/pagination": "^1",
     "@brightspace-ui/core": "^1.83.1",
     "@brightspace-ui/intl": "^3.0.11",
     "@webcomponents/webcomponentsjs": "^2",


### PR DESCRIPTION
We've published a new version of the pagination labs component that contains no code changes but just a different CI/release workflow using GitHub Actions. But `^` ranges on `0.0.x` versions can't be bumped, so we've gone to version 1.

This is currently preventing us from upgrading to this new version and breaking BSI builds, so we'd like to get this in and released quickly.

This will result in no code changes. Here's the actual diff:
https://github.com/BrightspaceUILabs/pagination/compare/v0.0.8...v1.0.1