### PR TITLE
US120707: column configuration ui

### DIFF
--- a/components/card-selection-list.js
+++ b/components/card-selection-list.js
@@ -114,7 +114,7 @@ class CardSelectionList extends RtlMixin(Localizer(LitElement)) {
 								${this.localize('components.insights-current-final-grade-card.currentGrade')}
 							</h3>
 							<d2l-offscreen>${this.localize('components.insights-current-final-grade-card.currentGrade')}</d2l-offscreen>
-							<p class="d2l-body-standard">${this.localize('components.insights-settings-view.currentGradeDesc')}</p>
+							<p class="d2l-body-standard">${this.localize('components.insights-engagement-settings.currentGradeDesc')}</p>
 						</div>
 					</div>
 				</d2l-list-item>
@@ -127,7 +127,7 @@ class CardSelectionList extends RtlMixin(Localizer(LitElement)) {
 								${this.localize('components.insights-course-last-access-card.courseAccess')}
 							</h3>
 							<d2l-offscreen>${this.localize('components.insights-course-last-access-card.courseAccess')}</d2l-offscreen>
-							<p class="d2l-body-standard">${this.localize('components.insights-settings-view.courseAccessDesc')}</p>
+							<p class="d2l-body-standard">${this.localize('components.insights-engagement-settings.courseAccessDesc')}</p>
 						</div>
 					</div>
 				</d2l-list-item>
@@ -140,7 +140,7 @@ class CardSelectionList extends RtlMixin(Localizer(LitElement)) {
 								${this.localize('components.insights-time-in-content-vs-grade-card.timeInContentVsGrade')}
 							</h3>
 							<d2l-offscreen>${this.localize('components.insights-time-in-content-vs-grade-card.timeInContentVsGrade')}</d2l-offscreen>
-							<p class="d2l-body-standard">${this.localize('components.insights-settings-view.ticVsGradeDesc')}</p>
+							<p class="d2l-body-standard">${this.localize('components.insights-engagement-settings.ticVsGradeDesc')}</p>
 						</div>
 					</div>
 				</d2l-list-item>
@@ -160,7 +160,7 @@ class CardSelectionList extends RtlMixin(Localizer(LitElement)) {
 								${this.localize('components.insights-engagement-dashboard.overdueAssignmentsHeading')}
 							</h3>
 							<d2l-offscreen>${this.localize('components.insights-engagement-dashboard.overdueAssignmentsHeading')}</d2l-offscreen>
-							<p class="d2l-body-standard">${this.localize('components.insights-settings-view.overdueAssignmentsDesc')}</p>
+							<p class="d2l-body-standard">${this.localize('components.insights-engagement-settings.overdueAssignmentsDesc')}</p>
 						</div>
 					</div>
 				</d2l-list-item>
@@ -179,7 +179,7 @@ class CardSelectionList extends RtlMixin(Localizer(LitElement)) {
 								${this.localize('components.insights-discussion-activity-card.cardTitle')}
 							</h3>
 							<d2l-offscreen>${this.localize('components.insights-discussion-activity-card.cardTitle')}</d2l-offscreen>
-							<p class="d2l-body-standard">${this.localize('components.insights-settings-view.discActivityDesc')}</p>
+							<p class="d2l-body-standard">${this.localize('components.insights-engagement-settings.discActivityDesc')}</p>
 						</div>
 					</div>
 				</d2l-list-item>
@@ -194,7 +194,7 @@ class CardSelectionList extends RtlMixin(Localizer(LitElement)) {
 		);
 
 		// hack to get 2 parts of a localized version of a string
-		const editTextParts = this.localize('components.insights-settings-view.systemAccessEdit', { num: '{num}' }).split('{num}');
+		const editTextParts = this.localize('components.insights-engagement-settings.systemAccessEdit', { num: '{num}' }).split('{num}');
 
 		return html`
 			<d2l-labs-summary-card
@@ -208,8 +208,8 @@ class CardSelectionList extends RtlMixin(Localizer(LitElement)) {
 				<h3 class="d2l-heading-3 d2l-card-selection-title" aria-hidden="true">
 					${this.localize('components.insights-engagement-dashboard.lastSystemAccessHeading')}
 				</h3>
-				<d2l-offscreen>${this.localize('components.insights-settings-view.systemAccessDesc')}</d2l-offscreen>
-				<p class="d2l-body-standard">${this.localize('components.insights-settings-view.systemAccessDesc')}</p>
+				<d2l-offscreen>${this.localize('components.insights-engagement-settings.systemAccessDesc')}</d2l-offscreen>
+				<p class="d2l-body-standard">${this.localize('components.insights-engagement-settings.systemAccessDesc')}</p>
 
 				<div>
 					<span class="d2l-body-small">${editTextParts[0]}</span>
@@ -219,7 +219,7 @@ class CardSelectionList extends RtlMixin(Localizer(LitElement)) {
 						value="${this.lastAccessThresholdDays}"
 						min="${lastSysAccessThresholdMinDays}"
 						max="${lastSysAccessThresholdMaxDays}"
-						label="${this.localize('components.insights-settings-view.systemAccessEditLabel')}"
+						label="${this.localize('components.insights-engagement-settings.systemAccessEditLabel')}"
 						label-hidden
 						@change="${this._handleThresholdFieldChange}">
 					</d2l-input-number>

--- a/components/column-configuration.js
+++ b/components/column-configuration.js
@@ -89,7 +89,7 @@ class ColumnConfiguration extends RtlMixin(Localizer(LitElement)) {
 				</d2l-list-item>
 				<d2l-list-item key="showTicCol" selectable ?selected="${this.showTicCol}">
 					<div class="d2l-insights-config-list-item">
-						<div class="d2l-column-example" slot="illustration">${formatNumber(92, numberFormatOptions)}</div>
+						<div class="d2l-column-example">${formatNumber(92, numberFormatOptions)}</div>
 						<div class="d2l-column-selection-text">
 							<h3 class="d2l-heading-3">${this.localize('components.insights-engagement-settings.avgTimeInContent')}</h3>
 							<p class="d2l-body-standard">${this.localize('components.insights-engagement-settings.avgTimeInContent-description')}</p>
@@ -98,7 +98,7 @@ class ColumnConfiguration extends RtlMixin(Localizer(LitElement)) {
 				</d2l-list-item>
 				<d2l-list-item key="showDiscussionsCol" selectable ?selected="${this.showDiscussionsCol}">
 					<div class="d2l-insights-config-list-item">
-						<div class="d2l-column-example" slot="illustration">${this._discussionsExample}</div>
+						<div class="d2l-column-example">${this._discussionsExample}</div>
 						<div class="d2l-column-selection-text">
 							<h3 class="d2l-heading-3">${this.localize('components.insights-engagement-settings.avgDiscussionActivity')}</h3>
 							<p class="d2l-body-standard">${this.localize('components.insights-engagement-settings.avgDiscussionActivity-description')}</p>
@@ -107,7 +107,7 @@ class ColumnConfiguration extends RtlMixin(Localizer(LitElement)) {
 				</d2l-list-item>
 				<d2l-list-item key="showLastAccessCol" selectable ?selected="${this.showLastAccessCol}">
 					<div class="d2l-insights-config-list-item">
-						<div class="d2l-column-example" slot="illustration">${formatDateTime(thirtyHoursAgo(), { format: 'medium' })}</div>
+						<div class="d2l-column-example">${formatDateTime(thirtyHoursAgo(), { format: 'medium' })}</div>
 						<div class="d2l-column-selection-text">
 							<h3 class="d2l-heading-3">${this.localize('components.insights-engagement-settings.lastAccessedSystem')}</h3>
 							<p class="d2l-body-standard">${this.localize('components.insights-engagement-settings.lastAccessedSystem-description')}</p>

--- a/components/column-configuration.js
+++ b/components/column-configuration.js
@@ -56,7 +56,7 @@ class ColumnConfiguration extends RtlMixin(Localizer(LitElement)) {
 			table {
 				width: min-content;
 			}
-			td.discussion-info {
+			td.d2l-insights-discussion-info {
 				vertical-align: top;
 			}
 		`];
@@ -121,21 +121,21 @@ class ColumnConfiguration extends RtlMixin(Localizer(LitElement)) {
 	get _discussionsExample() {
 		return html`<table>
 			<tr>
-				<td class="discussion-info">
+				<td class="d2l-insights-discussion-info">
 					<div class="d2l-body-standard" style="text-align:center;">1</div>
 					<div class="d2l-body-standard" style="text-align:center;">${this.localize('components.insights-discussion-activity-card.threads')}</div>
 				</td>
 				<td>
 					<d2l-icon icon="tier2:divider"></d2l-icon>
 				</td>
-				<td class="discussion-info">
+				<td class="d2l-insights-discussion-info">
 					<div class="d2l-body-standard" style="text-align:center;">1</div>
 					<div class="d2l-body-standard" style="text-align:center;">${this.localize('components.insights-discussion-activity-card.reads')}</div>
 				</td>
 				<td>
 					<d2l-icon icon="tier2:divider"></d2l-icon>
 				</td>
-				<td class="discussion-info">
+				<td class="d2l-insights-discussion-info">
 					<div class="d2l-body-standard" style="text-align:center;">0</div>
 					<div class="d2l-body-standard" style="text-align:center;">${this.localize('components.insights-discussion-activity-card.replies')}</div>
 				</td>

--- a/components/column-configuration.js
+++ b/components/column-configuration.js
@@ -1,0 +1,150 @@
+import '@brightspace-ui/core/components/list/list';
+import '@brightspace-ui/core/components/list/list-item';
+import { bodySmallStyles, bodyStandardStyles, heading3Styles } from '@brightspace-ui/core/components/typography/styles';
+import { css, html, LitElement } from 'lit-element/lit-element';
+import { formatNumber, formatPercent } from '@brightspace-ui/intl';
+import { formatDateTime } from '@brightspace-ui/intl/lib/dateTime.js';
+import { Localizer } from '../locales/localizer';
+import { numberFormatOptions } from './users-table';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin';
+
+function thirtyHoursAgo() {
+	return new Date(Date.now() - 30 * 60 * 60 * 1000);
+}
+
+class ColumnConfiguration extends RtlMixin(Localizer(LitElement)) {
+	static get properties() {
+		return {
+			showCoursesCol: { type: Boolean, attribute: 'courses-col', reflect: true },
+			showDiscussionsCol: { type: Boolean, attribute: 'discussions-col', reflect: true },
+			showGradeCol: { type: Boolean, attribute: 'grade-col', reflect: true },
+			showLastAccessCol: { type: Boolean, attribute: 'last-access-col', reflect: true },
+			showTicCol: { type: Boolean, attribute: 'tic-col', reflect: true }
+		};
+	}
+
+	static get styles() {
+		return [bodySmallStyles, bodyStandardStyles, heading3Styles, css`
+			:host {
+				display: block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			.d2l-insights-config-list-item {
+				display: flex;
+				flex-direction: row;
+			}
+
+			@media screen and (max-width: 767px) {
+				.d2l-insights-config-list-item {
+					display: flex;
+					flex-direction: column;
+				}
+			}
+			.d2l-column-example {
+				margin: 10px 30px;
+				min-width: 300px;
+			}
+			.d2l-column-selection-text {
+				margin: 10px 30px;
+			}
+			h3.d2l-heading-3 {
+				margin-top: 0;
+			}
+
+			table {
+				width: min-content;
+			}
+			td.discussion-info {
+				vertical-align: top;
+			}
+		`];
+	}
+
+	constructor() {
+		super();
+
+		this.showCoursesCol = false;
+		this.showDiscussionsCol = false;
+		this.showGradeCol = false;
+		this.showLastAccessCol = false;
+		this.showTicCol = false;
+	}
+
+	render() {
+		// NB: list-item keys MUST have the same name as its corresponding component property
+		// e.g. the key for this.showCoursesCol must be "showCoursesCol" (see _handleSelectionChange)
+
+		return html`
+			<d2l-list id="card-selection-list" @d2l-list-selection-change="${this._handleSelectionChange}">
+				<d2l-list-item key="showGradeCol" selectable ?selected="${this.showGradeCol}">
+					<div class="d2l-insights-config-list-item">
+						<div class="d2l-column-example">${formatPercent(0.8705, numberFormatOptions)}</div>
+						<div class="d2l-column-selection-text">
+							<h3 class="d2l-heading-3">${this.localize('components.insights-engagement-settings.avgGrade')}</h3>
+							<p class="d2l-body-standard">${this.localize('components.insights-engagement-settings.avgGrade-description')}</p>
+						</div>
+					</div>
+				</d2l-list-item>
+				<d2l-list-item key="showTicCol" selectable ?selected="${this.showTicCol}">
+					<div class="d2l-insights-config-list-item">
+						<div class="d2l-column-example" slot="illustration">${formatNumber(92, numberFormatOptions)}</div>
+						<div class="d2l-column-selection-text">
+							<h3 class="d2l-heading-3">${this.localize('components.insights-engagement-settings.avgTimeInContent')}</h3>
+							<p class="d2l-body-standard">${this.localize('components.insights-engagement-settings.avgTimeInContent-description')}</p>
+						</div>
+					</div>
+				</d2l-list-item>
+				<d2l-list-item key="showDiscussionsCol" selectable ?selected="${this.showDiscussionsCol}">
+					<div class="d2l-insights-config-list-item">
+						<div class="d2l-column-example" slot="illustration">${this._discussionsExample}</div>
+						<div class="d2l-column-selection-text">
+							<h3 class="d2l-heading-3">${this.localize('components.insights-engagement-settings.avgDiscussionActivity')}</h3>
+							<p class="d2l-body-standard">${this.localize('components.insights-engagement-settings.avgDiscussionActivity-description')}</p>
+						</div>
+					</div>
+				</d2l-list-item>
+				<d2l-list-item key="showLastAccessCol" selectable ?selected="${this.showLastAccessCol}">
+					<div class="d2l-insights-config-list-item">
+						<div class="d2l-column-example" slot="illustration">${formatDateTime(thirtyHoursAgo(), { format: 'medium' })}</div>
+						<div class="d2l-column-selection-text">
+							<h3 class="d2l-heading-3">${this.localize('components.insights-engagement-settings.lastAccessedSystem')}</h3>
+							<p class="d2l-body-standard">${this.localize('components.insights-engagement-settings.lastAccessedSystem-description')}</p>
+						</div>
+					</div>
+				</d2l-list-item>
+			</d2l-list>
+		`;
+	}
+
+	get _discussionsExample() {
+		return html`<table>
+			<tr>
+				<td class="discussion-info">
+					<div class="d2l-body-standard" style="text-align:center;">1</div>
+					<div class="d2l-body-standard" style="text-align:center;">${this.localize('components.insights-discussion-activity-card.threads')}</div>
+				</td>
+				<td>
+					<d2l-icon icon="tier2:divider"></d2l-icon>
+				</td>
+				<td class="discussion-info">
+					<div class="d2l-body-standard" style="text-align:center;">1</div>
+					<div class="d2l-body-standard" style="text-align:center;">${this.localize('components.insights-discussion-activity-card.reads')}</div>
+				</td>
+				<td>
+					<d2l-icon icon="tier2:divider"></d2l-icon>
+				</td>
+				<td class="discussion-info">
+					<div class="d2l-body-standard" style="text-align:center;">0</div>
+					<div class="d2l-body-standard" style="text-align:center;">${this.localize('components.insights-discussion-activity-card.replies')}</div>
+				</td>
+			</tr>
+		</table>`;
+	}
+
+	_handleSelectionChange(event) {
+		this[event.detail.key] = event.detail.selected;
+	}
+}
+customElements.define('d2l-insights-engagement-column-configuration', ColumnConfiguration);

--- a/components/dashboard-settings.js
+++ b/components/dashboard-settings.js
@@ -4,6 +4,7 @@ import '@brightspace-ui/core/components/tabs/tabs';
 import '@brightspace-ui/core/components/tabs/tab-panel';
 
 import './role-list.js';
+import './column-configuration';
 
 import { css, html, LitElement } from 'lit-element';
 import { heading1Styles, heading2Styles } from '@brightspace-ui/core/components/typography/styles.js';
@@ -163,11 +164,11 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 		return html`
 			<div class="d2l-insights-settings-page-main-container">
 				<div class="d2l-insights-settings-page-main-content">
-					<h1 class="d2l-heading-1">${this.localize('components.insights-settings-view.title')}</h1>
-					<h2 class="d2l-heading-2">${this.localize('components.insights-settings-view.description')}</h2>
+						<h1 class="d2l-heading-1">${this.localize('components.insights-engagement-settings.title')}</h1>
+						<h2 class="d2l-heading-2">${this.localize('components.insights-engagement-settings.description')}</h2>
 
 					<d2l-tabs>
-						<d2l-tab-panel text="${this.localize('components.insights-settings-view.tabTitleSummaryMetrics')}">
+						<d2l-tab-panel text="${this.localize('components.insights-engagement-settings.tabTitleSummaryMetrics')}">
 
 							<d2l-insights-role-list
 								?demo="${this.isDemo}"
@@ -175,8 +176,14 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 							</d2l-insights-role-list>
 						</d2l-tab-panel>
 
-						<d2l-tab-panel text="${this.localize('components.insights-settings-view.tabTitleResultsTableMetrics')}">
-							<!-- out of scope: users table column selection -->
+						<d2l-tab-panel text="${this.localize('components.insights-engagement-settings.tabTitleResultsTableMetrics')}">
+							<d2l-insights-engagement-column-configuration
+								?courses-col="${this.showCoursesCol}"
+								?discussions-col="${this.showDiscussionsCol}"
+								?grade-col="${this.showGradeCol}"
+								?last-access-col="${this.showLastAccessCol}"
+								?tic-col="${this.showTicCol}"
+							></d2l-insights-engagement-column-configuration>
 						</d2l-tab-panel>
 					</d2l-tabs>
 				</div>
@@ -188,18 +195,18 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 						primary
 						class="d2l-insights-settings-footer-button-desktop"
 						@click="${this._handleSaveAndClose}">
-						${this.localize('components.insights-settings-view.saveAndClose')}
+						${this.localize('components.insights-engagement-settings.saveAndClose')}
 					</d2l-button>
 					<d2l-button
 						primary
 						class="d2l-insights-settings-footer-button-responsive"
 						@click="${this._handleSaveAndClose}">
-						${this.localize('components.insights-settings-view.save')}
+						${this.localize('components.insights-engagement-settings.save')}
 					</d2l-button>
 					<d2l-button
 						class="d2l-insights-settings-footer-button"
 						@click="${this._handleCancel}">
-						${this.localize('components.insights-settings-view.cancel')}
+						${this.localize('components.insights-engagement-settings.cancel')}
 					</d2l-button>
 				</div>
 			</footer>
@@ -211,6 +218,7 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 	}
 
 	async _handleSaveAndClose() {
+		const columnConfig = this.shadowRoot.querySelector('d2l-insights-engagement-column-configuration');
 		const settings = {
 			showResultsCard: this.showResultsCard,
 			showOverdueCard: this.showOverdueCard,
@@ -219,11 +227,11 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 			showGradesCard: this.showGradesCard,
 			showTicGradesCard: this.showTicGradesCard,
 			showCourseAccessCard: this.showCourseAccessCard,
-			showCoursesCol: this.showCoursesCol,
-			showGradeCol: this.showGradeCol,
-			showTicCol: this.showTicCol,
-			showDiscussionsCol: this.showDiscussionsCol,
-			showLastAccessCol: this.showLastAccessCol,
+			showCoursesCol: columnConfig.showCoursesCol,
+			showGradeCol: columnConfig.showGradeCol,
+			showTicCol: columnConfig.showTicCol,
+			showDiscussionsCol: columnConfig.showDiscussionsCol,
+			showLastAccessCol: columnConfig.showLastAccessCol,
 			lastAccessThresholdDays: this.lastAccessThresholdDays,
 			includeRoles: this._selectedRoleIds
 		};
@@ -243,6 +251,9 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 	}
 
 	_returnToEngagementDashboard(settings) {
+		/**
+		 * @event d2l-insights-settings-view-back
+		 */
 		this.dispatchEvent(new CustomEvent('d2l-insights-settings-view-back', {
 			detail: settings
 		}));

--- a/components/immersive-nav.js
+++ b/components/immersive-nav.js
@@ -58,7 +58,7 @@ class InsightsImmersiveNav extends Localizer(MobxLitElement) {
 		switch (this.view) {
 			case 'home': return this.localize('components.insights-engagement-dashboard.title');
 			case 'user': return this.localize('components.insights-engagement-dashboard.title-user-view');
-			case 'settings': return this.localize('components.insights-settings-view.title');
+			case 'settings': return this.localize('components.insights-engagement-settings.title');
 		}
 		return this.localize('components.insights-engagement-dashboard.title');
 	}

--- a/components/table.js
+++ b/components/table.js
@@ -189,7 +189,7 @@ class Table extends SkeletonMixin(Localizer(RtlMixin(LitElement))) {
 				};
 			}
 
-			td.discussion-info {
+			td.d2l-insights-discussion-info {
 				vertical-align: top;
 			}
 		`];
@@ -353,21 +353,21 @@ class Table extends SkeletonMixin(Localizer(RtlMixin(LitElement))) {
 
 					<table>
 						<tr>
-							<td class="discussion-info">
+							<td class="d2l-insights-discussion-info">
 								<div class="d2l-body-standard" style="text-align:center;">${cellValue[0]}</div>
 								<div class="d2l-body-standard" style="text-align:center;">${this.localize('components.insights-discussion-activity-card.threads')}</div>
 							</td>
 							<td>
 								<d2l-icon icon="tier2:divider"></d2l-icon>
 							</td>
-							<td class="discussion-info">
+							<td class="d2l-insights-discussion-info">
 								<div class="d2l-body-standard" style="text-align:center;">${cellValue[1]}</div>
 								<div class="d2l-body-standard" style="text-align:center;">${this.localize('components.insights-discussion-activity-card.reads')}</div>
 							</td>
 							<td>
 								<d2l-icon icon="tier2:divider"></d2l-icon>
 							</td>
-							<td class="discussion-info">
+							<td class="d2l-insights-discussion-info">
 								<div class="d2l-body-standard" style="text-align:center;">${cellValue[2]}</div>
 								<div class="d2l-body-standard" style="text-align:center;">${this.localize('components.insights-discussion-activity-card.replies')}</div>
 							</td>

--- a/components/table.js
+++ b/components/table.js
@@ -188,6 +188,10 @@ class Table extends SkeletonMixin(Localizer(RtlMixin(LitElement))) {
 					@apply --d2l-table;
 				};
 			}
+
+			td.discussion-info {
+				vertical-align: top;
+			}
 		`];
 	}
 
@@ -349,21 +353,21 @@ class Table extends SkeletonMixin(Localizer(RtlMixin(LitElement))) {
 
 					<table>
 						<tr>
-							<td>
+							<td class="discussion-info">
 								<div class="d2l-body-standard" style="text-align:center;">${cellValue[0]}</div>
 								<div class="d2l-body-standard" style="text-align:center;">${this.localize('components.insights-discussion-activity-card.threads')}</div>
 							</td>
 							<td>
 								<d2l-icon icon="tier2:divider"></d2l-icon>
 							</td>
-							<td>
+							<td class="discussion-info">
 								<div class="d2l-body-standard" style="text-align:center;">${cellValue[1]}</div>
 								<div class="d2l-body-standard" style="text-align:center;">${this.localize('components.insights-discussion-activity-card.reads')}</div>
 							</td>
 							<td>
 								<d2l-icon icon="tier2:divider"></d2l-icon>
 							</td>
-							<td>
+							<td class="discussion-info">
 								<div class="d2l-body-standard" style="text-align:center;">${cellValue[2]}</div>
 								<div class="d2l-body-standard" style="text-align:center;">${this.localize('components.insights-discussion-activity-card.replies')}</div>
 							</td>

--- a/components/users-table.js
+++ b/components/users-table.js
@@ -21,7 +21,7 @@ export const TABLE_USER = {
 	LAST_ACCESSED_SYS: 6
 };
 
-const numberFormatOptions = { maximumFractionDigits: 2 };
+export const numberFormatOptions = { maximumFractionDigits: 2 };
 
 const DEFAULT_PAGE_SIZE = 20;
 

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -325,7 +325,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					</d2l-button-subtle>
 					<d2l-button-subtle
 						icon="d2l-tier1:gear"
-						text=${this.localize('components.insights-settings-view.title')}
+						text=${this.localize('components.insights-engagement-settings.title')}
 						@click="${this._openSettingsPage}">
 					</d2l-button-subtle>
 				</d2l-action-button-group>

--- a/locales/ar.js
+++ b/locales/ar.js
@@ -148,9 +148,9 @@ export default {
 	"components.insights-default-view-popup.collapseDefaultCourseList": "طي قائمة المقررات التعليمية المضمنة في العرض الافتراضي الخاص بك",
 	"components.insights-default-view-popup.buttonOk": "موافق",
 
-	"components.insights-settings-view.title": "الإعدادات",
-	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
-	"components.insights-settings-view.saveAndClose": "حفظ وإغلاق",
-	"components.insights-settings-view.save": "حفظ",
-	"components.insights-settings-view.cancel": "إلغاء"
+	"components.insights-engagement-settings.title": "الإعدادات",
+	"components.insights-engagement-settings.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-engagement-settings.saveAndClose": "حفظ وإغلاق",
+	"components.insights-engagement-settings.save": "حفظ",
+	"components.insights-engagement-settings.cancel": "إلغاء"
 };

--- a/locales/cy-gb.js
+++ b/locales/cy-gb.js
@@ -148,9 +148,9 @@ export default {
 	"components.insights-default-view-popup.collapseDefaultCourseList": "Crebachu’r rhestr o gyrsiau sydd wedi'u cynnwys yn eich gwedd ddiofyn",
 	"components.insights-default-view-popup.buttonOk": "Iawn",
 
-	"components.insights-settings-view.title": "Gosodiadau",
-	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
-	"components.insights-settings-view.saveAndClose": "Cadw a Chau",
-	"components.insights-settings-view.save": "Save",
-	"components.insights-settings-view.cancel": "Cancel"
+	"components.insights-engagement-settings.title": "Gosodiadau",
+	"components.insights-engagement-settings.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-engagement-settings.saveAndClose": "Cadw a Chau",
+	"components.insights-engagement-settings.save": "Save",
+	"components.insights-engagement-settings.cancel": "Cancel"
 };

--- a/locales/da.js
+++ b/locales/da.js
@@ -148,9 +148,9 @@ export default {
 	"components.insights-default-view-popup.collapseDefaultCourseList": "Skjul listen over kurser, der er inkluderet i standardvisningen",
 	"components.insights-default-view-popup.buttonOk": "Ok",
 
-	"components.insights-settings-view.title": "Settings",
-	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
-	"components.insights-settings-view.saveAndClose": "Gem og luk",
-	"components.insights-settings-view.save": "Gem",
-	"components.insights-settings-view.cancel": "Cancel"
+	"components.insights-engagement-settings.title": "Settings",
+	"components.insights-engagement-settings.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-engagement-settings.saveAndClose": "Gem og luk",
+	"components.insights-engagement-settings.save": "Gem",
+	"components.insights-engagement-settings.cancel": "Cancel"
 };

--- a/locales/de.js
+++ b/locales/de.js
@@ -148,9 +148,9 @@ export default {
 	"components.insights-default-view-popup.collapseDefaultCourseList": "Liste der Kurse reduzieren, die in der Standardansicht enthalten ist",
 	"components.insights-default-view-popup.buttonOk": "OK",
 
-	"components.insights-settings-view.title": "Einstellungen",
-	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
-	"components.insights-settings-view.saveAndClose": "Speichern und schließen",
-	"components.insights-settings-view.save": "Speichern",
-	"components.insights-settings-view.cancel": "Abbrechen"
+	"components.insights-engagement-settings.title": "Einstellungen",
+	"components.insights-engagement-settings.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-engagement-settings.saveAndClose": "Speichern und schließen",
+	"components.insights-engagement-settings.save": "Speichern",
+	"components.insights-engagement-settings.cancel": "Abbrechen"
 };

--- a/locales/en.js
+++ b/locales/en.js
@@ -158,15 +158,15 @@ export default {
 	"components.insights-engagement-settings.save": "Save",
 	"components.insights-engagement-settings.cancel": "Cancel",
 
-	"components.insights-settings-view.currentGradeDesc": "The Current Grade card shows the current grade for each enrollment per user. Data shown will appear both with the card and in the Result Detail table.",
-	"components.insights-settings-view.courseAccessDesc": "The Course Access card shows the last access in a course for each enrollment per user. Data shown will appear both with the card and in the Result Detail table.",
-	"components.insights-settings-view.ticVsGradeDesc": "The Time in Content vs. Grade card shows the time spent relative to the current grade for each enrollment per user. The chart is mapped into quadrants of high or low time and grade based off of course averages. Data shown will appear both with the card and in the Result Detail table.",
-	"components.insights-settings-view.overdueAssignmentsDesc": "The Overdue Assignments card shows the number of users who have one or more assignments overdue. Data shown will appear both with the card and in the Result Detail table.",
-	"components.insights-settings-view.systemAccessDesc": "The System Access card shows the last access in the system per user even if no courses have been accessed. Data shown will appear both with the card and in the Result Detail table.",
-	"components.insights-settings-view.discActivityDesc": "The Discussion Activity card shows passive and active social engagement in each course. The metric captures and shows when a user creates a post, replies to an existing post or reads a post.",
+	"components.insights-engagement-settings.currentGradeDesc": "The Current Grade card shows the current grade for each enrollment per user. Data shown will appear both with the card and in the Result Detail table.",
+	"components.insights-engagement-settings.courseAccessDesc": "The Course Access card shows the last access in a course for each enrollment per user. Data shown will appear both with the card and in the Result Detail table.",
+	"components.insights-engagement-settings.ticVsGradeDesc": "The Time in Content vs. Grade card shows the time spent relative to the current grade for each enrollment per user. The chart is mapped into quadrants of high or low time and grade based off of course averages. Data shown will appear both with the card and in the Result Detail table.",
+	"components.insights-engagement-settings.overdueAssignmentsDesc": "The Overdue Assignments card shows the number of users who have one or more assignments overdue. Data shown will appear both with the card and in the Result Detail table.",
+	"components.insights-engagement-settings.systemAccessDesc": "The System Access card shows the last access in the system per user even if no courses have been accessed. Data shown will appear both with the card and in the Result Detail table.",
+	"components.insights-engagement-settings.discActivityDesc": "The Discussion Activity card shows passive and active social engagement in each course. The metric captures and shows when a user creates a post, replies to an existing post or reads a post.",
 
-	"components.insights-settings-view.systemAccessEdit": "Show users who have not accessed the system in the last {num} days.",
-	"components.insights-settings-view.systemAccessEditLabel": "Edit system access threshold",
+	"components.insights-engagement-settings.systemAccessEdit": "Show users who have not accessed the system in the last {num} days.",
+	"components.insights-engagement-settings.systemAccessEditLabel": "Edit system access threshold",
 
 	"components.insights-engagement-settings.avgGrade": "Average Grade Performance Summary",
 	"components.insights-engagement-settings.avgTimeInContent": "Average Time in Content Summary",

--- a/locales/en.js
+++ b/locales/en.js
@@ -150,11 +150,20 @@ export default {
 	"components.insights-default-view-popup.collapseDefaultCourseList": "Collapse the list of courses included in your default view",
 	"components.insights-default-view-popup.buttonOk": "Ok",
 
-	"components.insights-settings-view.title": "Settings",
-	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
-	"components.insights-settings-view.tabTitleSummaryMetrics": "Summary Metrics",
-	"components.insights-settings-view.tabTitleResultsTableMetrics": "Results Table Metrics",
-	"components.insights-settings-view.saveAndClose": "Save and Close",
-	"components.insights-settings-view.save": "Save",
-	"components.insights-settings-view.cancel": "Cancel"
+	"components.insights-engagement-settings.title": "Settings",
+	"components.insights-engagement-settings.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-engagement-settings.tabTitleSummaryMetrics": "Summary Metrics",
+	"components.insights-engagement-settings.tabTitleResultsTableMetrics": "Results Table Metrics",
+	"components.insights-engagement-settings.saveAndClose": "Save and Close",
+	"components.insights-engagement-settings.save": "Save",
+	"components.insights-engagement-settings.cancel": "Cancel",
+
+	"components.insights-engagement-settings.avgGrade": "Average Grade Performance Summary",
+	"components.insights-engagement-settings.avgTimeInContent": "Average Time in Content Summary",
+	"components.insights-engagement-settings.avgDiscussionActivity": "Average Discussion Participation Summary",
+	"components.insights-engagement-settings.lastAccessedSystem": "System Last Access",
+	"components.insights-engagement-settings.avgGrade-description": "The Average Grades Performance Summary indicator presents the current average grade for the student across all the applied filtered fields.",
+	"components.insights-engagement-settings.avgTimeInContent-description": "The Average Time in Content indicator shows the average time spent in content across all the applied filtered fields. The metric is tracked in minutes.",
+	"components.insights-engagement-settings.avgDiscussionActivity-description": "The Average Discussion Participation Summary indicator presents user statistics for average reading, posting, and responding to discussions across all the applied filtered fields.",
+	"components.insights-engagement-settings.lastAccessedSystem-description": "The System Last Access indicator displays the last session date and local time that a user has accessed the system and any subsequent courses in the system.",
 };

--- a/locales/es-es.js
+++ b/locales/es-es.js
@@ -148,9 +148,9 @@ export default {
 	"components.insights-default-view-popup.collapseDefaultCourseList": "Contraer la lista de cursos incluidos en la vista predeterminada",
 	"components.insights-default-view-popup.buttonOk": "Aceptar",
 
-	"components.insights-settings-view.title": "Configuración",
-	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
-	"components.insights-settings-view.saveAndClose": "Guardar y cerrar",
-	"components.insights-settings-view.save": "Save",
-	"components.insights-settings-view.cancel": "Cancel"
+	"components.insights-engagement-settings.title": "Configuración",
+	"components.insights-engagement-settings.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-engagement-settings.saveAndClose": "Guardar y cerrar",
+	"components.insights-engagement-settings.save": "Save",
+	"components.insights-engagement-settings.cancel": "Cancel"
 };

--- a/locales/es.js
+++ b/locales/es.js
@@ -148,9 +148,9 @@ export default {
 	"components.insights-default-view-popup.collapseDefaultCourseList": "Contraer la lista de cursos incluidos en su vista predeterminada",
 	"components.insights-default-view-popup.buttonOk": "Aceptar",
 
-	"components.insights-settings-view.title": "Configuración",
-	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
-	"components.insights-settings-view.saveAndClose": "Guardar y cerrar",
-	"components.insights-settings-view.save": "Guardar",
-	"components.insights-settings-view.cancel": "Cancelar"
+	"components.insights-engagement-settings.title": "Configuración",
+	"components.insights-engagement-settings.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-engagement-settings.saveAndClose": "Guardar y cerrar",
+	"components.insights-engagement-settings.save": "Guardar",
+	"components.insights-engagement-settings.cancel": "Cancelar"
 };

--- a/locales/fr-fr.js
+++ b/locales/fr-fr.js
@@ -148,9 +148,9 @@ export default {
 	"components.insights-default-view-popup.collapseDefaultCourseList": "Réduire la liste des cours inclus dans votre vue par défaut",
 	"components.insights-default-view-popup.buttonOk": "OK",
 
-	"components.insights-settings-view.title": "Paramètres",
-	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
-	"components.insights-settings-view.saveAndClose": "Enregistrer et fermer",
-	"components.insights-settings-view.save": "Enregistrer",
-	"components.insights-settings-view.cancel": "Annuler"
+	"components.insights-engagement-settings.title": "Paramètres",
+	"components.insights-engagement-settings.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-engagement-settings.saveAndClose": "Enregistrer et fermer",
+	"components.insights-engagement-settings.save": "Enregistrer",
+	"components.insights-engagement-settings.cancel": "Annuler"
 };

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -148,9 +148,9 @@ export default {
 	"components.insights-default-view-popup.collapseDefaultCourseList": "Repliez la liste de cours de votre affichage par défaut",
 	"components.insights-default-view-popup.buttonOk": "OK",
 
-	"components.insights-settings-view.title": "Settings",
-	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
-	"components.insights-settings-view.saveAndClose": "Enregistrer et fermer",
-	"components.insights-settings-view.save": "Enregistrer",
-	"components.insights-settings-view.cancel": "Annuler"
+	"components.insights-engagement-settings.title": "Settings",
+	"components.insights-engagement-settings.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-engagement-settings.saveAndClose": "Enregistrer et fermer",
+	"components.insights-engagement-settings.save": "Enregistrer",
+	"components.insights-engagement-settings.cancel": "Annuler"
 };

--- a/locales/ja.js
+++ b/locales/ja.js
@@ -148,9 +148,9 @@ export default {
 	"components.insights-default-view-popup.collapseDefaultCourseList": "デフォルトビューに含まれているコースのリストを折りたたむ",
 	"components.insights-default-view-popup.buttonOk": "OK",
 
-	"components.insights-settings-view.title": "設定",
-	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
-	"components.insights-settings-view.saveAndClose": "保存して閉じる",
-	"components.insights-settings-view.save": "保存",
-	"components.insights-settings-view.cancel": "キャンセル"
+	"components.insights-engagement-settings.title": "設定",
+	"components.insights-engagement-settings.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-engagement-settings.saveAndClose": "保存して閉じる",
+	"components.insights-engagement-settings.save": "保存",
+	"components.insights-engagement-settings.cancel": "キャンセル"
 };

--- a/locales/ko.js
+++ b/locales/ko.js
@@ -148,9 +148,9 @@ export default {
 	"components.insights-default-view-popup.collapseDefaultCourseList": "기본 보기에 포함된 강의 목록을 축소합니다.",
 	"components.insights-default-view-popup.buttonOk": "확인",
 
-	"components.insights-settings-view.title": "설정",
-	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
-	"components.insights-settings-view.saveAndClose": "저장 및 닫기",
-	"components.insights-settings-view.save": "저장",
-	"components.insights-settings-view.cancel": "취소"
+	"components.insights-engagement-settings.title": "설정",
+	"components.insights-engagement-settings.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-engagement-settings.saveAndClose": "저장 및 닫기",
+	"components.insights-engagement-settings.save": "저장",
+	"components.insights-engagement-settings.cancel": "취소"
 };

--- a/locales/nl.js
+++ b/locales/nl.js
@@ -148,9 +148,9 @@ export default {
 	"components.insights-default-view-popup.collapseDefaultCourseList": "De lijst met cursussen in uw standaardweergave samenvouwen",
 	"components.insights-default-view-popup.buttonOk": "OK",
 
-	"components.insights-settings-view.title": "Settings",
-	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
-	"components.insights-settings-view.saveAndClose": "Opslaan en sluiten",
-	"components.insights-settings-view.save": "Opslaan",
-	"components.insights-settings-view.cancel": "Annuleren"
+	"components.insights-engagement-settings.title": "Settings",
+	"components.insights-engagement-settings.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-engagement-settings.saveAndClose": "Opslaan en sluiten",
+	"components.insights-engagement-settings.save": "Opslaan",
+	"components.insights-engagement-settings.cancel": "Annuleren"
 };

--- a/locales/pt.js
+++ b/locales/pt.js
@@ -148,9 +148,9 @@ export default {
 	"components.insights-default-view-popup.collapseDefaultCourseList": "Recolher a lista de cursos incluídos na exibição padrão",
 	"components.insights-default-view-popup.buttonOk": "Ok",
 
-	"components.insights-settings-view.title": "Configurações",
-	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
-	"components.insights-settings-view.saveAndClose": "Salvar e fechar",
-	"components.insights-settings-view.save": "Salvar",
-	"components.insights-settings-view.cancel": "Cancelar"
+	"components.insights-engagement-settings.title": "Configurações",
+	"components.insights-engagement-settings.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-engagement-settings.saveAndClose": "Salvar e fechar",
+	"components.insights-engagement-settings.save": "Salvar",
+	"components.insights-engagement-settings.cancel": "Cancelar"
 };

--- a/locales/sv.js
+++ b/locales/sv.js
@@ -148,9 +148,9 @@ export default {
 	"components.insights-default-view-popup.collapseDefaultCourseList": "Komprimera listan med kurser som visas i standardvyn",
 	"components.insights-default-view-popup.buttonOk": "Ok",
 
-	"components.insights-settings-view.title": "Inställningar",
-	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
-	"components.insights-settings-view.saveAndClose": "Spara och stäng",
-	"components.insights-settings-view.save": "Spara",
-	"components.insights-settings-view.cancel": "Avbryt"
+	"components.insights-engagement-settings.title": "Inställningar",
+	"components.insights-engagement-settings.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-engagement-settings.saveAndClose": "Spara och stäng",
+	"components.insights-engagement-settings.save": "Spara",
+	"components.insights-engagement-settings.cancel": "Avbryt"
 };

--- a/locales/tr.js
+++ b/locales/tr.js
@@ -148,9 +148,9 @@ export default {
 	"components.insights-default-view-popup.collapseDefaultCourseList": "Varsayılan görünümünüze dahil edilen derslerin listesini daraltın",
 	"components.insights-default-view-popup.buttonOk": "Tamam",
 
-	"components.insights-settings-view.title": "Ayarlar",
-	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
-	"components.insights-settings-view.saveAndClose": "Kaydet ve Kapat",
-	"components.insights-settings-view.save": "Kaydet",
-	"components.insights-settings-view.cancel": "Cancel"
+	"components.insights-engagement-settings.title": "Ayarlar",
+	"components.insights-engagement-settings.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-engagement-settings.saveAndClose": "Kaydet ve Kapat",
+	"components.insights-engagement-settings.save": "Kaydet",
+	"components.insights-engagement-settings.cancel": "Cancel"
 };

--- a/locales/zh-tw.js
+++ b/locales/zh-tw.js
@@ -148,9 +148,9 @@ export default {
 	"components.insights-default-view-popup.collapseDefaultCourseList": "摺疊預設檢視中包含的課程清單",
 	"components.insights-default-view-popup.buttonOk": "確定",
 
-	"components.insights-settings-view.title": "設定",
-	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
-	"components.insights-settings-view.saveAndClose": "儲存並關閉",
-	"components.insights-settings-view.save": "儲存",
-	"components.insights-settings-view.cancel": "取消"
+	"components.insights-engagement-settings.title": "設定",
+	"components.insights-engagement-settings.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-engagement-settings.saveAndClose": "儲存並關閉",
+	"components.insights-engagement-settings.save": "儲存",
+	"components.insights-engagement-settings.cancel": "取消"
 };

--- a/locales/zh.js
+++ b/locales/zh.js
@@ -148,9 +148,9 @@ export default {
 	"components.insights-default-view-popup.collapseDefaultCourseList": "折叠您的默认视图中包含的课程列表",
 	"components.insights-default-view-popup.buttonOk": "确定",
 
-	"components.insights-settings-view.title": "设置",
-	"components.insights-settings-view.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
-	"components.insights-settings-view.saveAndClose": "保存并关闭",
-	"components.insights-settings-view.save": "保存",
-	"components.insights-settings-view.cancel": "取消"
+	"components.insights-engagement-settings.title": "设置",
+	"components.insights-engagement-settings.description": "Set which metrics display in the Summary and Result Detail section of the Engagement Dashboard.",
+	"components.insights-engagement-settings.saveAndClose": "保存并关闭",
+	"components.insights-engagement-settings.save": "保存",
+	"components.insights-engagement-settings.cancel": "取消"
 };


### PR DESCRIPTION
- unit tests will come in another PR, in the interest of making this available to UX for accessibility review

Quality notes

- Testing
  - Browsers (Chrome, FF, Edgium, Edgacy)
  - Accessibility (keyboard nav / screen reader - tested with NVDA/Chrome)
  - RTL
  - Responsive
- Test cases
  - Loading: if settings exist for this user, it loads with those
  - Display: after save and close, engagement dashboard uses the new settings
  - Display: if cancel button is pressed, dashboard uses old settings
  - Reload after saving: saved settings are persisted
- Security, devops, perf: N/A
- UX
 - [x] Demo to Kevin

FYI @anhill-D2L @MykolaGalian @rohitvinnakota @Vitalii-Misechko 

![image](https://user-images.githubusercontent.com/11181217/100889841-9d57be00-3485-11eb-8b29-49396266d8ec.png)
