### PR TITLE
US120701 Settings page

### DIFF
--- a/components/dashboard-settings.js
+++ b/components/dashboard-settings.js
@@ -1,0 +1,153 @@
+import { css, html, LitElement } from 'lit-element';
+import { Localizer } from '../locales/localizer';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin';
+
+class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
+	static get styles() {
+		return [css`
+			:host {
+				display: flex;
+				flex-direction: column; /* required so the footer actually appears on-screen */
+				height: 100%;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+
+			.d2l-insights-settings-page-main-container {
+				height: 100%;
+				overflow-y: auto;
+			}
+
+			.d2l-insights-settings-page-main-content {
+				background-color: white;
+				margin: 0 auto;
+				max-width: 1230px;
+				padding-bottom: 72px; /* height of footer */
+				width: 100%;
+			}
+
+			footer {
+				background-color: white;
+				bottom: 0;
+				box-shadow: 0 -2px 4px rgba(73, 76, 78, 0.2); /* ferrite */
+				height: 42px; /* height of a d2l-button */
+				left: 0;
+				padding: 0.75rem 30px;
+				position: fixed;
+				right: 0;
+				z-index: 2; /* ensures the footer box-shadow is over main areas with background colours set */
+			}
+
+			.d2l-insights-settings-page-footer {
+				margin: 0 auto;
+				max-width: 1230px;
+				width: 100%;
+			}
+
+			h1, h2 {
+				font-weight: normal;
+				line-height: 2rem;
+			}
+
+			/* buttons */
+			.d2l-insights-settings-footer-button,
+			.d2l-insights-settings-footer-button-desktop,
+			.d2l-insights-settings-footer-button-responsive {
+				margin-right: 0.75rem;
+			}
+
+			:host([dir="rtl"]) .d2l-insights-settings-footer-button,
+			:host([dir="rtl"]) .d2l-insights-settings-footer-button-desktop,
+			:host([dir="rtl"]) .d2l-insights-settings-footer-button-responsive {
+				margin-left: 0.75rem;
+			}
+
+			.d2l-insights-settings-footer-button-desktop {
+				display: inline-block;
+			}
+
+			.d2l-insights-settings-footer-button-responsive {
+				display: none;
+			}
+
+			@media screen and (max-width: 615px) {
+				footer {
+					padding: 0.75rem 18px;
+				}
+
+				.d2l-insights-settings-footer-button-desktop {
+					display: none;
+				}
+
+				.d2l-insights-settings-footer-button-responsive {
+					display: inline-block;
+				}
+
+				.d2l-insights-settings-footer-button,
+				.d2l-insights-settings-footer-button-desktop,
+				.d2l-insights-settings-footer-button-responsive {
+					margin-right: 0;
+				}
+
+				:host([dir="rtl"]) .d2l-insights-settings-footer-button,
+				:host([dir="rtl"]) .d2l-insights-settings-footer-button-desktop,
+				:host([dir="rtl"]) .d2l-insights-settings-footer-button-responsive {
+					margin-left: 0;
+				}
+			}
+		`];
+	}
+
+	render() {
+		return html`
+			<div class="d2l-insights-settings-page-main-container">
+				<div class="d2l-insights-settings-page-main-content">
+						<h1>${this.localize('components.insights-settings-view.title')}</h1>
+						<h2>${this.localize('components.insights-settings-view.description')}</h2>
+						<p>Mock content</p>
+						<p>Mock content</p>
+						<p>Mock content</p>
+						<p>Mock content</p>
+						<p>Mock content</p>
+						<p>Mock content</p>
+						<p>Mock content</p>
+						<p>Mock content</p>
+				</div>
+			</div>
+
+			<footer>
+				<div class="d2l-insights-settings-page-footer">
+					<d2l-button
+						primary
+						class="d2l-insights-settings-footer-button-desktop"
+						@click="${this._handleSaveAndClose}">
+						${this.localize('components.insights-settings-view.saveAndClose')}
+					</d2l-button>
+					<d2l-button
+						primary
+						class="d2l-insights-settings-footer-button-responsive"
+						@click="${this._handleSaveAndClose}">
+						${this.localize('components.insights-settings-view.save')}
+					</d2l-button>
+					<d2l-button
+						class="d2l-insights-settings-footer-button"
+						@click="${this._returnToEngagementDashboard}">
+						${this.localize('components.insights-settings-view.cancel')}
+					</d2l-button>
+				</div>
+			</footer>
+		`;
+	}
+
+	_handleSaveAndClose() {
+		// out of scope: save settings
+
+		this._returnToEngagementDashboard();
+	}
+
+	_returnToEngagementDashboard() {
+		this.dispatchEvent(new Event('d2l-insights-settings-view-back'));
+	}
+}
+customElements.define('d2l-insights-engagement-dashboard-settings', DashboardSettings);

