### PR TITLE
US120705: show table columns according to user prefs

### DIFF
--- a/components/users-table.js
+++ b/components/users-table.js
@@ -1,6 +1,6 @@
-import '@brightspace-ui/core/components/inputs/input-text';
-import '@brightspace-ui-labs/pagination/pagination';
 import './table.js';
+import '@brightspace-ui-labs/pagination/pagination';
+import '@brightspace-ui/core/components/inputs/input-text';
 import { action, computed, decorate, observable, reaction } from 'mobx';
 import { css, html } from 'lit-element';
 import { formatNumber, formatPercent } from '@brightspace-ui/intl';
@@ -53,7 +53,14 @@ class UsersTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 			_pageSize: { type: Number, attribute: false },
 			_sortColumn: { type: Number, attribute: false },
 			_sortOrder: { type: String, attribute: false },
-			selectedUserIds: { type: Array, attribute: false }
+			selectedUserIds: { type: Array, attribute: false },
+
+			// user preferences:
+			showCoursesCol: { type: Boolean, attribute: 'courses-col', reflect: true },
+			showDiscussionsCol: { type: Boolean, attribute: 'discussions-col', reflect: true },
+			showGradeCol: { type: Boolean, attribute: 'grade-col', reflect: true },
+			showLastAccessCol: { type: Boolean, attribute: 'last-access-col', reflect: true },
+			showTicCol: { type: Boolean, attribute: 'tic-col', reflect: true }
 		};
 	}
 
@@ -94,6 +101,11 @@ class UsersTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 		this._sortOrder = 'desc';
 		this._sortColumn = TABLE_USER.NAME_INFO;
 		this.selectedUserIds = [];
+		this.showCoursesCol = false;
+		this.showDiscussionsCol = false;
+		this.showGradeCol = false;
+		this.showLastAccessCol = false;
+		this.showTicCol = false;
 
 		// reset selectedUserIds whenever the input data changes
 		reaction(
@@ -130,7 +142,10 @@ class UsersTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 
 			const start = this._pageSize * (this._currentPage - 1);
 			const end = this._pageSize * (this._currentPage); // it's ok if this goes over the end of the array
-			return this.userDataForDisplayFormatted.slice(start, end);
+			const visibleColumns = this._visibleColumns;
+			return this.userDataForDisplayFormatted
+				.slice(start, end)
+				.map(user => visibleColumns.map(column => user[column]));
 		}
 
 		return [];
@@ -138,7 +153,8 @@ class UsersTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 
 	_handleColumnSort(e) {
 		this._sortOrder = e.detail.order;
-		this._sortColumn = e.detail.column;
+		// convert from index in visible columns to general column index matching TABLE_USER
+		this._sortColumn = this._visibleColumns[e.detail.column];
 		this._currentPage = 0;
 
 		this._resetSelectedUserIds();
@@ -175,7 +191,7 @@ class UsersTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 		];
 	}
 
