### PR TITLE
US120705: apply role preference

### DIFF
--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -72,7 +72,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 			showTicCol: { type: Boolean, attribute: 'tic-col', reflect: true },
 			showTicGradesCard: { type: Boolean, attribute: 'tic-grades-card', reflect: true },
 			lastAccessThresholdDays: { type: Number, attribute: 'last-access-threshold-days', reflect: true },
-			includeRoles: { type: Array, attribute: 'include-roles', converter: v => v.split(',') }
+			includeRoles: { type: Array, attribute: 'include-roles', converter: v => v.split(',').filter(x => x).map(Number) }
 		};
 	}
 
@@ -287,10 +287,6 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					.preSelected="${this._serverData.selectedSemesterIds}"
 					@d2l-insights-semester-filter-change="${this._semesterFilterChange}"
 				></d2l-insights-semester-filter>
-				<d2l-insights-role-filter
-					@d2l-insights-role-filter-change="${this._roleFilterChange}"
-					?demo="${this.isDemo}"
-				></d2l-insights-role-filter>
 			</div>
 			<d2l-insights-message-container .data="${this._data}" .isNoDataReturned="${this._isNoUserResults}"></d2l-insights-message-container>
 			<h2 class="d2l-heading-3">${this.localize('components.insights-engagement-dashboard.summaryHeading')}</h2>
@@ -424,7 +420,8 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 
 			this.__serverData = new Data({
 				isDefault: isDefault(),
-				recordProvider: this.isDemo ? fetchDemoData : fetchData
+				recordProvider: this.isDemo ? fetchDemoData : fetchData,
+				includeRoles: this.includeRoles
 			});
 		}
 

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -72,7 +72,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 			showTicCol: { type: Boolean, attribute: 'tic-col', reflect: true },
 			showTicGradesCard: { type: Boolean, attribute: 'tic-grades-card', reflect: true },
 			lastAccessThresholdDays: { type: Number, attribute: 'last-access-threshold-days', reflect: true },
-			includeRoles: { type: Array, attribute: 'include-roles', converter: v => v.split(',').filter(x => x).map(Number) }
+			includeRoles: { type: String, attribute: 'include-roles', reflect: true }
 		};
 	}
 
@@ -98,7 +98,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 		this.showTicCol = false;
 		this.showTicGradesCard = false;
 		this.lastAccessThresholdDays = 14;
-		this.includeRoles = [];
+		this.includeRoles = '';
 
 		this.linkToInsightsPortal = ''; // initialized in firstUpdated to get the actual orgUnitId value
 	}
@@ -421,7 +421,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 			this.__serverData = new Data({
 				isDefault: isDefault(),
 				recordProvider: this.isDemo ? fetchDemoData : fetchData,
-				includeRoles: this.includeRoles
+				includeRoles: this.includeRoles.split(',').filter(x => x).map(Number)
 			});
 		}
 

