### PR TITLE
Settings page - error when saving fails(Last System Access threshold value)

### DIFF
--- a/components/card-selection-list.js
+++ b/components/card-selection-list.js
@@ -235,11 +235,11 @@ class CardSelectionList extends RtlMixin(Localizer(LitElement)) {
 
 	_handleThresholdFieldChange(event) {
 		const newValue = Number(event.target.value);
-		if (isNaN(newValue) || newValue < lastSysAccessThresholdMinDays || newValue > lastSysAccessThresholdMaxDays) {
-			return;
-		}
-
 		this.lastAccessThresholdDays = Math.floor(newValue);
+	}
+
+	isInvalidSystemAccessValue() {
+		return (isNaN(this.lastAccessThresholdDays) || this.lastAccessThresholdDays < lastSysAccessThresholdMinDays || this.lastAccessThresholdDays > lastSysAccessThresholdMaxDays);
 	}
 
 	get settings() {

--- a/components/custom-toast-message.js
+++ b/components/custom-toast-message.js
@@ -5,21 +5,22 @@ import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin';
 
 class CustomToastMessage extends RtlMixin(Localizer(LitElement)) {
 
+	static get properties() {
+		return {
+			toastMessageText: { type: String, attribute: false },
+		};
+	}
+
 	render() {
 		return html`
-			<d2l-alert-toast type="critical"></d2l-alert-toast>
+			<d2l-alert-toast type="critical" subtext="${this.toastMessageText}"></d2l-alert-toast>
 		`;
 	}
 
-	systemLastAccessError() {
-		this.shadowRoot.querySelector('d2l-alert-toast').innerHTML = this.localize('settings:invalidSystemAccessValueToast');
+	open() {
 		this.shadowRoot.querySelector('d2l-alert-toast').open = true;
 	}
 
-	failedServerResponseError() {
-		this.shadowRoot.querySelector('d2l-alert-toast').innerHTML = this.localize('settings:serverSideErrorToast');
-		this.shadowRoot.querySelector('d2l-alert-toast').open = true;
-	}
 }
 
 customElements.define('d2l-insights-custom-toast-message', CustomToastMessage);

--- a/components/custom-toast-message.js
+++ b/components/custom-toast-message.js
@@ -15,6 +15,11 @@ class CustomToastMessage extends RtlMixin(Localizer(LitElement)) {
 		this.shadowRoot.querySelector('d2l-alert-toast').innerHTML = this.localize('settings:invalidSystemAccessValueToast');
 		this.shadowRoot.querySelector('d2l-alert-toast').open = true;
 	}
+
+	failedServerResponseError() {
+		this.shadowRoot.querySelector('d2l-alert-toast').innerHTML = this.localize('settings:serverSideErrorToast');
+		this.shadowRoot.querySelector('d2l-alert-toast').open = true;
+	}
 }
 
 customElements.define('d2l-insights-custom-toast-message', CustomToastMessage);

--- a/components/custom-toast-message.js
+++ b/components/custom-toast-message.js
@@ -1,0 +1,20 @@
+import '@brightspace-ui/core/components/alert/alert-toast.js';
+import { html, LitElement } from 'lit-element/lit-element.js';
+import { Localizer } from '../locales/localizer';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin';
+
+class CustomToastMessage extends RtlMixin(Localizer(LitElement)) {
+
+	render() {
+		return html`
+			<d2l-alert-toast type="critical"></d2l-alert-toast>
+		`;
+	}
+
+	systemLastAccessError() {
+		this.shadowRoot.querySelector('d2l-alert-toast').innerHTML = this.localize('settings:invalidSystemAccessValueToast');
+		this.shadowRoot.querySelector('d2l-alert-toast').open = true;
+	}
+}
+
+customElements.define('d2l-insights-custom-toast-message', CustomToastMessage);

--- a/components/dashboard-settings.js
+++ b/components/dashboard-settings.js
@@ -36,7 +36,8 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 			showTicCol: { type: Boolean, attribute: 'tic-col', reflect: true },
 			showTicGradesCard: { type: Boolean, attribute: 'tic-grades-card', reflect: true },
 			lastAccessThresholdDays: { type: Number, attribute: 'last-access-threshold-days', reflect: true },
-			includeRoles: { type: Array, attribute: false }
+			includeRoles: { type: Array, attribute: false },
+			_toastMessagetext: { type: String, attribute: false }
 		};
 	}
 
