### PR TITLE
fix the bug where the discussions pie chart disappears

### DIFF
--- a/components/discussion-activity-card.js
+++ b/components/discussion-activity-card.js
@@ -219,7 +219,7 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 					enabled: false
 				}
 			},
-			series: {
+			series: [{
 				colorByPoint: true,
 				data: [{
 					name: that._legendLabels[0],
@@ -251,7 +251,7 @@ class DiscussionActivityCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 						return `${ix}, ${point.y}.`;
 					}
 				}
-			},
+			}],
 			accessibility: {
 				screenReaderSection: {
 					beforeChartFormat: BEFORE_CHART_FORMAT


### PR DESCRIPTION
I was able to consistently reproduce the discussions pie chart not displaying by clicking back from the user drill page.

Before:
![mXo3mJAtwn](https://user-images.githubusercontent.com/39747079/101683268-bab2fc00-3a32-11eb-9629-89aa76216b68.gif)

After:
![uvKHclG1On](https://user-images.githubusercontent.com/39747079/101683249-b4248480-3a32-11eb-993e-7d673fe2f856.gif)

FYI: @hyehayes @NicholasHallman @rohitvinnakota @MykolaGalian @Vitalii-Misechko 