### PR TITLE
hardcode the timestamps so visual diffing works

### DIFF
--- a/components/column-configuration.js
+++ b/components/column-configuration.js
@@ -19,7 +19,8 @@ class ColumnConfiguration extends RtlMixin(Localizer(LitElement)) {
 			showDiscussionsCol: { type: Boolean, attribute: 'discussions-col', reflect: true },
 			showGradeCol: { type: Boolean, attribute: 'grade-col', reflect: true },
 			showLastAccessCol: { type: Boolean, attribute: 'last-access-col', reflect: true },
-			showTicCol: { type: Boolean, attribute: 'tic-col', reflect: true }
+			showTicCol: { type: Boolean, attribute: 'tic-col', reflect: true },
+			isDemo: { type: Boolean, attribute: 'demo' }
 		};
 	}
 
@@ -107,7 +108,7 @@ class ColumnConfiguration extends RtlMixin(Localizer(LitElement)) {
 				</d2l-list-item>
 				<d2l-list-item key="showLastAccessCol" selectable ?selected="${this.showLastAccessCol}">
 					<div class="d2l-insights-config-list-item">
-						<div class="d2l-column-example">${formatDateTimeFromTimestamp(thirtyHoursAgo(), { format: 'medium' })}</div>
+						<div class="d2l-column-example">${formatDateTimeFromTimestamp(this.isDemo ? 1607546883964 : thirtyHoursAgo(), { format: 'medium' })}</div>
 						<div class="d2l-column-selection-text">
 							<h3 class="d2l-heading-3">${this.localize('settings:lastAccessedSystem')}</h3>
 							<p class="d2l-body-standard">${this.localize('settings:lastAccessedSystemDescription')}</p>

--- a/components/dashboard-settings.js
+++ b/components/dashboard-settings.js
@@ -195,6 +195,7 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 								?grade-col="${this.showGradeCol}"
 								?last-access-col="${this.showLastAccessCol}"
 								?tic-col="${this.showTicCol}"
+								?demo="${this.isDemo}"
 							></d2l-insights-engagement-column-configuration>
 						</d2l-tab-panel>
 					</d2l-tabs>

--- a/model/fake-lms.js
+++ b/model/fake-lms.js
@@ -4,7 +4,7 @@ export async function fetchData({ roleIds, semesterIds, orgUnitIds, defaultView 
 	const demoData = {
 		records: [
 			[1, 100, 500, 1, 55, 1000, Date.now(), 0, 0, 0, null],
-			[1, 200, 600, 0, 33, 2000, Date.now() - 2093, 0, 0, 0, null],
+			[1, 200, 600, 0, 33, 2000, 1607528563207, 0, 0, 0, null],
 			[1, 300, 500, 0, null, 1000, null, 0, 0, 0, null],
 			[1, 400, 500, 0, 30, 5000, null, 0, 0, 0, null],
 			[1, 500, 500, 0, 65, 5000, null, 2, 0, 40, null],
@@ -36,11 +36,11 @@ export async function fetchData({ roleIds, semesterIds, orgUnitIds, defaultView 
 			[6606, 'Dev', 1, [0], false]
 		],
 		users: [ // some of which are out of order
-			[100,  'ATest', 'AStudent', 'AStudent', Date.now() - 2000000000],
+			[100,  'ATest', 'AStudent', 'AStudent', 1601193037132],
 			[300,  'CTest', 'CStudent', 'CStudent', 1603193037132],
-			[200,  'BTest', 'BStudent', 'BStudent', Date.now()],
+			[200,  'BTest', 'BStudent', 'BStudent', 1607528565300],
 			[400,  'DTest', 'DStudent', 'DStudent', null],
-			[500,  'ETest', 'EStudent', 'EStudent', Date.now()],
+			[500,  'ETest', 'EStudent', 'EStudent', 1546318800000],
 			[600,  'GTest', 'GStudent', 'GStudent', Date.now()],
 			[700,  'FTest', 'FStudent', 'FStudent', Date.now()],
 			[800,  'HTest', 'HStudent', 'HStudent', Date.now()],


### PR DESCRIPTION
Right now visual diffing the demo page doesn't work.
This is because the golden screenshots include the last access columns which include the current time which is always changing.

Making the times in those columns static will make it so there are no differences in the visual diffs

Verified in my local LMS that the time values were not changed to what the demo page is using

FYI: @johngwilkinson @NicholasHallman @rohitvinnakota @Vitalii-Misechko @hyehayes 