### PR TITLE
US123012: off-by-one error when sorting user-drill courses table

### DIFF
--- a/components/user-drill-courses-table.js
+++ b/components/user-drill-courses-table.js
@@ -10,21 +10,13 @@ import { MobxLitElement } from '@adobe/lit-mobx';
 import { RECORD } from '../consts';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin';
 
-export const ACTIVE_TABLE_COLUMNS = {
+const TABLE_COLUMNS = {
 	COURSE_NAME: 0,
 	CURRENT_GRADE: 1,
 	PREDICTED_GRADE: 2,
 	TIME_IN_CONTENT: 3,
 	DISCUSSION_ACTIVITY: 4,
 	COURSE_LAST_ACCESS: 5
-};
-
-export const INACTIVE_TABLE_COLUMNS = {
-	COURSE_NAME: 0,
-	CURRENT_GRADE: 1,
-	TIME_IN_CONTENT: 2,
-	DISCUSSION_ACTIVITY: 3,
-	COURSE_LAST_ACCESS: 4
 };
 
 const numberFormatOptions = { maximumFractionDigits: 2 };
@@ -70,7 +62,7 @@ class UserDrillCoursesTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 	constructor() {
 		super();
 		this._sortOrder = 'desc';
-		this._sortColumn = ACTIVE_TABLE_COLUMNS.COURSE_NAME;
+		this._sortColumn = TABLE_COLUMNS.COURSE_NAME;
 		this._currentPage = 1;
 		this._pageSize = DEFAULT_PAGE_SIZE;
 	}
@@ -97,10 +89,10 @@ class UserDrillCoursesTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 		if (this._itemsCount) {
 			const start = this._pageSize * (this._currentPage - 1);
 			const end = this._pageSize * (this._currentPage); // it's ok if this goes over the end of the array
-			const numCols = this.isActiveTable && this.isStudentSuccessSys ? Array.from(Array(6), (_, x) => x) : Array.from(Array(5), (_, x) => x);
+			const visibleColumns = this._visibleColumns;
 			return this.userDataForDisplay
 				.slice(start, end)
-				.map(user => numCols.map(column => user[column]));
+				.map(course => visibleColumns.map(column => course[column]));
 		}
 
 		return [];
@@ -108,7 +100,8 @@ class UserDrillCoursesTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 
 	_handleColumnSort(e) {
 		this._sortOrder = e.detail.order;
-		this._sortColumn = e.detail.column;
+		// convert from index in visible columns to general column index matching TABLE_USER
+		this._sortColumn = this._visibleColumns[e.detail.column];
 		this._currentPage = 1;
 	}
 
@@ -128,24 +121,14 @@ class UserDrillCoursesTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 		const replies = record[RECORD.DISCUSSION_ACTIVITY_REPLIES];
 		const lastCourseAccess = record[RECORD.COURSE_LAST_ACCESS] ? new Date(record[RECORD.COURSE_LAST_ACCESS]) : undefined;
 
-		if (this.isActiveTable) {
-			return [
-				this.localize('treeFilter:nodeName', { orgUnitName, id: orgUnitId }),
-				finalGrade,
-				predictedGrade,
-				timeInContent,
-				[threads, reads, replies],
-				lastCourseAccess
-			];
-		} else {
-			return [
-				this.localize('treeFilter:nodeName', { orgUnitName, id: orgUnitId }),
-				finalGrade,
-				timeInContent,
-				[threads, reads, replies],
-				lastCourseAccess
-			];
-		}
+		return [
+			this.localize('treeFilter:nodeName', { orgUnitName, id: orgUnitId }),
+			finalGrade,
+			predictedGrade,
+			timeInContent,
+			[threads, reads, replies],
+			lastCourseAccess
+		];
 	}
 
 	_choseSortFunction(column, order) {
@@ -153,11 +136,11 @@ class UserDrillCoursesTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 			'asc': [-1, 1, 0],
 			'desc': [1, -1, 0]
 		};