--- a/components/dashboard-settings.js
+++ b/components/dashboard-settings.js
@@ -1,10 +1,11 @@
 import { css, html, LitElement } from 'lit-element';
+import { heading1Styles, heading2Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { Localizer } from '../locales/localizer';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin';
 
 class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 	static get styles() {
-		return [css`
+		return [heading1Styles, heading2Styles, css`
 			:host {
 				display: flex;
 				flex-direction: column; /* required so the footer actually appears on-screen */
@@ -17,6 +18,7 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 			.d2l-insights-settings-page-main-container {
 				height: 100%;
 				overflow-y: auto;
+				padding-top: 30px;
 			}
 
 			.d2l-insights-settings-page-main-content {
@@ -45,15 +47,15 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 				width: 100%;
 			}
 
-			h1, h2 {
+			h1.d2l-heading-1, h2.d2l-heading-2 {
 				font-weight: normal;
-				line-height: 2rem;
 			}
 
 			/* buttons */
 			.d2l-insights-settings-footer-button,
 			.d2l-insights-settings-footer-button-desktop,
 			.d2l-insights-settings-footer-button-responsive {
+				margin-left: 0;
 				margin-right: 0.75rem;
 			}
 
@@ -61,6 +63,7 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 			:host([dir="rtl"]) .d2l-insights-settings-footer-button-desktop,
 			:host([dir="rtl"]) .d2l-insights-settings-footer-button-responsive {
 				margin-left: 0.75rem;
+				margin-right: 0;
 			}
 
 			.d2l-insights-settings-footer-button-desktop {
@@ -72,6 +75,10 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 			}
 
 			@media screen and (max-width: 615px) {
+				h1.d2l-heading-1, h2.d2l-heading-2 {
+					font-weight: normal;
+				}
+
 				footer {
 					padding: 0.75rem 18px;
 				}
@@ -103,8 +110,8 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 		return html`
 			<div class="d2l-insights-settings-page-main-container">
 				<div class="d2l-insights-settings-page-main-content">
-						<h1>${this.localize('components.insights-settings-view.title')}</h1>
-						<h2>${this.localize('components.insights-settings-view.description')}</h2>
+						<h1 class="d2l-heading-1">${this.localize('components.insights-settings-view.title')}</h1>
+						<h2 class="d2l-heading-2">${this.localize('components.insights-settings-view.description')}</h2>
 						<p>Mock content</p>
 						<p>Mock content</p>
 						<p>Mock content</p>

--- a/components/immersive-nav.js
+++ b/components/immersive-nav.js
@@ -58,14 +58,18 @@ class InsightsImmersiveNav extends Localizer(MobxLitElement) {
 		switch (this.view) {
 			case 'home': return this.localize('components.insights-engagement-dashboard.title');
 			case 'user': return this.localize('components.insights-engagement-dashboard.title-user-view');
+			case 'settings': return this.localize('components.insights-settings-view.title');
 		}
 		return this.localize('components.insights-engagement-dashboard.title');
 	}
 
 	get backText() {
 		switch (this.view) {
-			case 'home': return this.localize('components.insights-engagement-dashboard.backToInsightsPortal');
-			case 'user': return this.localize('components.insights-engagement-dashboard.backToEngagementDashboard');
+			case 'home':
+				return this.localize('components.insights-engagement-dashboard.backToInsightsPortal');
+			case 'user':
+			case 'settings':
+				return this.localize('components.insights-engagement-dashboard.backToEngagementDashboard');
 		}
 		return this.localize('components.insights-engagement-dashboard.backToInsightsPortal');
 	}

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -18,6 +18,7 @@ import './components/message-container.js';
 import './components/default-view-popup.js';
 import './components/user-drill-view.js';
 import './components/immersive-nav.js';
+import './components/dashboard-settings';
 
 import { css, html } from 'lit-element/lit-element.js';
 import { DefaultViewState, ViewState } from './model/view-state';
@@ -219,7 +220,10 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				innerView = this._renderHomeView();
 				break;
 			case 'user':
-				innerView =  this._renderUserDrillView();
+				innerView = this._renderUserDrillView();
+				break;
+			case 'settings':
+				innerView = this._renderSettingsView();
 				break;
 		}
 
@@ -256,6 +260,14 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 		`;
 	}
 
+	_renderSettingsView() {
+		return html`
+			<d2l-insights-engagement-dashboard-settings
+				@d2l-insights-settings-view-back="${this._backToHomeHandler}"
+			></d2l-insights-engagement-dashboard-settings>
+		`;
+	}
+
 	_renderHomeView() {
 		return html`
 
@@ -278,6 +290,11 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 						icon="d2l-tier1:help"
 						text=${this.localize('components.insights-engagement-dashboard.learMore')}
 						@click="${this._openHelpLink}">
+					</d2l-button-subtle>
+					<d2l-button-subtle
+						icon="d2l-tier1:gear"
+						text=${this.localize('components.insights-settings-view.title')}
+						@click="${this._openSettingsPage}">
 					</d2l-button-subtle>
 				</d2l-action-button-group>
 			</div>
@@ -449,6 +466,10 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 
 	_openHelpLink() {
 		window.open('https://community.brightspace.com/s/article/Brightspace-Performance-Plus-Analytics-Administrator-Guide', '_blank');
+	}
+
+	_openSettingsPage() {
+		this.currentView = 'settings';
 	}
 
 	_roleFilterChange(event) {

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -277,7 +277,6 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				<d2l-action-button-group
 					class="d2l-main-action-button-group"
 					min-to-show="0"
-					max-to-show="2"
 					opener-type="more"
 				>
 					<d2l-button-subtle

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -242,7 +242,6 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 		const userData = this._serverData.userDictionary.get(userId);
 
 		if (!userData) {
-			console.log(`User id ${this._userId} is not provided.`);
 			return;
 		}
 
@@ -464,12 +463,20 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 		return this.__telemetryHelper;
 	}
 
+	_backToHomeHandler() {
+		if (this._viewState) {
+			this._viewState.setHomeView();
+		}
+	}
+
 	_openHelpLink() {
 		window.open('https://community.brightspace.com/s/article/Brightspace-Performance-Plus-Analytics-Administrator-Guide', '_blank');
 	}
 
 	_openSettingsPage() {
-		this.currentView = 'settings';
+		if (this._viewState) {
+			this._viewState.setSettingsView();
+		}
 	}
 
 	_roleFilterChange(event) {

--- a/locales/en.js
+++ b/locales/en.js
@@ -145,5 +145,11 @@ export default {
 	"components.insights-default-view-popup.emptyResultsFromNRecentSemesters": "This dashboard is designed to look at portions of your organization's engagement. You do not have permission to review data in any courses in the most recently created {numDefaultSemesters} semesters.",
 	"components.insights-default-view-popup.expandDefaultCourseList": "Expand to see the courses included in your default view",
 	"components.insights-default-view-popup.collapseDefaultCourseList": "Collapse the list of courses included in your default view",
-	"components.insights-default-view-popup.buttonOk": "Ok"
+	"components.insights-default-view-popup.buttonOk": "Ok",
+
+	"components.insights-settings-view.title": "Settings",
+	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-settings-view.saveAndClose": "Save and Close",
+	"components.insights-settings-view.save": "Save",
+	"components.insights-settings-view.cancel": "Cancel"
 };

--- a/model/view-state.js
+++ b/model/view-state.js
@@ -28,6 +28,15 @@ export class ViewState {
 		if (this._urlState) this._urlState.save();
 	}
 
+	setSettingsView() {
+		this.currentView = 'settings';
+		this.userViewUserId = 0;
+		// odd, but after second navigation to user view
+		// autorun reaction stops observing properties form ViewState
+		// therefore this line is needed
+		if (this._urlState) this._urlState.save();
+	}
+
 	//for Urlstate
 	get persistenceKey() {
 		return 'v';
@@ -48,6 +57,8 @@ export class ViewState {
 			case 'home': this.setHomeView();
 				break;
 			case 'user': this.setUserView(Number(userId));
+				break;
+			case 'settings': this.setSettingsView();
 				break;
 			default:
 				this.setHomeView();

--- a/test/components/dashboard-settings.test.js
+++ b/test/components/dashboard-settings.test.js
@@ -1,0 +1,42 @@
+import '../../components/dashboard-settings';
+
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
+
+describe('d2l-insights-engagement-dashboard-settings', () => {
+
+	describe('constructor', () => {
+		it('should construct', () => {
+			runConstructor('d2l-insights-engagement-dashboard-settings');
+		});
+	});
+
+	describe('accessibility', () => {
+		it('should pass all axe tests', async() => {
+			const el = await fixture(html`<d2l-insights-engagement-dashboard-settings></d2l-insights-engagement-dashboard-settings>`);
+			await expect(el).to.be.accessible();
+		});
+	});
+
+	describe('eventing', () => {
+		it('should fire d2l-insights-settings-view-back when closed with cancel button', async() => {
+			const el = await fixture(html`<d2l-insights-engagement-dashboard-settings></d2l-insights-engagement-dashboard-settings>`);
+			const button = el.shadowRoot.querySelector('.d2l-insights-settings-page-footer > d2l-button:last-child');
+			const listener = oneEvent(el, 'd2l-insights-settings-view-back');
+
+			button.click();
+
+			await listener;
+		});
+
+		it('should fire d2l-insights-settings-view-back when closed with save button', async() => {
+			const el = await fixture(html`<d2l-insights-engagement-dashboard-settings></d2l-insights-engagement-dashboard-settings>`);
+			const button = el.shadowRoot.querySelector('.d2l-insights-settings-page-footer > d2l-button:first-child');
+			const listener = oneEvent(el, 'd2l-insights-settings-view-back');
+
+			button.click();
+
+			await listener;
+		});
+	});
+});

--- a/test/model/view-state.test.js
+++ b/test/model/view-state.test.js
@@ -31,6 +31,15 @@ describe('ViewState', () => {
 			expect(sut.persistenceValue).equals('user,321');
 		});
 
+		it('should load settings view from url', async() => {
+			setStateForTesting(KEY, 'settings,0');
+
+			const sut = new ViewState();
+
+			expect(sut.currentView).equals('settings');
+			expect(sut.persistenceValue).equals('settings,0');
+		});
+
 		it('should save home view to the url', async() => {
 			setStateForTesting(KEY, 'viewId,userId');
 
@@ -59,6 +68,20 @@ describe('ViewState', () => {
 
 			const searchParams = new URLSearchParams(window.location.search);
 			expect(searchParams.get(KEY)).equals('user,321');
+		});
+
+		it('should save settings view to the url', async() => {
+			setStateForTesting(KEY, 'home,0');
+
+			const sut = new ViewState();
+
+			sut.setSettingsView();
+
+			expect(sut.currentView).equals('settings');
+			expect(sut.persistenceValue).equals('settings,0');
+
+			const searchParams = new URLSearchParams(window.location.search);
+			expect(searchParams.get(KEY)).equals('settings,0');
 		});
 	});
 });


### PR DESCRIPTION
Sets up the settings page so that we can start working on the content. ~~It does not yet work with URL state.~~ It now works with URL state

Quality notes
* Testing
  * [x] Responsive
    * It scrolls correctly when there is enough content on the page to cause scrolling
    * Footer is still at the bottom of the page even if there isn't enough content to cause scrolling
  * [x] Browsers
  * [x] Accessible (screen reader / keyboard nav)
    * Tested w/ Chrome+NVDA
    * D2L menus have interesting behaviour: you can't tab through the items but you can go through them with arrow keys. This is [expected behaviour](https://d2l.slack.com/archives/C0PHG3QB0/p1606404317237600). (@johngwilkinson you were right) 
  * [x] RTL
  * [x] Test cases
    * Settings page -> home page
      * via browser back button
      * via immersive nav back button
      * via cancel / save and close buttons
    * Home page -> settings page -> home page
      * via browser back button
      * via immersive nav back button
      * via cancel / save and close buttons
    * Browser forward button
* Security, perf, devops: N/A
* UX
  * [x] Demo to Kevin

@anhill-D2L @rohitvinnakota @johngwilkinson @NicholasHallman 