### PR TITLE
fix: semester filter state on reload data from server

### DIFF
--- a/model/data.js
+++ b/model/data.js
@@ -83,9 +83,7 @@ export class Data {
 		this.userDictionary = new Map(newServerData.users.map(user => [user[USER.ID], user]));
 		this.isLoading = false;
 		this.serverData = newServerData;
-		if (this.serverData.selectedSemestersIds) {
-			this._selectorFilters.semester.selected = this.serverData.selectedSemestersIds;
-		}
+		this._selectorFilters.semester.selected = this.serverData.selectedSemestersIds || [];
 	}
 
 	set selectedRoleIds(newRoleIds) {
@@ -163,5 +161,8 @@ decorate(Data, {
 	isLoading: observable,
 	isQueryError: observable,
 	records: computed,
+	selectedOrgUnitIds: computed,
+	selectedRoleIds: computed,
+	selectedSemesterIds: computed,
 	onServerDataReload: action
 });

--- a/model/selectorFilters.js
+++ b/model/selectorFilters.js
@@ -35,6 +35,9 @@ export class SemesterSelectorFilter {
 	constructor(data) {
 		this._data = data;
 		this.selected = data.serverData.selectedSemestersIds || [];
+		// at least one filter needs this flag so that an intentional all-filters-cleared state
+		// is distinct from the default state
+		this.persistEmpty = true;
 		// noinspection JSUnusedGlobalSymbols
 		this._urlState = new UrlState(this);
 	}

--- a/model/urlState.js
+++ b/model/urlState.js
@@ -40,6 +40,8 @@ export function clearUrlState() {
  * set persistenceValue({String}) - called when the component should set the given state
  * If persistenceValue references one or more mobx observables, mobx will track changes. Otherwise,
  * it is necessary to call save() when the state changes.
+ * The wrapped object may optionally implement:
+ * {Boolean} get persistEmpty() - if true, the key will not be removed from the url even if the value is ''
  */
 export class UrlState {
 
@@ -60,7 +62,7 @@ export class UrlState {
 	save() {
 		const url = new URL(window.location.href);
 		const valueToSave = this.value;
-		if (valueToSave === '' && url.searchParams.has(this.key)) {
+		if (!this.persistEmpty && valueToSave === '' && url.searchParams.has(this.key)) {
 			url.searchParams.delete(this.key);
 			UrlState.pushState(url);
 		}
@@ -72,6 +74,10 @@ export class UrlState {
 
 	get key() {
 		return this._wrapped.persistenceKey;
+	}
+
+	get persistEmpty() {
+		return this._wrapped.persistEmpty;
 	}
 
 	get value() {


### PR DESCRIPTION
Three small changes here:
1. fix handling of null semester filter in server response.
2. add `computed` to some getters in `Data` - not strictly necessary, but good practice, especially for the ones with corresponding setters (makes those into `action`s).
3. add `persistEmpty` to the semester filter so we can distinguish the default state from an all-filters-cleared state

Quality Notes
- functional (on local LMS)
  - load default, check url
  - clear all filters, check url
  - clear all filters, refresh page (no default view popup or filters)
  - clear query string and load (default view popup and filters)
  - back and forward buttons with various filter settings including cleared semester filter
- devops/security/perf/ux: n/a

FYI @bemailloux @MykolaGalian @rohitvinnakota @Vitalii-Misechko 