-		if (column === ACTIVE_TABLE_COLUMNS.COURSE_NAME) {
+		if (column === TABLE_COLUMNS.COURSE_NAME) {
 			// NB: "desc" and "asc" are inverted for course info: desc sorts a-z whereas asc sorts z-a
 			return (course1, course2) => {
-				const courseId1 = course1[ACTIVE_TABLE_COLUMNS.COURSE_NAME].toLowerCase();
-				const courseId2 = course2[ACTIVE_TABLE_COLUMNS.COURSE_NAME].toLowerCase();
+				const courseId1 = course1[TABLE_COLUMNS.COURSE_NAME].toLowerCase();
+				const courseId2 = course2[TABLE_COLUMNS.COURSE_NAME].toLowerCase();
 				return (courseId1 > courseId2 ? ORDER[order][0] :
 					courseId1 < courseId2 ? ORDER[order][1] :
 						ORDER[order][2]);
@@ -175,30 +158,17 @@ class UserDrillCoursesTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 	}
 
 	_formatDataForDisplay(course) {
-		const courseLastAccessFormattedIndex = this.isActiveTable ? ACTIVE_TABLE_COLUMNS.COURSE_LAST_ACCESS : INACTIVE_TABLE_COLUMNS.COURSE_LAST_ACCESS;
-		const courseLastAccessFormatted = course[courseLastAccessFormattedIndex]
-			? formatDateTime(new Date(course[courseLastAccessFormattedIndex]), { format: 'medium' })
+		const courseLastAccessFormatted = course[TABLE_COLUMNS.COURSE_LAST_ACCESS]
+			? formatDateTime(new Date(course[TABLE_COLUMNS.COURSE_LAST_ACCESS]), { format: 'medium' })
 			: this.localize('usersTable:null');
-		if (this.isActiveTable) {
-			const formattedColumns = [
-				course[ACTIVE_TABLE_COLUMNS.COURSE_NAME],
-				course[ACTIVE_TABLE_COLUMNS.CURRENT_GRADE] ? formatPercent(course[ACTIVE_TABLE_COLUMNS.CURRENT_GRADE] / 100, numberFormatOptions) : this.localize('activeCoursesTable:noGrade'),
-				course[ACTIVE_TABLE_COLUMNS.PREDICTED_GRADE] ? formatPercent(course[ACTIVE_TABLE_COLUMNS.PREDICTED_GRADE], numberFormatOptions) : this.localize('activeCoursesTable:noPredictedGrade'),
-				formatNumber(course[ACTIVE_TABLE_COLUMNS.TIME_IN_CONTENT] / 60, numberFormatOptions),
-				course[ACTIVE_TABLE_COLUMNS.DISCUSSION_ACTIVITY],
-				courseLastAccessFormatted
-			];
-			if (!this.isStudentSuccessSys) formattedColumns.splice(ACTIVE_TABLE_COLUMNS.PREDICTED_GRADE, 1);
-			return formattedColumns;
-		} else {
-			return [
-				course[INACTIVE_TABLE_COLUMNS.COURSE_NAME],
-				course[INACTIVE_TABLE_COLUMNS.CURRENT_GRADE] ? formatPercent(course[INACTIVE_TABLE_COLUMNS.CURRENT_GRADE] / 100, numberFormatOptions) : this.localize('activeCoursesTable:noGrade'),
-				formatNumber(course[INACTIVE_TABLE_COLUMNS.TIME_IN_CONTENT] / 60, numberFormatOptions),
-				course[INACTIVE_TABLE_COLUMNS.DISCUSSION_ACTIVITY],
-				courseLastAccessFormatted
-			];
-		}
+		return [
+			course[TABLE_COLUMNS.COURSE_NAME],
+			course[TABLE_COLUMNS.CURRENT_GRADE] ? formatPercent(course[TABLE_COLUMNS.CURRENT_GRADE] / 100, numberFormatOptions) : this.localize('activeCoursesTable:noGrade'),
+			course[TABLE_COLUMNS.PREDICTED_GRADE] ? formatPercent(course[TABLE_COLUMNS.PREDICTED_GRADE], numberFormatOptions) : this.localize('activeCoursesTable:noPredictedGrade'),
+			formatNumber(course[TABLE_COLUMNS.TIME_IN_CONTENT] / 60, numberFormatOptions),
+			course[TABLE_COLUMNS.DISCUSSION_ACTIVITY],
+			courseLastAccessFormatted
+		];
 	}
 
 	// @computed
@@ -212,6 +182,14 @@ class UserDrillCoursesTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 			.map(this._preProcessData, this)
 			.sort(sortFunction)
 			.map(this._formatDataForDisplay, this);
+	}
+
+	get _visibleColumns() {
+		const columns = Object.values(TABLE_COLUMNS);
+
+		if (!this.isActiveTable || !this.isStudentSuccessSys) columns.splice(TABLE_COLUMNS.PREDICTED_GRADE, 1);
+
+		return columns;
 	}
 
 	get columnInfo() {
@@ -242,7 +220,7 @@ class UserDrillCoursesTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 					columnType: COLUMN_TYPES.NORMAL_TEXT
 				}
 			];
