### PR TITLE
Us122289+DE41776 user drill table errors

### DIFF
--- a/components/message-container.js
+++ b/components/message-container.js
@@ -47,6 +47,10 @@ class MessageContainer extends LitElement {
 			.d2l-insights-message-container-button-container {
 				margin-top: 20px;
 			}
+
+			.d2l-insights-message-container-button-container > d2l-button {
+				min-width: 200px;
+			}
 		`];
 	}
 

--- a/components/message-container.js
+++ b/components/message-container.js
@@ -44,9 +44,8 @@ class MessageContainer extends LitElement {
 				word-wrap: break-word;
 			}
 
-			.d2l-insights-message-container-body.d2l-insights-message-noResultsAvailable > d2l-button {
+			.d2l-insights-message-container-button-container {
 				margin-top: 20px;
-				width: 200px;
 			}
 		`];
 	}
@@ -66,7 +65,9 @@ class MessageContainer extends LitElement {
 				return html`
 					<div class="d2l-insights-message-container-body d2l-insights-message-noResultsAvailable">
 						<span class="d2l-insights-message-container-value">${this.text}</span>
-						<d2l-button primary slot="footer" @click="${this._handleButtonClick}">${this.buttonText}</d2l-button>
+						<div class="d2l-insights-message-container-button-container">
+							<d2l-button primary slot="footer" @click="${this._handleButtonClick}">${this.buttonText}</d2l-button>
+						</div>
 					</div>
 				`;
 			default:

--- a/components/user-drill-courses-table.js
+++ b/components/user-drill-courses-table.js
@@ -1,5 +1,8 @@
-import './table.js';
 import '@brightspace-ui-labs/pagination/pagination';
+
+import './table.js';
+import './message-container';
+
 import { action, computed, decorate, observable } from 'mobx';
 import { css, html } from 'lit-element';
 import { formatNumber, formatPercent } from '@brightspace-ui/intl';
@@ -318,15 +321,21 @@ class UserDrillCoursesTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 	}
 
 	render() {
-		if (this._displayData.length !== 0) {
+		if (!this.skeleton && this._displayData.length === 0) {
+			const textKey = this.isActiveTable ? 'activeCoursesTable:empty' : 'inactiveCoursesTable:empty';
+			return html`
+				<d2l-insights-message-container type="default" text="${this.localize(textKey)}"></d2l-insights-message-container>
+			`;
+		} else {
 			return this._renderCoursesTable();
 		}
 	}
 
 	_renderCoursesTable() {
+		const titleKey = this.isActiveTable ? 'activeCoursesTable:title' : 'inactiveCoursesTable:title';
 		return html`
 			<d2l-insights-table
-				title="${this.localize('activeCoursesTable:title')}"
+				title="${this.localize(titleKey)}"
 				@d2l-insights-table-sort="${this._handleColumnSort}"
 				sort-column="0"
 				.columnInfo=${this.columnInfo}

--- a/components/user-drill-view.js
+++ b/components/user-drill-view.js
@@ -29,7 +29,8 @@ class UserDrill extends SkeletonMixin(Localizer(MobxLitElement)) {
 			user: { type: Object, attribute: false },
 			isDemo: { type: Boolean, attribute: 'demo' },
 			isStudentSuccessSys: { type: Boolean, attribute: false },
-			orgUnitId: { type: Object, attribute: 'org-unit-id' }
+			orgUnitId: { type: Number, attribute: 'org-unit-id' },
+			viewState: { type: Object, attribute: false }
 		};
 	}
 
@@ -37,6 +38,16 @@ class UserDrill extends SkeletonMixin(Localizer(MobxLitElement)) {
 		super();
 		this.hasToken = false;
 		this._token = undefined;
+		this.data = null;
+		this.user = {
+			userId: null,
+			username: null,
+			firstName: null,
+			lastName: null
+		};
+		this.isStudentSuccessSys = false;
+		this.orgUnitId = 0;
+		this.viewState = null;
 	}
 
 	static get styles() {
@@ -194,14 +205,27 @@ class UserDrill extends SkeletonMixin(Localizer(MobxLitElement)) {
 	}
 
 	render() {
+		if (!this.skeleton && !this.user.userId) {
+			return html`
+				<d2l-insights-message-container
+					type="button"
+					text="${this.localize('userDrill:noUser')}"
+					button-text="${this.localize('userDrill:return')}"
+					@d2l-insights-message-container-button-click=${this._loadHomeView}>
+				</d2l-insights-message-container>
+			`;
+		}
+
+		const displayName = this.user.userId ? `${this.user.firstName} ${this.user.lastName}` : '';
+		const userInfo = this.user.userId ? `${this.user.username} - ${this.user.userId}` : '';
 
 		return html`<div class="d2l-insights-user-drill-view-container">
 			<div class="d2l-insights-user-drill-view-header-panel">
 				<div class="d2l-insights-user-drill-view-profile">
 					${this.userProfile}
 					<div class="d2l-insights-user-drill-view-profile-name">
-						<div class="d2l-heading-2">${this.user.firstName} ${this.user.lastName}</div>
-						<div class="d2l-body-small">${this.user.username} - ${this.user.userId}</div>
+						<div class="d2l-heading-2 ${this.skeletonClass}">${displayName}</div>
+						<div class="d2l-body-small ${this.skeletonClass}">${userInfo}</div>
 					</div>
 				</div>
 
@@ -264,6 +288,13 @@ class UserDrill extends SkeletonMixin(Localizer(MobxLitElement)) {
 				?skeleton="${this.skeleton}">
 			</d2l-insights-user-drill-courses-table>
 		`;
+	}
+
+	_loadHomeView(e) {
+		this.viewState.setHomeView();
+		// prevent href navigation
+		e.preventDefault();
+		return false;
 	}
 }
 

--- a/components/user-drill-view.js
+++ b/components/user-drill-view.js
@@ -13,6 +13,7 @@ import { ExportData } from '../model/exportData';
 import { Localizer } from '../locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RECORD } from '../consts';
+import { resetUrlState } from '../model/urlState';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin';
 import { until } from 'lit-html/directives/until';
 
@@ -211,7 +212,7 @@ class UserDrill extends SkeletonMixin(Localizer(MobxLitElement)) {
 					type="button"
 					text="${this.localize('userDrill:noUser')}"
 					button-text="${this.localize('userDrill:return')}"
-					@d2l-insights-message-container-button-click=${this._loadHomeView}>
+					@d2l-insights-message-container-button-click=${this._loadDefaultView}>
 				</d2l-insights-message-container>
 			`;
 		}
@@ -290,8 +291,10 @@ class UserDrill extends SkeletonMixin(Localizer(MobxLitElement)) {
 		`;
 	}
 
-	_loadHomeView(e) {
-		this.viewState.setHomeView();
+	_loadDefaultView(e) {
+		// DE41776: likely this is an error state with no good exit options. Force a hard refresh of the default view.
+		resetUrlState();
+
 		// prevent href navigation
 		e.preventDefault();
 		return false;

--- a/components/user-drill-view.js
+++ b/components/user-drill-view.js
@@ -211,7 +211,7 @@ class UserDrill extends SkeletonMixin(Localizer(MobxLitElement)) {
 				<d2l-insights-message-container
 					type="button"
 					text="${this.localize('userDrill:noUser')}"
-					button-text="${this.localize('userDrill:return')}"
+					button-text="${this.localize('dashboard:title')}"
 					@d2l-insights-message-container-button-click=${this._loadDefaultView}>
 				</d2l-insights-message-container>
 			`;

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -236,16 +236,14 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 			const userId = this._viewState.userViewUserId;
 			const userData = this._serverData.userDictionary.get(userId);
 
-			if (!userData) {
-				return;
+			if (userData) {
+				user = {
+					firstName: userData[USER.FIRST_NAME],
+					lastName: userData[USER.LAST_NAME],
+					username: userData[USER.USERNAME],
+					userId: userId
+				};
 			}
-
-			user = {
-				firstName: userData[USER.FIRST_NAME],
-				lastName: userData[USER.LAST_NAME],
-				username: userData[USER.USERNAME],
-				userId: userId
-			};
 		}
 
 		return html`
@@ -256,6 +254,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				.user="${user}"
 				.isStudentSuccessSys="${this._serverData.serverData.isStudentSuccessSys}"
 				org-unit-id="${this.orgUnitId}"
+				.viewState="${this._viewState}"
 				@d2l-insights-user-drill-view-back="${this._backToHomeHandler}"
 			>
 				<div slot="filters">

--- a/locales/en.js
+++ b/locales/en.js
@@ -180,6 +180,8 @@ export default {
 	"settings:avgDiscussionActivityDescription": "The Average Discussion Participation indicator presents user statistics for how often the user creates a thread, reads a post or replies to a post across all the courses included in the applied filters.  This metric averages the total count per course.",
 	"settings:lastAccessedSystemDescription": "The System Last Access indicator displays the timestamp, in Brightspace local time, of the last time the user accessed the system in any way.",
 
+	"userDrill:noUser": "The user could not be loaded. Please return to the engagement dashboard to continue.",
+	"userDrill:return": "Return",
 	"userDrill:noData": "No data in filtered ranges. Refine your selection.",
 
 	"activeCoursesTable:title": "Active Courses",

--- a/locales/en.js
+++ b/locales/en.js
@@ -180,6 +180,8 @@ export default {
 	"settings:avgDiscussionActivityDescription": "The Average Discussion Participation indicator presents user statistics for how often the user creates a thread, reads a post or replies to a post across all the courses included in the applied filters.  This metric averages the total count per course.",
 	"settings:lastAccessedSystemDescription": "The System Last Access indicator displays the timestamp, in Brightspace local time, of the last time the user accessed the system in any way.",
 
+	"userDrill:noData": "No data in filtered ranges. Refine your selection.",
+
 	"activeCoursesTable:title": "Active Courses",
 	"activeCoursesTable:loadingPlaceholder": "Loading",
 	"activeCoursesTable:course": "Course Name",
@@ -190,7 +192,9 @@ export default {
 	"activeCoursesTable:discussions": "Discussion Activity",
 	"activeCoursesTable:courseLastAccess": "Course Last Access",
 	"activeCoursesTable:noGrade": "No grade",
+	"activeCoursesTable:noPredictedGrade": "No predicted grade",
 	"activeCoursesTable:isActive": "Is Active Course",
+	"activeCoursesTable:empty": "No active course data in filtered ranges.",
 
 	"inactiveCoursesTable:title": "Inactive Courses",
 	"inactiveCoursesTable:course": "Course Name",
@@ -199,6 +203,5 @@ export default {
 	"inactiveCoursesTable:discussions": "Discussion Activity",
 	"inactiveCoursesTable:lastAccessedCourse": "Course Last Access",
 	"inactiveCoursesTable:loadingPlaceholder": "Loading",
-
-	"activeCoursesTable:noPredictedGrade": "No predicted grade",
+	"inactiveCoursesTable:empty": "No inactive course data in filtered ranges.",
 };

--- a/locales/en.js
+++ b/locales/en.js
@@ -180,8 +180,7 @@ export default {
 	"settings:avgDiscussionActivityDescription": "The Average Discussion Participation indicator presents user statistics for how often the user creates a thread, reads a post or replies to a post across all the courses included in the applied filters.  This metric averages the total count per course.",
 	"settings:lastAccessedSystemDescription": "The System Last Access indicator displays the timestamp, in Brightspace local time, of the last time the user accessed the system in any way.",
 
-	"userDrill:noUser": "The user could not be loaded. Please return to the engagement dashboard to continue.",
-	"userDrill:return": "Return",
+	"userDrill:noUser": "This user could not be loaded. Go to the Engagement Dashboard to view the list of users.",
 	"userDrill:noData": "No data in filtered ranges. Refine your selection.",
 
 	"activeCoursesTable:title": "Active Courses",

--- a/test/components/user-drill-courses-table.test.js
+++ b/test/components/user-drill-courses-table.test.js
@@ -36,6 +36,17 @@ const data = {
 	}
 };
 
+const emptyData = {
+	records: [ // only records for the wrong user
+		[199, 2, ROLE_ID, 0, 90, 6000, 1607979698265, 1, 2, 3],
+		[99, 2, ROLE_ID, 0, 90, 6000, 1607979698265, 5, 6, 7]
+	],
+	orgUnitTree: {
+		isActive: (orgUnitId) => orgUnitId >= 100,
+		getName: (orgUnitId) => `Course ${orgUnitId}`
+	}
+};
+
 const user = { userId: 1 };
 
 const expected = {
@@ -128,6 +139,20 @@ describe('d2l-insights-user-drill-courses-table', () => {
 					'Course Last Access'
 				]);
 			});
+
+			it('should display no data error message if there was no data', async() => {
+				const el = await fixture(html`
+					<d2l-insights-user-drill-courses-table
+						.data="${emptyData}"
+						.user="${user}"
+						.isActiveTable="${Boolean(true)}"
+						.isStudentSuccessSys="${Boolean(false)}">
+					</d2l-insights-user-drill-courses-table>
+				`);
+
+				const errorMessage = el.shadowRoot.querySelector('d2l-insights-message-container');
+				expect(errorMessage.text).to.equal('No active course data in filtered ranges.');
+			});
 		});
 
 		describe('sorting', () => {
@@ -198,6 +223,19 @@ describe('d2l-insights-user-drill-courses-table', () => {
 					'Discussion Activity',
 					'Course Last Access'
 				]);
+			});
+
+			it('should display no data error message if there was no data', async() => {
+				const el = await fixture(html`
+					<d2l-insights-user-drill-courses-table
+						.data="${emptyData}"
+						.user="${user}"
+						.isActiveTable="${Boolean(false)}">
+					</d2l-insights-user-drill-courses-table>
+				`);
+
+				const errorMessage = el.shadowRoot.querySelector('d2l-insights-message-container');
+				expect(errorMessage.text).to.equal('No inactive course data in filtered ranges.');
 			});
 		});
 

--- a/test/components/user-drill-view.test.js
+++ b/test/components/user-drill-view.test.js
@@ -22,9 +22,13 @@ describe('d2l-insights-user-drill-view', () => {
 					[1, 'Course 1', mockOuTypes.course, [1001], false],
 					[2, 'Course 2', mockOuTypes.course, [1001], false],
 					[3, 'Course 3', mockOuTypes.course, [1002], true]
-				]
+				],
 			}
 		},
+		records: [
+			[3, 232], // the rest of the records object isn't necessary (for now)
+			[2, 232]
+		]
 	};
 
 	data.recordsByUser = new Map();
@@ -85,7 +89,7 @@ describe('d2l-insights-user-drill-view', () => {
 
 		it('should render the users profile', async() => {
 			const el = await fixture(html`<d2l-insights-user-drill-view
-				.user=${user}
+				.user=${user} .data=${data}
 			></d2l-insights-user-drill-view>`);
 			const profile = el.shadowRoot.querySelector('d2l-profile-image');
 			await new Promise(res => setTimeout(res, 10));
@@ -94,6 +98,27 @@ describe('d2l-insights-user-drill-view', () => {
 			const results = ['First', 'Last'];
 
 			expect(names).to.eql(results);
+		});
+
+		it('should render no user error message if there is no user', async() => {
+			const el = await fixture(html`<d2l-insights-user-drill-view .data=${data}></d2l-insights-user-drill-view>`);
+			await new Promise(res => setTimeout(res, 10));
+
+			const errorMessage = el.shadowRoot.querySelector('d2l-insights-message-container');
+			expect(errorMessage.type).to.equal('button');
+			expect(errorMessage.text).to.equal('The user could not be loaded. Please return to the engagement dashboard to continue.');
+		});
+
+		it('should render no data error message if user exists but has no data', async() => {
+			const dataNoRecords = { ...data };
+			dataNoRecords.records = [];
+
+			const el = await fixture(html`<d2l-insights-user-drill-view .user="${user}" .data=${dataNoRecords}></d2l-insights-user-drill-view>`);
+			await new Promise(res => setTimeout(res, 10));
+
+			const errorMessage = el.shadowRoot.querySelector('d2l-insights-message-container');
+			expect(errorMessage.type).to.equal('default');
+			expect(errorMessage.text).to.equal('No data in filtered ranges. Refine your selection.');
 		});
 	});
 });

--- a/test/components/user-drill-view.test.js
+++ b/test/components/user-drill-view.test.js
@@ -106,7 +106,7 @@ describe('d2l-insights-user-drill-view', () => {
 
 			const errorMessage = el.shadowRoot.querySelector('d2l-insights-message-container');
 			expect(errorMessage.type).to.equal('button');
-			expect(errorMessage.text).to.equal('The user could not be loaded. Please return to the engagement dashboard to continue.');
+			expect(errorMessage.text).to.equal('This user could not be loaded. Go to the Engagement Dashboard to view the list of users.');
 		});
 
 		it('should render no data error message if user exists but has no data', async() => {


### PR DESCRIPTION
Shows error messages for various possible states.

## Quality notes
* Testing (in progress)
  * [x] Unit tests for new code 
  * [x] Browsers (Chrome, FF, Edgium, Edgacy)
  * [x] Responsive
  * [x] Accessibility
  * [x] Test cases
    * (Regression) It shows skeletons when loading
    * (Regression) Both tables show data if there is data to show
    * When user was not loaded due to invalid user id, displays "return to engagement dashboard" message
    * When user was not loaded due to lack of permissions, displays "return to engagement dashboard" message
    * When user was not loaded due to reload after specific user + filter combo, displays "return to engagement dashboard" message
    * Return to engagement dashboard button ~~returns to home view~~ hard resets to default view
    * When filters were applied such that no courses are in view, it hides both tables and displays "No data" message
    * When filters were applied such that no active courses are in view, it displays "no active courses" message; inactive still displays data
    * When filters were applied such that no inactive courses are in view, it displays "no inactive courses" message; active still displays data
* Security, docs, perf, devops: N/A
* UX:
  * [ ] Demo to Kevin and/or Megan

## Screenshots
![image](https://user-images.githubusercontent.com/11587338/102517631-485ba080-405e-11eb-9e62-ae66ce42f0d5.png)
![image](https://user-images.githubusercontent.com/11587338/102517737-688b5f80-405e-11eb-954c-9df9a839fb3e.png)
![image](https://user-images.githubusercontent.com/11587338/102517781-750fb800-405e-11eb-8ac6-f068cd03dcd2.png)
![image](https://user-images.githubusercontent.com/11587338/102517809-7f31b680-405e-11eb-8736-3cfb5b42b0f2.png)



FYI @johngwilkinson @Vitalii-Misechko @MykolaGalian @anhill-D2L 