### PR TITLE
US120704 [Engage][Config] Get rid of vertical scroll bar for role list

### DIFF
--- a/components/role-list.js
+++ b/components/role-list.js
@@ -39,7 +39,7 @@ class RoleList extends Localizer(LitElement) {
 				min-width: 260px;
 			}
 
-			.d2l-insights-role-list-small-list > d2l-input-checkbox{
+			.d2l-insights-role-list-small-list > d2l-input-checkbox {
 				flex: 1 1 50%;
 			}
 

--- a/components/role-list.js
+++ b/components/role-list.js
@@ -2,6 +2,7 @@ import './dropdown-filter';
 import '@brightspace-ui/core/components/inputs/input-checkbox';
 
 import { css, html, LitElement } from 'lit-element';
+import { classMap } from 'lit-html/directives/class-map.js';
 import { fetchRoles as fetchDemoRoles } from '../model/fake-lms';
 import { fetchRoles } from '../model/lms';
 import { heading3Styles } from '@brightspace-ui/core/components/typography/styles.js';
@@ -38,14 +39,16 @@ class RoleList extends Localizer(LitElement) {
 				min-width: 260px;
 			}
 
+			.d2l-insights-role-list-small-list > d2l-input-checkbox{
+				flex: 1 1 50%;
+			}
+
 			.d2l-insights-role-list-list {
 				display: flex;
 				flex-direction: row;
 				flex-wrap: wrap;
-				max-height: 536px;
 				max-width: 100vw;
-				min-height: 200px;
-				overflow-y: auto;
+				min-height: 50px;
 			}
 
 		`];
@@ -100,12 +103,19 @@ class RoleList extends Localizer(LitElement) {
 	}
 
 	render() {
+		const filterData = this._filterData;
+		const styles = {
+			'd2l-insights-role-list-list': true,
+			// shows only one column if there are less than 13 roles in the list
+			'd2l-insights-role-list-small-list': filterData.length < 13
+		};
+
 		return html`
 			<h3 class="d2l-heading-3">${this.localize('components.insights-settings-view-role-list.title')}</h3>
 			<span>${this.localize('components.insights-settings-view-role-list.description')}</span>
 
-			<div class="d2l-insights-role-list-list">
-				${this._filterData.map(item => html`<d2l-input-checkbox value="${item.id}" @change="${this._handleSelectionChange}" ?checked="${item.selected}" >${item.displayName}</d2l-input-checkbox>`)}
+			<div class="${classMap(styles)}">
+				${filterData.map(item => html`<d2l-input-checkbox value="${item.id}" @change="${this._handleSelectionChange}" ?checked="${item.selected}" >${item.displayName}</d2l-input-checkbox>`)}
 			</div>
 		`;
 	}


### PR DESCRIPTION
[US120704](https://rally1.rallydev.com/#/detail/userstory/437183105984?fdp=true): [Engage][Config] Move Role Filter

Main PR: https://github.com/Brightspace/insights-engagement-dashboard/pull/168

FYI @anhill-D2L @MykolaGalian @rohitvinnakota @hyehayes @NicholasHallman 

### Functional Testing
- [x] Manual tests (Chrome, FF, Edge)
  * Role list: shows only two column if there more than 13 roles
  * Role list: does not show vertical scroll bar
### Security Testing - N/A
### Performance Testing - N/A
### Devops - N/A
### UX and docs - N/A

- [x] Demo

#### Pic 1
![image](https://user-images.githubusercontent.com/9429561/100874392-2df5c480-34ad-11eb-8171-1c8d3cc311f5.png)

#### Pic 2
![image](https://user-images.githubusercontent.com/9429561/100874555-6eedd900-34ad-11eb-9c4b-f9bbad477a77.png)

#### Pic 3
![image](https://user-images.githubusercontent.com/9429561/100874697-a2306800-34ad-11eb-8fe2-03f7bf66d8c4.png)