-			if (!this.isStudentSuccessSys) columnInfo.splice(ACTIVE_TABLE_COLUMNS.PREDICTED_GRADE, 1);
+			if (!this.isStudentSuccessSys) columnInfo.splice(TABLE_COLUMNS.PREDICTED_GRADE, 1);
 			return columnInfo;
 		} else {
 			return [
@@ -271,7 +249,7 @@ class UserDrillCoursesTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 	}
 
 	get headersForExport() {
-		return [
+		const columns = [
 			this.localize('activeCoursesTable:course'),
 			this.localize('activeCoursesTable:grade'),
 			this.localize('activeCoursesTable:predictedGrade'),
@@ -282,17 +260,18 @@ class UserDrillCoursesTable extends SkeletonMixin(Localizer(MobxLitElement)) {
 			this.localize('activeCoursesTable:courseLastAccess'),
 			this.localize('activeCoursesTable:isActive')
 		];
+
+		if (!this.isStudentSuccessSys) columns.splice(TABLE_COLUMNS.PREDICTED_GRADE, 1);
+
+		return columns;
 	}
 
 	get dataForExport() {
 		return this.userDataForDisplay
-			.map(user => {
-				if (!this.isActiveTable || (this.isActiveTable && !this.isStudentSuccessSys)) {
-					user.splice(2, 0, this.localize('activeCoursesTable:noPredictedGrade'));
-					return user;
-				} else return user;
-			})
-			.map(course => [...course.flat(), this.isActiveTable]);
+			.map(course => {
+				if (!this.isStudentSuccessSys) course.splice(TABLE_COLUMNS.PREDICTED_GRADE, 1);
+				return [...course.flat(), this.isActiveTable];
+			});
 	}
 
 	_handlePageChange(event) {

--- a/components/user-drill-view.js
+++ b/components/user-drill-view.js
@@ -239,6 +239,7 @@ class UserDrill extends SkeletonMixin(Localizer(MobxLitElement)) {
 					.data="${this.data}"
 					.user="${this.user}"
 					.isActiveTable=${Boolean(false)}
+					.isStudentSuccessSys="${this.isStudentSuccessSys}"
 					?skeleton="${this.skeleton}"
 				></d2l-insights-user-drill-courses-table>
 			</div>

--- a/test/components/user-drill-courses-table.test.js
+++ b/test/components/user-drill-courses-table.test.js
@@ -359,7 +359,8 @@ describe('d2l-insights-user-drill-courses-table', () => {
 				await new Promise(resolve => setTimeout(resolve, 200));
 				await el.updateComplete;
 				expect(el.dataForExport[0]).to.deep.equal(
-					[ 'Course 101 (Id: 101)', '80 %', 'No predicted grade', '110', 3, 3, 3, getLocalDateTime(1607979700000), true]);
+					[ 'Course 101 (Id: 101)', '80 %', '110', 3, 3, 3, getLocalDateTime(1607979700000), true]);
+				expect(el.headersForExport).to.deep.equal(['Course Name', 'Grade', 'Time in Content (mins)', 'Threads', 'Reads', 'Replies', 'Course Last Access', 'Is Active Course']);
 			});
 		});
 	});

--- a/test/components/user-drill-courses-table.test.js
+++ b/test/components/user-drill-courses-table.test.js
@@ -231,11 +231,11 @@ describe('d2l-insights-user-drill-courses-table', () => {
 			`;
 
 			const testCases = [
-				['Course name', undefined, 0],
-				['Final Grade', numsWithTextSort, 1],
-				['Total Time in Content (mins)', numsWithTextSort, 3],
-				['Discussion Activity', undefined, 4],
-				['Course Last Access', datesWithTextSort, 5]
+				['Course name', undefined],
+				['Final Grade', numsWithTextSort],
+				['Total Time in Content (mins)', numsWithTextSort],
+				['Discussion Activity', undefined],
+				['Course Last Access', datesWithTextSort]
 			];
 			testCases.forEach(([colName, sortFunction], colIdx) => {
 				verifySorting(true, tableHtml, expected.inactive, sortFunction, colIdx, colName);

--- a/test/components/user-drill-courses-table.test.js
+++ b/test/components/user-drill-courses-table.test.js
@@ -139,17 +139,28 @@ describe('d2l-insights-user-drill-courses-table', () => {
 					.isStudentSuccessSys="${Boolean(true)}">
 				</d2l-insights-user-drill-courses-table>
 			`;
+			const noS3TableHtml = html`
+				<d2l-insights-user-drill-courses-table
+					.data="${data}"
+					.user="${user}"
+					.isActiveTable="${Boolean(true)}"
+					.isStudentSuccessSys="${Boolean(false)}">
+				</d2l-insights-user-drill-courses-table>
+			`;
 
 			const testCases = [
-				['Course name', undefined],
-				['Current Grade', numsWithTextSort],
-				['Predicted Grade', numsWithTextSort],
-				['Time in Content (mins)', numsWithTextSort],
-				['Discussion Activity', undefined],
-				['Course Last Access', datesWithTextSort]
+				['Course name', undefined, 0],
+				['Current Grade', numsWithTextSort, 1],
+				['Predicted Grade', numsWithTextSort, null],
+				['Time in Content (mins)', numsWithTextSort, 2],
+				['Discussion Activity', undefined, 3],
+				['Course Last Access', datesWithTextSort, 4]
 			];
-			testCases.forEach(([colName, sortFunction], colIdx) => {
-				verifySorting(tableHtml, expected.active, sortFunction, colIdx, colName);
+			testCases.forEach(([colName, sortFunction, noS3Index], colIdx) => {
+				verifySorting(true, tableHtml, expected.active, sortFunction, colIdx, colName);
+				if (noS3Index) {
+					verifySorting(false, noS3TableHtml, expected.active, sortFunction, colIdx, colName, noS3Index);
+				}
 			});
 		});
 	});