-	_choseSortFunction(column, order) {
+	_chosenSortFunction(column, order) {
 		const ORDER = {
 			'asc': [-1, 1, 0],
 			'desc': [1, -1, 0]
@@ -221,7 +237,7 @@ class UsersTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 	get userDataForDisplay() {
 		// map to a 2D userData array, with column 1 as a sub-array of [id, FirstName, LastName, UserName]
 		// then sort by the selected sorting function
-		const sortFunction = this._choseSortFunction(this._sortColumn, this._sortOrder);
+		const sortFunction = this._chosenSortFunction(this._sortColumn, this._sortOrder);
 		return this.data.users
 			.map(this._preProcessData, this)
 			.sort(sortFunction)
@@ -243,28 +259,55 @@ class UsersTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 	}
 
 	get dataForExport() {
-		return this.userDataForDisplay;
+		const visibleColumns = this._visibleColumns;
+		return this.userDataForDisplay
+			.map(user => visibleColumns.flatMap(column => {
+				const val = user[column];
+				if (column === TABLE_USER.NAME_INFO) {
+					// setting a different order for these columns
+					return [val[USER.LAST_NAME], val[USER.FIRST_NAME], val[USER.USERNAME], val[USER.ID]];
+				}
+				return val;
+			})
+				// skip the selector column
+				.slice(1)
+			);
 	}
 
 	get headersForExport() {
-		const headerArray = this.columnInfo.map(item => item.headerText);
-		return [
+		const headers = [
 			this.localize('components.insights-users-table-export.lastName'),
 			this.localize('components.insights-users-table-export.FirstName'),
 			this.localize('components.insights-users-table-export.UserName'),
-			this.localize('components.insights-users-table-export.UserID'),
-			headerArray[TABLE_USER.COURSES],
-			headerArray[TABLE_USER.AVG_GRADE],
-			headerArray[TABLE_USER.AVG_TIME_IN_CONTENT],
-			this.localize('components.insights-discussion-activity-card.threads'),
-			this.localize('components.insights-discussion-activity-card.reads'),
-			this.localize('components.insights-discussion-activity-card.replies'),
-			headerArray[TABLE_USER.LAST_ACCESSED_SYS]
+			this.localize('components.insights-users-table-export.UserID')
 		];
+		if (this.showCoursesCol) headers.push(this.localize('components.insights-users-table.courses'));
+		if (this.showGradeCol) headers.push(this.localize('components.insights-users-table.avgGrade'));
+		if (this.showTicCol) headers.push(this.localize('components.insights-users-table.avgTimeInContent'));
+		if (this.showDiscussionsCol) {
+			headers.push(this.localize('components.insights-discussion-activity-card.threads'));
+			headers.push(this.localize('components.insights-discussion-activity-card.reads'));
+			headers.push(this.localize('components.insights-discussion-activity-card.replies'));
+		}
+		if (this.showLastAccessCol) headers.push(this.localize('components.insights-users-table.lastAccessedSys'));
+
+		return headers;
+	}
+
+	get _visibleColumns() {
+		const columns = [TABLE_USER.SELECTOR_VALUE, TABLE_USER.NAME_INFO];
+
+		if (this.showCoursesCol) columns.push(TABLE_USER.COURSES);
+		if (this.showGradeCol) columns.push(TABLE_USER.AVG_GRADE);
+		if (this.showTicCol) columns.push(TABLE_USER.AVG_TIME_IN_CONTENT);
+		if (this.showDiscussionsCol) columns.push(TABLE_USER.AVG_DISCUSSION_ACTIVITY);
+		if (this.showLastAccessCol) columns.push(TABLE_USER.LAST_ACCESSED_SYS);
+
+		return columns;
 	}
 
 	get columnInfo() {
-		return [
+		const columnInfo = [
 			{
 				headerText: '', // no text should appear for this column header
 				columnType: COLUMN_TYPES.ROW_SELECTOR
@@ -294,6 +337,8 @@ class UsersTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 				columnType: COLUMN_TYPES.NORMAL_TEXT
 			}
 		];
+
+		return this._visibleColumns.map(column => columnInfo[column]);
 	}
 
 	render() {

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -319,11 +319,11 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 			<d2l-insights-users-table
 				.data="${this._data}"
 				?skeleton="${this._isLoading}"
-				?show-courses-col="${this.showCoursesCol}"
-				?show-discussions-col="${this.showDiscussionsCol}"
-				?show-grade-col="${this.showGradeCol}"
-				?show-last-access-col="${this.showLastAccessCol}"
-				?show-tic-col="${this.showTicCol}"
+				?courses-col="${this.showCoursesCol}"
+				?discussions-col="${this.showDiscussionsCol}"
+				?grade-col="${this.showGradeCol}"
+				?last-access-col="${this.showLastAccessCol}"
+				?tic-col="${this.showTicCol}"
 			></d2l-insights-users-table>
 
 

--- a/model/exportData.js
+++ b/model/exportData.js
@@ -1,7 +1,5 @@
 import exportFromJSON from 'export-from-json';
-import { TABLE_USER } from '../components/users-table';
 import { toJS } from 'mobx';
-import { USER } from '../consts';
 
 export const DISCUSSION = {
 	THREADS: 0,
@@ -10,24 +8,8 @@ export const DISCUSSION = {
 };
 
 export class ExportData {
-
 	static userDataToCsv(data, headers) {
-		const formattedData = toJS(data).map(item => {
-			return [
-				item[TABLE_USER.NAME_INFO][USER.LAST_NAME],
-				item[TABLE_USER.NAME_INFO][USER.FIRST_NAME],
-				item[TABLE_USER.NAME_INFO][USER.USERNAME],
-				item[TABLE_USER.NAME_INFO][USER.ID],
-				item[TABLE_USER.COURSES],
-				item[TABLE_USER.AVG_GRADE],
-				item[TABLE_USER.AVG_TIME_IN_CONTENT],
-				item[TABLE_USER.AVG_DISCUSSION_ACTIVITY][DISCUSSION.THREADS],
-				item[TABLE_USER.AVG_DISCUSSION_ACTIVITY][DISCUSSION.READS],
-				item[TABLE_USER.AVG_DISCUSSION_ACTIVITY][DISCUSSION.REPLIES],
-				item[TABLE_USER.LAST_ACCESSED_SYS]];
-		});
-
-		return this.exportToCsv(formattedData, headers);
+		return this.exportToCsv(toJS(data), headers);
 	}
 
 	static exportToCsv(formattedData, headers) {


### PR DESCRIPTION
Quality Notes:

- functional
  - demo page: remove various columns, including all possible: renders as expected
  - demo page: sort on columns where an earlier column is hidden
  - demo page: export with hidden columns
  - e2e: remove columns via API; render, sort, and export
  - tested export with and without the discussions columns
- perf: no significant change
- devops: n/a
- security: n/a
- ux/docs: table seems to behave pretty well - but there is a story scheduled to adjust layout in any case

@anhill-D2L @MykolaGalian @rohitvinnakota @Vitalii-Misechko 