### PR TITLE
Us120705/sa threshold pref

### DIFF
--- a/components/last-access-card.js
+++ b/components/last-access-card.js
@@ -62,10 +62,12 @@ class LastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 	}
 
 	get _cardMessage() {
-		return this.localize(
-			'components.insights-engagement-dashboard.lastSystemAccessMessage',
-			{ thresholdDays: this.filter.thresholdDays }
-		);
+		return this.filter.thresholdDays !== 1 ?
+			this.localize(
+				'components.insights-engagement-dashboard.lastSystemAccessMessage',
+				{ thresholdDays: this.filter.thresholdDays }
+			) :
+			this.localize('components.insights-engagement-dashboard.lastSystemAccessMessageOneDay');
 	}
 
 	get _cardTitle() {

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -397,7 +397,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 			// on the results of the other: we avoid this by building them on specific sets of filters.
 			const rowFilteredData = new FilteredData(this._serverData)
 				.withFilter(new OverdueAssignmentsFilter())
-				.withFilter(new LastAccessFilter())
+				.withFilter(new LastAccessFilter(this.lastAccessThresholdDays))
 				.withFilter(new CourseLastAccessFilter())
 				.withFilter(new CurrentFinalGradesFilter())
 				.withFilter(new DiscussionActivityFilter());

--- a/locales/en.js
+++ b/locales/en.js
@@ -10,7 +10,7 @@ export default {
 	"components.insights-engagement-dashboard.resultsReturned": "Users returned within results.",
 	"components.insights-engagement-dashboard.overdueAssignments": "Users currently have one or more overdue assignments.",
 	"components.insights-engagement-dashboard.overdueAssignmentsHeading": "Overdue Assignments",
-	"components.insights-engagement-dashboard.lastSystemAccess": "Users have no system access in the last 14 days.",
+	"components.insights-engagement-dashboard.lastSystemAccessMessage": 'Users have no system access in the last {thresholdDays} days.',
 	"components.insights-engagement-dashboard.lastSystemAccessHeading": "System Access",
 	"components.insights-engagement-dashboard.tooManyResults": "There are too many results in your filters. Please refine your selection.",
 	"components.insights-engagement-dashboard.learMore": "Learn More",

--- a/locales/en.js
+++ b/locales/en.js
@@ -12,6 +12,7 @@ export default {
 	"components.insights-engagement-dashboard.overdueAssignments": "Users currently have one or more overdue assignments.",
 	"components.insights-engagement-dashboard.overdueAssignmentsHeading": "Overdue Assignments",
 	"components.insights-engagement-dashboard.lastSystemAccessMessage": 'Users have no system access in the last {thresholdDays} days.',
+	"components.insights-engagement-dashboard.lastSystemAccessMessageOneDay": 'Users have no system access in the last day.',
 	"components.insights-engagement-dashboard.lastSystemAccessHeading": "System Access",
 	"components.insights-engagement-dashboard.tooManyResults": "There are too many results in your filters. Please refine your selection.",
 	"components.insights-engagement-dashboard.learMore": "Learn More",

--- a/test/components/last-access-card.test.js
+++ b/test/components/last-access-card.test.js
@@ -8,7 +8,7 @@ describe('d2l-insights-last-access-card', () => {
 	before(() => disableUrlStateForTesting());
 	after(() => enableUrlState());
 
-	const filter = new LastAccessFilter();
+	const filter = new LastAccessFilter(14);
 
 	const data = {
 		getFilter: id => (id === filter.id ? filter : null),

--- a/test/engagement-dashboard.test.js
+++ b/test/engagement-dashboard.test.js
@@ -1,5 +1,6 @@
 import '../engagement-dashboard.js';
 import { expect, fixture, html } from '@open-wc/testing';
+import { LastAccessFilter } from '../components/last-access-card';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
 
 describe('d2l-insights-engagement-dashboard', () => {
@@ -53,6 +54,16 @@ describe('d2l-insights-engagement-dashboard', () => {
 			await new Promise(resolve => setTimeout(resolve, 100));
 
 			expect(el._serverData.selectedRoleIds).to.deep.equal([900, 1000, 11]);
+		});
+
+		it('should provide threshold to last access filter', async() => {
+			const el = await fixture(html`<d2l-insights-engagement-dashboard
+					last-access-threshold-days="6"
+					demo
+				></d2l-insights-engagement-dashboard>`);
+			await new Promise(resolve => setTimeout(resolve, 100));
+
+			expect(el._data.getFilter(new LastAccessFilter().id).thresholdDays).to.equal(6);
 		});
 
 		const allCards = [


### PR DESCRIPTION
Quality Notes
- functional: test different values via demo and LMS; with some data munging to set last access time to N days ago, confirmed both card count and filtering of table rows works as expected, with both higher and lower values of the preference
- devops/perf/security: n/a
- ux/docs: split langterm so the message is grammatical if the preference is set to "1"

FYI @anhill-D2L @bemailloux @MykolaGalian @rohitvinnakota 