### PR TITLE
Fix bad merge

### DIFF
--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -426,11 +426,11 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 			<d2l-insights-users-table
 				.data="${this._data}"
 				?skeleton="${this._isLoading}"
-				?show-courses-col="${this.showCoursesCol}"
-				?show-discussions-col="${this.showDiscussionsCol}"
-				?show-grade-col="${this.showGradeCol}"
-				?show-last-access-col="${this.showLastAccessCol}"
-				?show-tic-col="${this.showTicCol}"
+				?courses-col="${this.showCoursesCol}"
+				?discussions-col="${this.showDiscussionsCol}"
+				?grade-col="${this.showGradeCol}"
+				?last-access-col="${this.showLastAccessCol}"
+				?tic-col="${this.showTicCol}"
 				@d2l-insights-users-table-cell-clicked="${this._userTableCellClicked}"
 			></d2l-insights-users-table>
 		`;

--- a/test/engagement-dashboard.test.js
+++ b/test/engagement-dashboard.test.js
@@ -138,12 +138,13 @@ describe('d2l-insights-engagement-dashboard', () => {
 
 				const usersTable = el.shadowRoot.querySelector('d2l-insights-users-table');
 				const innerTable = usersTable.shadowRoot.querySelector('d2l-insights-table');
+				await innerTable.updateComplete;
 
 				const actualColHeaders = Array.from(innerTable.shadowRoot.querySelectorAll('th'));
 				expect(actualColHeaders.length).to.equal(expectedList.length + 2); // 2 extra for row-selector and name columns
 
 				expect(actualColHeaders[0].firstElementChild.nodeName).to.equal('D2L-INPUT-CHECKBOX');
-				expect(actualColHeaders[1].innerText).to.equal('Name');
+				expect(actualColHeaders[1].innerText.trim()).to.equal('Name');
 
 				expectedList.forEach((col, idx) => {
 					expect(actualColHeaders[idx + 2].innerText).to.equal(allCols.get(col));

--- a/test/engagement-dashboard.test.js
+++ b/test/engagement-dashboard.test.js
@@ -108,5 +108,47 @@ describe('d2l-insights-engagement-dashboard', () => {
 					});
 				})
 			);
+
+		const allCols = new Map([
+			['courses-col', 'Courses'],
+			['grade-col', 'Average Grade'],
+			['tic-col', 'Average Time in Content (mins)'],
+			['discussions-col', 'Average Discussion Activity'],
+			['last-access-col', 'Last Accessed System']
+		]);
+		const allColsKeys = Array.from(allCols.keys());
+
+		[
+			allColsKeys,
+			[],
+			['grade-col', 'discussions-col'],
+			...allColsKeys.map(omitCol => allColsKeys.filter(col => col !== omitCol))
+		].forEach(expectedList => {
+			it(`should show selected columns in users table (${expectedList})`, async() => {
+				// cards aren't loaded for this test
+				const el = await fixture(html`<d2l-insights-engagement-dashboard
+						?courses-col="${expectedList.includes('courses-col')}"
+						?discussions-col="${expectedList.includes('discussions-col')}"
+						?grade-col="${expectedList.includes('grade-col')}"
+						?last-access-col="${expectedList.includes('last-access-col')}"
+						?tic-col="${expectedList.includes('tic-col')}"
+						demo
+					></d2l-insights-engagement-dashboard>`);
+				await new Promise(resolve => setTimeout(resolve, 100));
+
+				const usersTable = el.shadowRoot.querySelector('d2l-insights-users-table');
+				const innerTable = usersTable.shadowRoot.querySelector('d2l-insights-table');
+
+				const actualColHeaders = Array.from(innerTable.shadowRoot.querySelectorAll('th'));
+				expect(actualColHeaders.length).to.equal(expectedList.length + 2); // 2 extra for row-selector and name columns
+
+				expect(actualColHeaders[0].firstElementChild.nodeName).to.equal('D2L-INPUT-CHECKBOX');
+				expect(actualColHeaders[1].innerText).to.equal('Name');
+
+				expectedList.forEach((col, idx) => {
+					expect(actualColHeaders[idx + 2].innerText).to.equal(allCols.get(col));
+				});
+			});
+		});
 	});
 });


### PR DESCRIPTION
Fix a bad merge which was causing most columns in the users-table to disappear. + tests

Quality notes
* Testing
  * Users table shows all columns if all columns are enabled in settings
  * Users table shows only selector, name and courses columns if all columns are disabled in settings
  * Users table shows correct columns if some are enabled in settings
* Security, devops, perf, docs, UX: N/A

@Vitalii-Misechko @NicholasHallman @rohitvinnakota @MykolaGalian 