--- a/model/data.js
+++ b/model/data.js
@@ -8,7 +8,7 @@ import { Tree } from '../components/tree-filter';
  * Data from the server, along with filter settings that are passed in server calls.
  */
 export class Data {
-	constructor({ recordProvider, isDefault }) {
+	constructor({ recordProvider, isDefault, includeRoles }) {
 		this.recordProvider = recordProvider;
 		this.orgUnitTree = new Tree({});
 		this.userDictionary = null;
@@ -29,7 +29,7 @@ export class Data {
 			semesterTypeId: null,
 			numDefaultSemesters: 0,
 			selectedOrgUnitIds: [],
-			selectedRolesIds: [],
+			selectedRolesIds: includeRoles || [],
 			selectedSemestersIds: [],
 			defaultViewOrgUnitIds: null
 		};

--- a/model/selectorFilters.js
+++ b/model/selectorFilters.js
@@ -15,19 +15,6 @@ export class RoleSelectorFilter {
 	constructor(data) {
 		this._data = data;
 		this.selected = data.serverData.selectedRolesIds || [];
-		// noinspection JSUnusedGlobalSymbols
-		this._urlState = new UrlState(this);
-	}
-
-	// persistence key and value for UrlState
-	get persistenceKey() { return 'rf'; }
-
-	get persistenceValue() {
-		return this.selected.join(',');
-	}
-
-	set persistenceValue(value) {
-		this.selected = value.split(',').filter(x => x).map(Number);
 	}
 
 	shouldInclude(record) {

--- a/test/engagement-dashboard.test.js
+++ b/test/engagement-dashboard.test.js
@@ -45,6 +45,16 @@ describe('d2l-insights-engagement-dashboard', () => {
 	});
 
 	describe('prefs', () => {
+		it('should provide configured roles to the data object', async() => {
+			const el = await fixture(html`<d2l-insights-engagement-dashboard
+					include-roles="900, 1000, 11"
+					demo
+				></d2l-insights-engagement-dashboard>`);
+			await new Promise(resolve => setTimeout(resolve, 100));
+
+			expect(el._serverData.selectedRoleIds).to.deep.equal([900, 1000, 11]);
+		});
+
 		const allCards = [
 			'course-last-access-card',
 			'discussion-activity-card',

--- a/test/model/data.test.js
+++ b/test/model/data.test.js
@@ -64,6 +64,13 @@ describe('Data', () => {
 		await new Promise(resolve => setTimeout(resolve, 0)); // allow recordProvider to resolve
 	});
 
+	describe('constructor', () => {
+		it('should set configured roles', () => {
+			expect(new Data({ recordProvider, cardFilters, includeRoles: [123, 4, 567] }).selectedRoleIds)
+				.to.deep.equal([123, 4, 567]);
+		});
+	});
+
 	describe('reload from server', () => {
 		it('maintains ou tree open state', async() => {
 			const oldTree = sut.orgUnitTree;

--- a/test/model/data.test.js
+++ b/test/model/data.test.js
@@ -66,7 +66,7 @@ describe('Data', () => {
 
 	describe('constructor', () => {
 		it('should set configured roles', () => {
-			expect(new Data({ recordProvider, cardFilters, includeRoles: [123, 4, 567] }).selectedRoleIds)
+			expect(new Data({ recordProvider, includeRoles: [123, 4, 567] }).selectedRoleIds)
 				.to.deep.equal([123, 4, 567]);
 		});
 	});

--- a/test/model/selectorFilters.test.js
+++ b/test/model/selectorFilters.test.js
@@ -88,30 +88,6 @@ describe('selectorFilters', () => {
 				expect(sut.shouldReloadFromServer([1, 3, 5, 6])).to.be.true;
 			});
 		});
-
-		describe('urlState', () => {
-
-			const key = new RoleSelectorFilter({ serverData: {} }).persistenceKey;
-			before(() => {
-				enableUrlState();
-			});
-			after(() => disableUrlStateForTesting());
-
-			it('should load the filter from the url state then save to it', async() => {
-
-				setStateForTesting(key, '1,3,5');
-
-				const sut = new RoleSelectorFilter({ serverData: { selectedRolesIds: null, isRecordsTruncated: false } });
-				expect(sut.selected).eqls([1, 3, 5]);
-
-				sut.selected = [1];
-
-				const params = new URLSearchParams(window.location.search);
-				const values = params.get(sut.persistenceKey);
-
-				expect(values).equals('1');
-			});
-		});
 	});
 
 	describe('SemesterSelectorFilter', () => {


### PR DESCRIPTION
I removed the role filter UI since it doesn't reflect this change, and it will shortly be replaced by the config page anyway.

I also removed the UrlState support from the role filter. Including it might make it possible to email links with specific role configs, but how that should interact with user prefs isn't clear - so it seemed safest just to remove it.

Quality Notes
- functional
  - checked that configured list of roles is passed to server on load and data loads
  - checked that data loads when there is no configured list of roles (PUT to config API without an `includeRoles` field)
  - checked that configured roles are passed and data loads on reload from server (cleared semester filter)
- perf, security, devops: n/a
- ux/docs: role selection only via API for the moment, until the config page tab for roles is available

FYI @bemailloux @MykolaGalian @NicholasHallman @Vitalii-Misechko 