@@ -201,7 +202,7 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 					</d2l-tabs>
 				</div>
 			</div>
-			<d2l-insights-custom-toast-message></d2l-insights-custom-toast-message>
+			<d2l-insights-custom-toast-message .toastMessageText="${this._toastMessagetext}"></d2l-insights-custom-toast-message>
 			${this._renderFooter()}
 		`;
 	}
@@ -251,15 +252,16 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 		};
 
 		if (cardSelectionList.isInvalidSystemAccessValue()) {
-			this.shadowRoot.querySelector('d2l-insights-custom-toast-message').systemLastAccessError();
+			this._toastMessagetext = this.localize('settings:invalidSystemAccessValueToast');
+			this._openToastMessage();
 			return;
 		}
 
 		const response = await saveSettings(settings);
 
 		if (!response.ok) {
-			this.shadowRoot.querySelector('d2l-insights-custom-toast-message').failedServerResponseError();
-			console.error('Dashboard Settings View. Cannot save settings!');
+			this._toastMessagetext = this.localize('settings:serverSideErrorToast');
+			this._openToastMessage();
 			return;
 		}
 
@@ -277,6 +279,10 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 		this.dispatchEvent(new CustomEvent('d2l-insights-settings-view-back', {
 			detail: settings
 		}));
+	}
+
+	_openToastMessage() {
+		this.shadowRoot.querySelector('d2l-insights-custom-toast-message').open();
 	}
 }
 customElements.define('d2l-insights-engagement-dashboard-settings', DashboardSettings);

--- a/components/dashboard-settings.js
+++ b/components/dashboard-settings.js
@@ -258,6 +258,7 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 		const response = await saveSettings(settings);
 
 		if (!response.ok) {
+			this.shadowRoot.querySelector('d2l-insights-custom-toast-message').failedServerResponseError();
 			console.error('Dashboard Settings View. Cannot save settings!');
 			return;
 		}

--- a/components/dashboard-settings.js
+++ b/components/dashboard-settings.js
@@ -7,6 +7,7 @@ import '@brightspace-ui/core/components/inputs/input-number';
 import './card-selection-list';
 import './role-list.js';
 import './column-configuration';
+import './custom-toast-message';
 
 import { css, html, LitElement } from 'lit-element';
 import { heading1Styles, heading2Styles } from '@brightspace-ui/core/components/typography/styles.js';
@@ -167,7 +168,6 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 				<div class="d2l-insights-settings-page-main-content">
 						<h1 class="d2l-heading-1">${this.localize('settings:title')}</h1>
 						<h2 class="d2l-heading-2">${this.localize('settings:description')}</h2>
-
 					<d2l-tabs>
 						<d2l-tab-panel text="${this.localize('settings:tabTitleSummaryMetrics')}">
 
@@ -201,6 +201,7 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 					</d2l-tabs>
 				</div>
 			</div>
+			<d2l-insights-custom-toast-message></d2l-insights-custom-toast-message>
 			${this._renderFooter()}
 		`;
 	}
@@ -248,6 +249,11 @@ class DashboardSettings extends RtlMixin(Localizer(LitElement)) {
 			showLastAccessCol: columnConfig.showLastAccessCol,
 			includeRoles: this._selectedRoleIds
 		};
+
+		if (cardSelectionList.isInvalidSystemAccessValue()) {
+			this.shadowRoot.querySelector('d2l-insights-custom-toast-message').systemLastAccessError();
+			return;
+		}
 
 		const response = await saveSettings(settings);
 