@@ -207,18 +218,28 @@ describe('d2l-insights-user-drill-courses-table', () => {
 					.data="${data}"
 					.user="${user}"
 					.isActiveTable="${Boolean(false)}">
+					.isStudentSuccessSys="${Boolean(true)}">
+				</d2l-insights-user-drill-courses-table>
+			`;
+			const noS3TableHtml = html`
+				<d2l-insights-user-drill-courses-table
+					.data="${data}"
+					.user="${user}"
+					.isActiveTable="${Boolean(false)}">
+					.isStudentSuccessSys="${Boolean(false)}">
 				</d2l-insights-user-drill-courses-table>
 			`;
 
 			const testCases = [
-				['Course name', undefined],
-				['Final Grade', numsWithTextSort],
-				['Total Time in Content (mins)', numsWithTextSort],
-				['Discussion Activity', undefined],
-				['Course Last Access', datesWithTextSort]
+				['Course name', undefined, 0],
+				['Final Grade', numsWithTextSort, 1],
+				['Total Time in Content (mins)', numsWithTextSort, 3],
+				['Discussion Activity', undefined, 4],
+				['Course Last Access', datesWithTextSort, 5]
 			];
 			testCases.forEach(([colName, sortFunction], colIdx) => {
-				verifySorting(tableHtml, expected.inactive, sortFunction, colIdx, colName);
+				verifySorting(true, tableHtml, expected.inactive, sortFunction, colIdx, colName);
+				verifySorting(false, noS3TableHtml, expected.inactive, sortFunction, colIdx, colName);
 			});
 		});
 
@@ -384,23 +405,23 @@ async function getInnerTable(el) {
 	return innerTable;
 }
 
-function verifySorting(tableHtml, expectedRecords, sortFunction, colIdx, colName) {
-	it(`should sort by the ${colName} column`, async() => {
+function verifySorting(hasS3, tableHtml, expectedRecords, sortFunction, colIdx, colName, displayIndex = colIdx) {
+	it(`should sort by the ${colName} column with${hasS3 ? '' : 'out'} s3`, async() => {
 		const [, innerTable, headers] = await setupTable(tableHtml);
 
 		const expectedDesc = [...expectedRecords.map(record => record[colIdx])].sort(sortFunction).reverse();
 
 		// first click to sort by descending order
-		headers.item(colIdx).click();
+		headers.item(displayIndex).click();
 		await innerTable.updateComplete;
-		expect(innerTable.data.map(record => record[colIdx])).to.deep.equal(expectedDesc);
+		expect(innerTable.data.map(record => record[displayIndex])).to.deep.equal(expectedDesc);
 
 		const expectedAsc = [...expectedRecords.map(record => record[colIdx])].sort(sortFunction);
 
 		// then click again to sort by ascending order
-		headers.item(colIdx).click();
+		headers.item(displayIndex).click();
 		await innerTable.updateComplete;
-		expect(innerTable.data.map(record => record[colIdx])).to.deep.equal(expectedAsc);
+		expect(innerTable.data.map(record => record[displayIndex])).to.deep.equal(expectedAsc);
 	});
 }
 


### PR DESCRIPTION

Quality Notes
Before: on an org with no predicted grades, sorting on time-in-content did nothing because it was looking at current grade (one column over) instead (which happened to be null in my test data).
After: sorting works on all columns
Before: export always included predicted grade (even if not enabled)
After: export doesn't include predicted grade if not enabled (PM said either was fine, but this was equally easy along with the other changes)
Still testing:
- [x] render and sort of inactive courses
- [x] render, sort, and export when predicted grades are enabled

FYI @anhill-D2L @MykolaGalian @rohitvinnakota @Vitalii-Misechko 