### PR TITLE
DE41591: use lms timezone setting for last accessed date

### DIFF
--- a/components/active-courses-table.js
+++ b/components/active-courses-table.js
@@ -4,7 +4,7 @@ import { css, html } from 'lit-element';
 import { formatNumber, formatPercent } from '@brightspace-ui/intl';
 import { ORG_UNIT, RECORD } from '../consts';
 import { COLUMN_TYPES } from './table';
-import { formatDateTime } from '@brightspace-ui/intl/lib/dateTime.js';
+import { formatDateTimeFromTimestamp } from '@brightspace-ui/intl/lib/dateTime.js';
 import { Localizer } from '../locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin';
@@ -138,7 +138,7 @@ class CoursesTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 
 	_formatDataForDisplay(user) {
 		const lastSysAccessFormatted = user[TABLE_COURSES.COURSE_LAST_ACCESS]
-			? formatDateTime(new Date(user[TABLE_COURSES.COURSE_LAST_ACCESS]), { format: 'medium' })
+			? formatDateTimeFromTimestamp(user[TABLE_COURSES.COURSE_LAST_ACCESS], { format: 'medium' })
 			: this.localize('usersTable:null');
 		const currentGrade = user[TABLE_COURSES.CURRENT_GRADE]
 			? formatPercent(user[TABLE_COURSES.CURRENT_GRADE] / 100, numberFormatOptions)

--- a/components/column-configuration.js
+++ b/components/column-configuration.js
@@ -3,13 +3,13 @@ import '@brightspace-ui/core/components/list/list-item';
 import { bodySmallStyles, bodyStandardStyles, heading3Styles } from '@brightspace-ui/core/components/typography/styles';
 import { css, html, LitElement } from 'lit-element/lit-element';
 import { formatNumber, formatPercent } from '@brightspace-ui/intl';
-import { formatDateTime } from '@brightspace-ui/intl/lib/dateTime.js';
+import { formatDateTimeFromTimestamp } from '@brightspace-ui/intl/lib/dateTime.js';
 import { Localizer } from '../locales/localizer';
 import { numberFormatOptions } from './users-table';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin';
 
 function thirtyHoursAgo() {
-	return new Date(Date.now() - 30 * 60 * 60 * 1000);
+	return Date.now() - 30 * 60 * 60 * 1000;
 }
 
 class ColumnConfiguration extends RtlMixin(Localizer(LitElement)) {
@@ -107,7 +107,7 @@ class ColumnConfiguration extends RtlMixin(Localizer(LitElement)) {
 				</d2l-list-item>
 				<d2l-list-item key="showLastAccessCol" selectable ?selected="${this.showLastAccessCol}">
 					<div class="d2l-insights-config-list-item">
-						<div class="d2l-column-example">${formatDateTime(thirtyHoursAgo(), { format: 'medium' })}</div>
+						<div class="d2l-column-example">${formatDateTimeFromTimestamp(thirtyHoursAgo(), { format: 'medium' })}</div>
 						<div class="d2l-column-selection-text">
 							<h3 class="d2l-heading-3">${this.localize('settings:lastAccessedSystem')}</h3>
 							<p class="d2l-body-standard">${this.localize('settings:lastAccessedSystemDescription')}</p>

--- a/components/users-table.js
+++ b/components/users-table.js
@@ -6,7 +6,7 @@ import { css, html } from 'lit-element';
 import { formatNumber, formatPercent } from '@brightspace-ui/intl';
 import { RECORD, USER } from '../consts';
 import { COLUMN_TYPES } from './table';
-import { formatDateTime } from '@brightspace-ui/intl/lib/dateTime.js';
+import { formatDateTimeFromTimestamp } from '@brightspace-ui/intl/lib/dateTime.js';
 import { Localizer } from '../locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin';
@@ -219,7 +219,7 @@ class UsersTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 
 	_formatDataForDisplay(user) {
 		const lastSysAccessFormatted = user[TABLE_USER.LAST_ACCESSED_SYS]
-			? formatDateTime(new Date(user[TABLE_USER.LAST_ACCESSED_SYS]), { format: 'medium' })
+			? formatDateTimeFromTimestamp(user[TABLE_USER.LAST_ACCESSED_SYS], { format: 'medium' })
 			: this.localize('usersTable:null');
 		const averageGrade = user[TABLE_USER.AVG_GRADE]
 			? formatPercent(user[TABLE_USER.AVG_GRADE] / 100, numberFormatOptions)

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-timezone='{"name":"Canada - Toronto","identifier":"America/Chicago"}'>
 	<head>
 		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
 		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@adobe/lit-mobx": "0.0.x",
     "@brightspace-ui-labs/pagination": "^1",
     "@brightspace-ui/core": "^1.102.8",
-    "@brightspace-ui/intl": "^3.0.11",
+    "@brightspace-ui/intl": "^3.2.0",
     "@webcomponents/webcomponentsjs": "^2",
     "array-flat-polyfill": "^1.0.1",
     "d2l-button-group": "BrightspaceUI/button-group#semver:^3",

--- a/test/components/users-table.test.js
+++ b/test/components/users-table.test.js
@@ -2,7 +2,7 @@ import '../../components/users-table.js';
 import { expect, fixture, html } from '@open-wc/testing';
 import { mockRoleIds, records } from '../model/mocks';
 import { RECORD, USER } from '../../consts';
-import { formatDateTime } from '@brightspace-ui/intl/lib/dateTime.js';
+import { formatDateTimeFromTimestamp } from '@brightspace-ui/intl/lib/dateTime.js';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
 
 const COLS = {
@@ -559,5 +559,5 @@ function verifyCellValue(expectedValue, cell, colType) {
 }
 
 function getLocalDateTime(rowIndex) {
-	return formatDateTime(new Date(new Date(data.users[rowIndex][USER.LAST_SYS_ACCESS]).toISOString()), { format: 'medium' });
+	return formatDateTimeFromTimestamp(data.users[rowIndex][USER.LAST_SYS_ACCESS], { format: 'medium' });
 }


### PR DESCRIPTION
Quality Notes
- functional
  - demo page: change timezone in html tag and check that times adjust
  - lms: change timezone in account settings and verify times change (including a tz that pushed a date across a day boundary)
- devops: relies on new version of intl; will tag a release after this merges so that BSI can pick it up
- security/perf/ux: n/a

FYI @MykolaGalian @NicholasHallman @rohitvinnakota @Vitalii-Misechko 