### PR TITLE
Fix: Popping from history doesn't break mobx state tracking

### DIFF
--- a/components/course-last-access-card.js
+++ b/components/course-last-access-card.js
@@ -66,8 +66,7 @@ export class CourseLastAccessFilter extends CategoryFilter {
 			return;
 		}
 		const categories = value.split(',').map(category => Number(category));
-		this.selectedCategories.clear();
-		categories.forEach(category => this.selectCategory(category));
+		this.setCategories(categories);
 	}
 }
 

--- a/components/current-final-grade-card.js
+++ b/components/current-final-grade-card.js
@@ -1,4 +1,4 @@
-import { action, computed, decorate } from 'mobx';
+import { computed, decorate } from 'mobx';
 import { css, html } from 'lit-element/lit-element.js';
 import { BEFORE_CHART_FORMAT } from './chart/chart';
 import { bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';

--- a/components/current-final-grade-card.js
+++ b/components/current-final-grade-card.js
@@ -1,4 +1,4 @@
-import { computed, decorate } from 'mobx';
+import { action, computed, decorate } from 'mobx';
 import { css, html } from 'lit-element/lit-element.js';
 import { BEFORE_CHART_FORMAT } from './chart/chart';
 import { bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
@@ -46,8 +46,7 @@ export class CurrentFinalGradesFilter extends CategoryFilter {
 			return;
 		}
 		const categories = value.split(',').map(category => Number(category));
-		this.selectedCategories.clear();
-		categories.forEach(category => this.selectCategory(category));
+		this.setCategories(categories);
 	}
 }
 

--- a/components/discussion-activity-card.js
+++ b/components/discussion-activity-card.js
@@ -36,8 +36,7 @@ export class DiscussionActivityFilter extends CategoryFilter {
 			return;
 		}
 		const categories = value.split(',').map(category => Number(category));
-		this.selectedCategories.clear();
-		categories.forEach(category => this.selectCategory(category));
+		this.setCategories(categories);
 	}
 }
 

--- a/model/categoryFilter.js
+++ b/model/categoryFilter.js
@@ -25,6 +25,11 @@ export class CategoryFilter {
 		this.selectedCategories.add(category);
 	}
 
+	setCategories(categories) {
+		this.selectedCategories.clear();
+		categories.forEach(category => this.selectedCategories.add(category));
+	}
+
 	toggleCategory(category) {
 		if (this.selectedCategories.has(category)) {
 			this.clearCategory(category);
@@ -37,6 +42,7 @@ decorate(CategoryFilter, {
 	isApplied: computed,
 	clearCategory: action,
 	selectCategory: action,
+	setCategories: action,
 	toggleCategory: action,
 	selectedCategories: observable
 });

--- a/model/urlState.js
+++ b/model/urlState.js
@@ -1,4 +1,4 @@
-import { autorun } from 'mobx';
+import { autorun, observable, reaction, untracked } from 'mobx';
 
 let isDisabledForTesting = false;
 export function disableUrlStateForTesting() {
@@ -40,7 +40,6 @@ export class UrlState {
 
 	constructor(wrapped) {
 		this._wrapped = wrapped;
-		this.popping = false;
 
 		if (isDisabledForTesting) return;
 
@@ -49,15 +48,11 @@ export class UrlState {
 		this._load();
 		this._onpopstate = this._onpopstate.bind(this);
 		window.addEventListener('popstate', this._onpopstate);
-
 		autorun(() => this.save());
 	}
 
 	save() {
-
 		// don't save state changes if we are restoring an old state
-		if (this.popping) return;
-
 		const url = new URL(window.location.href);
 		const valueToSave = this.value;
 		if (valueToSave === '' && url.searchParams.has(this.key)) {
@@ -83,9 +78,7 @@ export class UrlState {
 	}
 
 	_onpopstate(e) {
-		this.popping = true;
 		if (e.state !== null) this._load();
-		this.popping = false;
 	}
 
 	_load() {

--- a/model/urlState.js
+++ b/model/urlState.js
@@ -1,4 +1,4 @@
-import { autorun, observable, reaction, untracked } from 'mobx';
+import { autorun } from 'mobx';
 
 let isDisabledForTesting = false;
 export function disableUrlStateForTesting() {


### PR DESCRIPTION
A brief history...

### Problem 1

The urlstate created a loop so when we saved the the persistenceValue it would call autorun to save the new state. Mobx is smart enough to know that the outcome will be the same as the url that was just set. However, when we set the persistent state for category filters (like the course access chart) the state was set by clearing all the categories and then turing on all the ones received from the url. autorun would get called for each of the individual category changes, which polluted the history and prevented the user from using the forward button in the browser.

My initial solution was simple, if we are popping the state, don't allow urlstate to save the state.

### Problem 2

When mobx called the autorun it would change the dependent observable to the popping boolean. Because this variable wasn't an observable mobx would simply stop tracking the persistentValue... darn.

The second sultion, was to create a new function in the category filters class that would clear the categories and set the categories given but all wrapped in an actio. This way mobx only called autorun to save the urlstate AFTER all the intermediate states had collapsed. 


TLDR mobx actions are useful 