### PR TITLE
Us118253/oslo

### DIFF
--- a/locales/localizer.js
+++ b/locales/localizer.js
@@ -1,6 +1,8 @@
-// copied from BrightspaceUI/core's LocalizeCoreElement, with modifications
+// see https://docs.dev.d2l/index.php/Oslo
+import { getLocalizeOverrideResources } from '@brightspace-ui/core/helpers/getLocalizeResources.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin';
 
+// copied from BrightspaceUI/core's LocalizeCoreElement, with modifications
 export const Localizer = superclass => class extends LocalizeMixin(superclass) {
 
 	/**
@@ -8,6 +10,11 @@ export const Localizer = superclass => class extends LocalizeMixin(superclass) {
 	 * e.g. ['fr-fr', 'fr', 'en-us', 'en']
 	 */
 	static async getLocalizeResources(langs) {
+		function getCollectionName() {
+			// must be "name" from package.json, then backslash, then "name" from *.serge.json
+			return 'd2l-engagement-dashboard\\insights-engagement-dashboard';
+		}
+
 		let translations;
 		// always load in English translations, so we have something to default to
 		const enTranslations = await import('./en.js');
@@ -69,25 +76,29 @@ export const Localizer = superclass => class extends LocalizeMixin(superclass) {
 						translations = await import('./zh.js');
 						break;
 				}
+
 				if (translations && translations.default) {
-					return {
-						language: lang,
-						resources: Object.assign(enTranslations.default, translations.default)
-					};
+					return await getLocalizeOverrideResources(
+						lang,
+						Object.assign(enTranslations.default, translations.default),
+						getCollectionName
+					);
 				}
 			}
 
-			return {
-				language: 'en',
-				resources: enTranslations.default
-			};
+			return await getLocalizeOverrideResources(
+				'en',
+				enTranslations.default,
+				getCollectionName
+			);
 
 		} catch (err) {
 			// can happen if the langterms file for a language doesn't exist
-			return {
-				language: 'en',
-				resources: enTranslations.default
-			};
+			return await getLocalizeOverrideResources(
+				'en',
+				enTranslations.default,
+				getCollectionName
+			);
 		}
 	}
 };


### PR DESCRIPTION
This adds oslo support for this repo (following a change in BSI to tell it to include our serge langterms in the bundle for oslo).

Quality Notes:
- Functional testing is illustrated by the pictures below.
  - slight glitch: when you change a langterm, you have to refresh the page _twice_ to pick it up (apparently due to caching and a race of some sort in UI core)
- performance: the helper functions we're using cache very effectively
- security, devops: n/a (langterms already exist in the main-branch LMS)
- ux/docs: uses the LMS standard language management tool, so n/a

FYI @anhill-D2L @bemailloux @MykolaGalian @Vitalii-Misechko 

![image](https://user-images.githubusercontent.com/11181217/101192644-5dc9d700-3629-11eb-864a-79fd9e3ac576.png)
![image](https://user-images.githubusercontent.com/11181217/101192685-6e7a4d00-3629-11eb-9121-a501cf09d42f.png)
![image](https://user-images.githubusercontent.com/11181217/101192706-789c4b80-3629-11eb-91ca-84668e50a162.png)
