### PR TITLE
US120701 Immersive nav back doesn't reload page

### DIFF
--- a/components/immersive-nav.js
+++ b/components/immersive-nav.js
@@ -1,12 +1,20 @@
 import 'd2l-navigation/d2l-navigation-immersive';
 import 'd2l-navigation/d2l-navigation-link-back';
+import 'd2l-navigation/d2l-navigation-button';
+import '@brightspace-ui/core/components/icons/icon';
 
 import { css, html, LitElement } from 'lit-element/lit-element';
 
-// Extends the standard immersive nav to resize the back link on small screens
+// Extends the standard immersive nav to
+// - resize the back button on small screens
+// - allow use of a button instead of a link
 class InsightsImmersiveNav extends LitElement {
 	static get properties() {
 		return {
+			/**
+			 * type: either 'button' or 'link'
+			 */
+			backButtonType: { type: String, attribute: 'back-button-type' },
 			href: { type: String, attribute: true },
 			mainText: { type: String, attribute: 'main-text' },
 			backText: { type: String, attribute: 'back-text' },
@@ -43,10 +51,49 @@ class InsightsImmersiveNav extends LitElement {
 
 	constructor() {
 		super();
+		this.backButtonType = '';
 		this.href = '';
 		this.mainText = '';
 		this.backText = '';
 		this.backTextShort = '';
+	}
+
+	_renderBackButton() {
+		return html`
+			<d2l-navigation-button
+				text="${this.backText}"
+				class="d2l-insights-link-back-default"
+				@click="${this._handleBackButtonClick}">
+
+				<d2l-icon icon="d2l-tier1:chevron-left"></d2l-icon>
+				<span>${this.backText}</span>
+			</d2l-navigation-button>
+
+			<d2l-navigation-button
+				text="${this.backTextShort}"
+				class="d2l-insights-link-back-responsive"
+				@click="${this._handleBackButtonClick}">
+
+				<d2l-icon icon="d2l-tier1:chevron-left"></d2l-icon>
+				<span>${this.backTextShort}</span>
+			</d2l-navigation-button>
+		`;
+	}
+
+	_renderBackLink() {
+		return html`
+			<d2l-navigation-link-back
+				text="${this.backText}"
+				href="${this.href}"
+				class="d2l-insights-link-back-default">
+			</d2l-navigation-link-back>
+
+			<d2l-navigation-link-back
+				text="${this.backTextShort || this.backText}"
+				href="${this.href}"
+				class="d2l-insights-link-back-responsive">
+			</d2l-navigation-link-back>
+		`;
 	}
 
 	render() {
@@ -54,16 +101,7 @@ class InsightsImmersiveNav extends LitElement {
 			<d2l-navigation-immersive width-type="fullscreen">
 
 				<div slot="left">
-					<d2l-navigation-link-back
-						text="${this.backText}"
-						href="${this.href}"
-						class="d2l-insights-link-back-default">
-					</d2l-navigation-link-back>
-					<d2l-navigation-link-back
-						text="${this.backTextShort || this.backText}"
-						href="${this.href}"
-						class="d2l-insights-link-back-responsive">
-					</d2l-navigation-link-back>
+					${ this.backButtonType === 'button' ? this._renderBackButton() : this._renderBackLink() }
 				</div>
 
 				<div slot="middle" class="d2l-insights-immersive-nav-title">
@@ -73,5 +111,11 @@ class InsightsImmersiveNav extends LitElement {
 			</d2l-navigation-immersive>
 		`;
 	}
+
+	// only for when the immersive nav is configured to use a button and not a link
+	_handleBackButtonClick() {
+		this.dispatchEvent(new Event('d2l-insights-immersive-nav-back'));
+	}
 }
+
 customElements.define('d2l-insights-immersive-nav', InsightsImmersiveNav);

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -39,7 +39,6 @@ import { TimeInContentVsGradeFilter } from './components/time-in-content-vs-grad
 import { toJS } from 'mobx';
 
 const insightsPortalEndpoint = '/d2l/ap/insightsPortal/main.d2l';
-const engagementDashboardEndpoint = '/d2l/ap/visualizations/dashboards/engagement';
 
 /**
  * @property {Boolean} isDemo - if true, use canned data; otherwise call the LMS
@@ -77,6 +76,8 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 
 	constructor() {
 		super();
+
+		this.__defaultViewPopupShown = false; // a test-and-set variable: will always be true after the first read
 
 		this.orgUnitId = 0;
 		this.isDemo = false;
@@ -206,31 +207,12 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 	}
 
 	render() {
-		let innerView = html``;
-		let href = '';
-		let backLinkText = '';
 		switch (this.currentView) {
 			case 'home':
-				innerView = this._renderHomeView();
-				href = this.linkToInsightsPortal;
-				backLinkText = this.localize('components.insights-engagement-dashboard.backToInsightsPortal');
-				break;
+				return this._renderHomeView();
 			case 'user':
-				innerView =  this._renderUserDrillView();
-				href = new URL(engagementDashboardEndpoint, window.location.origin).toString();
-				backLinkText = this.localize('components.insights-engagement-dashboard.backToEngagementDashboard');
-				break;
+				return this._renderUserDrillView();
 		}
-
-		return html`
-			<d2l-insights-immersive-nav
-				href="${href}"
-				main-text="${this.localize('components.insights-engagement-dashboard.title')}"
-				back-text="${backLinkText}"
-				back-text-short="${this.localize('components.insights-engagement-dashboard.backLinkTextShort')}"
-			></d2l-insights-immersive-nav>
-			${ innerView }
-		`;
 	}
 
 	_renderUserDrillView() {
@@ -242,6 +224,14 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 		};
 
 		return html`
+			<d2l-insights-immersive-nav
+				back-button-type="button"
+				main-text="${this.localize('components.insights-engagement-dashboard.title')}"
+				back-text="${this.localize('components.insights-engagement-dashboard.backToEngagementDashboard')}"
+				back-text-short="${this.localize('components.insights-engagement-dashboard.backLinkTextShort')}"
+				@d2l-insights-immersive-nav-back="${this._backToHomeHandler}"
+			></d2l-insights-immersive-nav>
+
 			<d2l-insights-user-drill-view
 				.user="${user}"
 				@d2l-insights-user-drill-view-back="${this._backToHomeHandler}"
@@ -251,6 +241,13 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 
 	_renderHomeView() {
 		return html`
+			<d2l-insights-immersive-nav
+				back-button-type="link"
+				href="${this.linkToInsightsPortal}"
+				main-text="${this.localize('components.insights-engagement-dashboard.title')}"
+				back-text="${this.localize('components.insights-engagement-dashboard.backToInsightsPortal')}"
+				back-text-short="${this.localize('components.insights-engagement-dashboard.backLinkTextShort')}"
+			></d2l-insights-immersive-nav>
 
 			<d2l-insights-aria-loading-progress .data="${this._data}"></d2l-insights-aria-loading-progress>
 
@@ -326,9 +323,8 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				?show-tic-col="${this.showTicCol}"
 			></d2l-insights-users-table>
 
-
 			<d2l-insights-default-view-popup
-				?opened=${Boolean(this._serverData.isDefaultView)}
+				?opened=${Boolean(this._serverData.isDefaultView && !this._defaultViewPopupShown)}
 				.data="${this._serverData}">
 			</d2l-insights-default-view-popup>
 
@@ -340,6 +336,12 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				</d2l-button>
 			</d2l-dialog-confirm>
 		`;
+	}
+
+	get _defaultViewPopupShown() {
+		const currentVal = this.__defaultViewPopupShown;
+		this.__defaultViewPopupShown = true;
+		return currentVal;
 	}
 
 	get _courseAccessCard() {


### PR DESCRIPTION
Modify the immersive nav back link to be a button on dashboard subpages, so it doesn't fully reload the page when clicked.

Quality notes
* Testing
  * [x] Browsers (Chrome, FF, Edgium, Edgacy)
  * [x] Responsive
  * [x] Accessibility (keyboard nav / accessibility: tested with NVDA/Chrome)
  * [x] Test cases
    * (Default size + responsive) On dashboard home page, back button still goes to Insights Portal
    * (Default size + responsive) On dashboard user drill page, back button goes to home page
    * Default view popup is only displayed once
* Security, perf, devops: N/A
* UX: not demoing to Kevin as this is not really something "new"

@johngwilkinson @rohitvinnakota @anhill-D2L @MykolaGalian 