--- a/locales/en.js
+++ b/locales/en.js
@@ -179,6 +179,7 @@ export default {
 	"settings:avgTimeInContentDescription": "The Average Time in Content indicator shows the average time spent in content, as an average of total time per course, for the user across all the courses included in the applied filters.  This metric is reported in minutes.",
 	"settings:avgDiscussionActivityDescription": "The Average Discussion Participation indicator presents user statistics for how often the user creates a thread, reads a post or replies to a post across all the courses included in the applied filters.  This metric averages the total count per course.",
 	"settings:lastAccessedSystemDescription": "The System Last Access indicator displays the timestamp, in Brightspace local time, of the last time the user accessed the system in any way.",
+	"settings:invalidSystemAccessValueToast": "Your settings could not be saved, please try again. System Access thresholds need to be between 1 and 30.",
 
 	"activeCoursesTable:title": "Active Courses",
 	"activeCoursesTable:loadingPlaceholder": "Loading",

--- a/locales/en.js
+++ b/locales/en.js
@@ -179,7 +179,7 @@ export default {
 	"settings:avgTimeInContentDescription": "The Average Time in Content indicator shows the average time spent in content, as an average of total time per course, for the user across all the courses included in the applied filters.  This metric is reported in minutes.",
 	"settings:avgDiscussionActivityDescription": "The Average Discussion Participation indicator presents user statistics for how often the user creates a thread, reads a post or replies to a post across all the courses included in the applied filters.  This metric averages the total count per course.",
 	"settings:lastAccessedSystemDescription": "The System Last Access indicator displays the timestamp, in Brightspace local time, of the last time the user accessed the system in any way.",
-	"settings:invalidSystemAccessValueToast": "Your settings could not be saved, please try again. System Access thresholds need to be between 1 and 30.",
+	"settings:invalidSystemAccessValueToast": "Your settings could not be saved. System Access thresholds need to be between 1 and 30.",
 
 	"activeCoursesTable:title": "Active Courses",
 	"activeCoursesTable:loadingPlaceholder": "Loading",

--- a/locales/en.js
+++ b/locales/en.js
@@ -180,6 +180,7 @@ export default {
 	"settings:avgDiscussionActivityDescription": "The Average Discussion Participation indicator presents user statistics for how often the user creates a thread, reads a post or replies to a post across all the courses included in the applied filters.  This metric averages the total count per course.",
 	"settings:lastAccessedSystemDescription": "The System Last Access indicator displays the timestamp, in Brightspace local time, of the last time the user accessed the system in any way.",
 	"settings:invalidSystemAccessValueToast": "Your settings could not be saved. System Access thresholds need to be between 1 and 30.",
+	"settings:serverSideErrorToast": "Something went wrong. Your settings could not be saved.",
 
 	"activeCoursesTable:title": "Active Courses",
 	"activeCoursesTable:loadingPlaceholder": "Loading",

--- a/test/components/card-selection-list.test.js
+++ b/test/components/card-selection-list.test.js
@@ -92,9 +92,10 @@ describe('d2l-insights-engagement-card-selection-list', () => {
 				await thresholdInput.updateComplete;
 
 				expect(el.settings).to.deep.equal({ ...defaultSettingsTemplate, lastAccessThresholdDays: 21 });
+				expect(el.isInvalidSystemAccessValue()).to.equal(false);
 			});
 
-			it('should return original lastAccessThreshold if the new value is invalid', async() => {
+			it('should set isInvalidSystemAccessValue to true if the new value is invalid', async() => {
 				const el = await fixture(html`<d2l-insights-engagement-card-selection-list></d2l-insights-engagement-card-selection-list>`);
 				const thresholdInput = el.shadowRoot.querySelector('d2l-input-number');
 				await thresholdInput.updateComplete;
@@ -108,7 +109,7 @@ describe('d2l-insights-engagement-card-selection-list', () => {
 				innerInput.dispatchEvent(new Event('change'));
 				await thresholdInput.updateComplete;
 
-				expect(el.settings).to.deep.equal(defaultSettingsTemplate);
+				expect(el.isInvalidSystemAccessValue()).to.equal(true);
 
 				// less than valid range
 				innerInput.value = '0';
@@ -116,7 +117,7 @@ describe('d2l-insights-engagement-card-selection-list', () => {
 				innerInput.dispatchEvent(new Event('change'));
 				await thresholdInput.updateComplete;
 
-				expect(el.settings).to.deep.equal(defaultSettingsTemplate);
+				expect(el.isInvalidSystemAccessValue()).to.equal(true);
 
 				// more than valid range
 				innerInput.value = '31';
@@ -124,7 +125,7 @@ describe('d2l-insights-engagement-card-selection-list', () => {
 				innerInput.dispatchEvent(new Event('change'));
 				await thresholdInput.updateComplete;
 
-				expect(el.settings).to.deep.equal(defaultSettingsTemplate);
+				expect(el.isInvalidSystemAccessValue()).to.equal(true);
 			});
 		});
 	});

--- a/test/components/custom-toast-message.test.js
+++ b/test/components/custom-toast-message.test.js
@@ -3,6 +3,8 @@ import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-help
 
 describe('d2l-insights-custom-toast-message', () => {
 
+	const toastMessageText = 'toast message';
+
 	describe('constructor', () => {
 		it('should construct', () => {
 			runConstructor('d2l-insights-custom-toast-message');
@@ -20,16 +22,11 @@ describe('d2l-insights-custom-toast-message', () => {
 
 	describe('render', () => {
 		it('should render the toast message as expected', async() => {
-			const el = await fixture(html`<d2l-insights-custom-toast-message></d2l-insights-custom-toast-message>`);
+			const el = await fixture(html`<d2l-insights-custom-toast-message .toastMessageText="${toastMessageText}"></d2l-insights-custom-toast-message>`);
 			await new Promise(resolve => setTimeout(resolve, 200));
 			expect(el.shadowRoot.querySelector('d2l-alert-toast').innerHTML).to.equal('');
-			el.systemLastAccessError();
-			await new Promise(resolve => setTimeout(resolve, 200));
-			expect(el.shadowRoot.querySelector('d2l-alert-toast').innerHTML).to.deep.equal('Your settings could not be saved. System Access thresholds need to be between 1 and 30.');
-			expect(el.shadowRoot.querySelector('d2l-alert-toast').open).to.equal(true);
-			await new Promise(resolve => setTimeout(resolve, 500));
-			el.failedServerResponseError();
-			expect(el.shadowRoot.querySelector('d2l-alert-toast').innerHTML).to.deep.equal('Something went wrong. Your settings could not be saved.');
+			el.open();
+			expect(el.shadowRoot.querySelector('d2l-alert-toast').subtext).to.deep.equal('toast message');
 			expect(el.shadowRoot.querySelector('d2l-alert-toast').open).to.equal(true);
 		});
 	});

--- a/test/components/custom-toast-message.test.js
+++ b/test/components/custom-toast-message.test.js
@@ -21,11 +21,11 @@ describe('d2l-insights-custom-toast-message', () => {
 	describe('render', () => {
 		it('should render the invalid system last accessed value toast message as expected', async() => {
 			const el = await fixture(html`<d2l-insights-custom-toast-message></d2l-insights-custom-toast-message>`);
-			await new Promise(resolve => setTimeout(resolve, 200)); // allow fetch to run
-			expect(el.shadowRoot.querySelector('d2l-alert-toast').innerHTML).to.deep.equal('');
+			await new Promise(resolve => setTimeout(resolve, 200));
+			expect(el.shadowRoot.querySelector('d2l-alert-toast').innerHTML).to.equal('');
 			el.systemLastAccessError();
 			await new Promise(resolve => setTimeout(resolve, 200));
-			expect(el.shadowRoot.querySelector('d2l-alert-toast').innerHTML).to.deep.equal('Your settings could not be saved, please try again. System Access thresholds need to be between 1 and 30.');
+			expect(el.shadowRoot.querySelector('d2l-alert-toast').innerHTML).to.deep.equal('Your settings could not be saved. System Access thresholds need to be between 1 and 30.');
 			expect(el.shadowRoot.querySelector('d2l-alert-toast').open).to.equal(true);
 		});
 	});

--- a/test/components/custom-toast-message.test.js
+++ b/test/components/custom-toast-message.test.js
@@ -1,0 +1,33 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
+
+describe('d2l-insights-custom-toast-message', () => {
+
+	describe('constructor', () => {
+		it('should construct', () => {
+			runConstructor('d2l-insights-custom-toast-message');
+		});
+	});
+
+	describe('accessibility', () => {
+		it('should pass all axe tests', async function() {
+			this.timeout(4000);
+
+			const el = await fixture(html`<d2l-insights-custom-toast-message></d2l-insights-custom-toast-message>`);
+			await expect(el).to.be.accessible();
+		});
+	});
+
+	describe('render', () => {
+		it('should render the invalid system last accessed value toast message as expected', async() => {
+			const el = await fixture(html`<d2l-insights-custom-toast-message></d2l-insights-custom-toast-message>`);
+			await new Promise(resolve => setTimeout(resolve, 200)); // allow fetch to run
+			expect(el.shadowRoot.querySelector('d2l-alert-toast').innerHTML).to.deep.equal('');
+			el.systemLastAccessError();
+			await new Promise(resolve => setTimeout(resolve, 200));
+			expect(el.shadowRoot.querySelector('d2l-alert-toast').innerHTML).to.deep.equal('Your settings could not be saved, please try again. System Access thresholds need to be between 1 and 30.');
+			expect(el.shadowRoot.querySelector('d2l-alert-toast').open).to.equal(true);
+		});
+	});
+
+});

--- a/test/components/custom-toast-message.test.js
+++ b/test/components/custom-toast-message.test.js
@@ -19,13 +19,17 @@ describe('d2l-insights-custom-toast-message', () => {
 	});
 
 	describe('render', () => {
-		it('should render the invalid system last accessed value toast message as expected', async() => {
+		it('should render the toast message as expected', async() => {
 			const el = await fixture(html`<d2l-insights-custom-toast-message></d2l-insights-custom-toast-message>`);
 			await new Promise(resolve => setTimeout(resolve, 200));
 			expect(el.shadowRoot.querySelector('d2l-alert-toast').innerHTML).to.equal('');
 			el.systemLastAccessError();
 			await new Promise(resolve => setTimeout(resolve, 200));
 			expect(el.shadowRoot.querySelector('d2l-alert-toast').innerHTML).to.deep.equal('Your settings could not be saved. System Access thresholds need to be between 1 and 30.');
+			expect(el.shadowRoot.querySelector('d2l-alert-toast').open).to.equal(true);
+			await new Promise(resolve => setTimeout(resolve, 500));
+			el.failedServerResponseError();
+			expect(el.shadowRoot.querySelector('d2l-alert-toast').innerHTML).to.deep.equal('Something went wrong. Your settings could not be saved.');
 			expect(el.shadowRoot.querySelector('d2l-alert-toast').open).to.equal(true);
 		});
 	});


### PR DESCRIPTION
Adds a d2l-alert-toast message when trying to save and close an invalid set of settings. Currently, the message works for the last system access threshold value case but the functionality can be extended.

[US122868](https://rally1.rallydev.com/#/23525809118d/workviews/collection?detail=%2Fuserstory%2F459991179776%2Ftasks&itemRef=%2Fhierarchicalrequirement%2F459991179776&previousTokens=%2F23525809118d%2Fcustom%2F12155517225%3F&project=%2Fproject%2F23525809118&ref=%2Fhierarchicalrequirement%2F459991179776&relationship=tasks&fdp=true?fdp=true): [Engagement][Config] Settings page - error when saving fails

![image](https://user-images.githubusercontent.com/21348406/102398316-1dfdda80-3fad-11eb-8937-1a542ac28dd0.png)
![image](https://user-images.githubusercontent.com/21348406/102504129-72a56200-404e-11eb-8461-e248b8e7aed8.png)

(The value in the screenshot's input is 233, not 23)

Screen reader: Clicking Save and close on an invalid system access value immediately triggers the alert and reads it out.
Responsiveness: Alert centers around screen when window is resized. 
Tested on edge, chrome, firefox

Security: n/a
Devops: n/a

- [x] Demo to Kevin

fyi: @johngwilkinson @hyehayes @NicholasHallman @anhill-D2L @MykolaGalian 