### PR TITLE
Export from user table

### DIFF
--- a/components/user-drill-view.js
+++ b/components/user-drill-view.js
@@ -4,6 +4,7 @@ import 'd2l-users/components/d2l-profile-image';
 import { bodySmallStyles, heading2Styles, heading3Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { createComposeEmailPopup } from './email-integration';
+import { ExportData } from '../model/exportData';
 import { Localizer } from '../locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { until } from 'lit-html/directives/until';
@@ -112,7 +113,8 @@ class UserDrill extends Localizer(MobxLitElement) {
 	}
 
 	_exportToCsvHandler() {
-		// outside the scope of the story
+		const usersTable = this.shadowRoot.querySelector('d2l-insights-active-courses-table');
+		ExportData.userDataToCsv(usersTable.dataForExport, usersTable.headersForExport);
 	}
 
 	_printHandler() {

--- a/components/users-table.js
+++ b/components/users-table.js
@@ -434,6 +434,7 @@ decorate(UsersTable, {
 	userDataForDisplay: computed,
 	userDataForDisplayFormatted: computed,
 	headersForExport: computed,
+	dataForExport: computed,
 	_sortColumn: observable,
 	_sortOrder: observable,
 	_handleColumnSort: action

--- a/locales/en.js
+++ b/locales/en.js
@@ -183,10 +183,12 @@ export default {
 	"activeCoursesTable:loadingPlaceholder": "Loading",
 	"activeCoursesTable:course": "Course Name",
 	"activeCoursesTable:currentGrade": "Current Grade",
+	"activeCoursesTable:grade": "Grade",
 	"activeCoursesTable:predictedGrade": "Predicted Grade",
 	"activeCoursesTable:timeInContent": "Time in Content (mins)",
 	"activeCoursesTable:discussions": "Discussion Activity",
 	"activeCoursesTable:courseLastAccess": "Course Last Access",
 	"activeCoursesTable:noPredictedGrade": "No predicted grade",
-	"activeCoursesTable:noGrade": "No grade"
+	"activeCoursesTable:noGrade": "No grade",
+	"activeCoursesTable:isActive": "Is Active Course"
 };

--- a/model/exportData.js
+++ b/model/exportData.js
@@ -1,12 +1,6 @@
 import exportFromJSON from 'export-from-json';
 import { toJS } from 'mobx';
 
-export const DISCUSSION = {
-	THREADS: 0,
-	READS: 1,
-	REPLIES: 2
-};
-
 export class ExportData {
 	static userDataToCsv(data, headers) {
 		return this.exportToCsv(toJS(data), headers);


### PR DESCRIPTION
[US121804](https://rally1.rallydev.com/#/23525809118d/iterationstatus?detail=%2Fuserstory%2F449519683764&sharedViewId=328666453148&fdp=true?fdp=true): [Engagement] Export from user table

Local
![1](https://user-images.githubusercontent.com/27500223/101635010-18931400-3a32-11eb-8db7-922226722245.png)

LMS
![2](https://user-images.githubusercontent.com/27500223/101635017-1af56e00-3a32-11eb-9396-b2c64760609e.png)

In progress: unit tests
PR depending from "Add active and inactive courses table" PR