### PR TITLE
Update the major facet-filter-sort version

### DIFF
--- a/components/applied-filters.js
+++ b/components/applied-filters.js
@@ -1,8 +1,8 @@
 import './summary-card.js';
-import 'd2l-facet-filter-sort/components/d2l-applied-filters/d2l-applied-filters';
-import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown.js';
-import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js';
-import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown-option.js';
+import '@brightspace-ui-labs/facet-filter-sort/components/applied-filters/applied-filters';
+import '@brightspace-ui-labs/facet-filter-sort/components/filter-dropdown/filter-dropdown.js';
+import '@brightspace-ui-labs/facet-filter-sort/components/filter-dropdown/filter-dropdown-category.js';
+import '@brightspace-ui-labs/facet-filter-sort/components/filter-dropdown/filter-dropdown-option.js';
 
 import { html } from 'lit-element';
 import { Localizer } from '../locales/localizer';
@@ -54,27 +54,27 @@ class AppliedFilters extends SkeletonMixin(Localizer(MobxLitElement)) {
 		// clear all button appears if 4 or more filters are applied
 		return html`
 			<div style="display: none;">
-				<d2l-filter-dropdown id="d2l-insights-applied-filters-dropdown" total-selected-option-count="${filters.length}">
-					<d2l-filter-dropdown-category
+				<d2l-labs-filter-dropdown id="d2l-insights-applied-filters-dropdown" total-selected-option-count="${filters.length}">
+					<d2l-labs-filter-dropdown-category
 						disable-search
-						@d2l-filter-dropdown-option-change="${this._filterChangeHandler}"
+						@d2l-labs-filter-dropdown-option-change="${this._filterChangeHandler}"
 					>
-						${repeat(filters, (f) => `${f.id}:${f.isApplied}`, (item) => html`<d2l-filter-dropdown-option
+						${repeat(filters, (f) => `${f.id}:${f.isApplied}`, (item) => html`<d2l-labs-filter-dropdown-option
 								text="${item.title}"
 								value="${item.id}"
 								?selected="${item.isApplied}"
-							></d2l-filter-dropdown-option>`)}
+							></d2l-labs-filter-dropdown-option>`)}
 
-					</d2l-filter-dropdown-category>
-				</d2l-filter-dropdown>
+					</d2l-labs-filter-dropdown-category>
+				</d2l-labs-filter-dropdown>
 			</div>
 
 			${!this.skeleton
 				? html`
-					<d2l-applied-filters
+					<d2l-labs-applied-filters
 						for="d2l-insights-applied-filters-dropdown"
 						label-text="${this.localize('appliedFilters:labelText')}">
-					</d2l-applied-filters>`
+					</d2l-labs-applied-filters>`
 				: html``
 			}
 		`;

--- a/components/dropdown-filter.js
+++ b/components/dropdown-filter.js
@@ -1,6 +1,6 @@
-import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown.js';
-import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js';
-import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown-option.js';
+import '@brightspace-ui-labs/facet-filter-sort/components/filter-dropdown/filter-dropdown.js';
+import '@brightspace-ui-labs/facet-filter-sort/components/filter-dropdown/filter-dropdown-category.js';
+import '@brightspace-ui-labs/facet-filter-sort/components/filter-dropdown/filter-dropdown-option.js';
 
 import { css, html, LitElement } from 'lit-element';
 import { Localizer } from '../locales/localizer';
@@ -39,7 +39,7 @@ class DropdownFilter extends Localizer(LitElement) {
 				margin: 0.25rem;
 			}
 
-			d2l-filter-dropdown-category[disable-search] {
+			d2l-labs-filter-dropdown-category[disable-search] {
 				padding-top: 0;
 			}
 		`];
@@ -83,30 +83,30 @@ class DropdownFilter extends Localizer(LitElement) {
 		}
 
 		return html`
-			<d2l-filter-dropdown
+			<d2l-labs-filter-dropdown
 				total-selected-option-count="${selectedCount}"
 				opener-text="${this.localize('dropdownFilter:openerTextAll', { filterName: this.name })}"
 				opener-text-single="${openerSelectedText}"
 				opener-text-multiple="${openerSelectedText}"
 				header-text=""
-				@d2l-filter-dropdown-cleared="${this._clearSelectionClick}"
+				@d2l-labs-filter-dropdown-cleared="${this._clearSelectionClick}"
 				@d2l-dropdown-close="${this._filterClose}"
 			>
-				<d2l-filter-dropdown-category
+				<d2l-labs-filter-dropdown-category
 					?disable-search="${this.disableSearch}"
 					category-text="${this.name}"
-					@d2l-filter-dropdown-option-change="${this._handleElementSelected}"
-					@d2l-filter-dropdown-category-searched="${this._handleSearchedClick}"
+					@d2l-labs-filter-dropdown-option-change="${this._handleElementSelected}"
+					@d2l-labs-filter-dropdown-category-searched="${this._handleSearchedClick}"
 				>
-					${this.data.map(item => html`<d2l-filter-dropdown-option
+					${this.data.map(item => html`<d2l-labs-filter-dropdown-option
  						text="${item.displayName}"
  						value="${item.id}"
  						?selected="${item.selected}"
  						?hidden="${!!this.filter && !item.displayName.toLowerCase().includes(this.filter.toLowerCase())}"
- 					></d2l-filter-dropdown-option>`)}
+ 					></d2l-labs-filter-dropdown-option>`)}
 
-				</d2l-filter-dropdown-category>
-			</d2l-filter-dropdown>
+				</d2l-labs-filter-dropdown-category>
+			</d2l-labs-filter-dropdown>
 		`;
 	}
 

--- a/components/tree-selector.js
+++ b/components/tree-selector.js
@@ -36,11 +36,11 @@ class TreeSelector extends Localizer(LitElement) {
 					display: none;
 				}
 
-				.d2l-filter-dropdown-content-header {
+				.d2l-labs-filter-dropdown-content-header {
 					display: flex;
 					justify-content: space-between;
 				}
-				.d2l-filter-dropdown-content-header > span {
+				.d2l-labs-filter-dropdown-content-header > span {
 					align-self: center;
 				}
 
@@ -88,7 +88,7 @@ class TreeSelector extends Localizer(LitElement) {
 			<d2l-dropdown>
 				<d2l-dropdown-button-subtle text="${this.name}">
 					<d2l-dropdown-content align="start" no-auto-fit>
-						<div class="d2l-filter-dropdown-content-header" slot="header">
+						<div class="d2l-labs-filter-dropdown-content-header" slot="header">
 							<span>${this.localize('treeSelector:filterBy')}</span>
 							<d2l-button-subtle
 							 	text="${this.localize('treeSelector:clearLabel')}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-engagement-dashboard",
-  "version": "1.2101.0",
+  "version": "1.2102.0",
   "description": "D2L Insights Engagement Dashboard",
   "repository": "https://github.com/Brightspace/insights-engagement-dashboard.git",
   "private": true,
@@ -46,13 +46,13 @@
   },
   "dependencies": {
     "@adobe/lit-mobx": "0.0.x",
+    "@brightspace-ui-labs/facet-filter-sort": "^4",
     "@brightspace-ui-labs/pagination": "^1",
     "@brightspace-ui/core": "^1.102.8",
     "@brightspace-ui/intl": "^3.2.0",
     "@webcomponents/webcomponentsjs": "^2",
     "array-flat-polyfill": "^1.0.1",
     "d2l-button-group": "BrightspaceUI/button-group#semver:^3",
-    "d2l-facet-filter-sort": "BrightspaceUI/facet-filter-sort#semver:^3",
     "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",
     "d2l-fetch-auth": "^1",
     "d2l-navigation": "BrightspaceUI/navigation#semver:^4",

--- a/test/components/applied-filters.test.js
+++ b/test/components/applied-filters.test.js
@@ -29,7 +29,7 @@ describe('d2l-insights-applied-filters', () => {
 		it('should not render if there are no card filters', async function() {
 			this.timeout(3000);
 			const el = await fixture(html`<d2l-insights-applied-filters .data="${data}"></d2l-insights-applied-filters>`);
-			const appliedFilters = el.shadowRoot.querySelector('d2l-applied-filters');
+			const appliedFilters = el.shadowRoot.querySelector('d2l-labs-applied-filters');
 			expect(appliedFilters).to.be.null;
 		});
 
@@ -39,7 +39,7 @@ describe('d2l-insights-applied-filters', () => {
 				{ id: 'filter-key-1', title: 'filter 1', isApplied: false }
 			];
 			const el = await fixture(html`<d2l-insights-applied-filters .data="${data}"></d2l-insights-applied-filters>`);
-			const appliedFilters = el.shadowRoot.querySelector('d2l-applied-filters');
+			const appliedFilters = el.shadowRoot.querySelector('d2l-labs-applied-filters');
 			expect(appliedFilters).to.be.null;
 		});
 
@@ -49,7 +49,7 @@ describe('d2l-insights-applied-filters', () => {
 				{ id: 'filter-key-2', title: 'dashboard:title', isApplied: true }
 			];
 			const el = await fixture(html`<d2l-insights-applied-filters .data="${data}"></d2l-insights-applied-filters>`);
-			const appliedFilters = el.shadowRoot.querySelector('d2l-applied-filters');
+			const appliedFilters = el.shadowRoot.querySelector('d2l-labs-applied-filters');
 			expect(appliedFilters).to.exist;
 
 			const filters = appliedFilters.shadowRoot.querySelectorAll('d2l-labs-multi-select-list-item');
@@ -64,7 +64,7 @@ describe('d2l-insights-applied-filters', () => {
 				{ id: 'filter-key-2', title: 'filter 2', isApplied: false }
 			];
 			const el = await fixture(html`<d2l-insights-applied-filters .data="${data}"></d2l-insights-applied-filters>`);
-			const appliedFilters = el.shadowRoot.querySelector('d2l-applied-filters');
+			const appliedFilters = el.shadowRoot.querySelector('d2l-labs-applied-filters');
 			expect(appliedFilters).to.exist;
 
 			const filters = appliedFilters.shadowRoot.querySelectorAll('d2l-labs-multi-select-list-item');
@@ -78,7 +78,7 @@ describe('d2l-insights-applied-filters', () => {
 				{ id: 'filter-key-2', title: 'filter 2', isApplied: true }
 			];
 			const el = await fixture(html`<d2l-insights-applied-filters .data="${data}"></d2l-insights-applied-filters>`);
-			const appliedFilters = el.shadowRoot.querySelector('d2l-applied-filters');
+			const appliedFilters = el.shadowRoot.querySelector('d2l-labs-applied-filters');
 			expect(appliedFilters).to.exist;
 
 			const filters = appliedFilters.shadowRoot.querySelectorAll('d2l-labs-multi-select-list-item');

--- a/test/components/dropdown-filter.test.js
+++ b/test/components/dropdown-filter.test.js
@@ -39,7 +39,7 @@ describe('d2l-insights-dropdown-filter', () => {
 
 	describe('render', () => {
 		it('should render the dropdown opener with the correct name if none are selected', async() => {
-			const filter = el.shadowRoot.querySelector('d2l-filter-dropdown');
+			const filter = el.shadowRoot.querySelector('d2l-labs-filter-dropdown');
 			expect(filter.openerText).to.equal(`${name}: All`);
 			expect(filter.openerTextSingle).to.equal(`${name}: 0 selected`);
 			expect(filter.openerTextMultiple).to.equal(`${name}: 0 selected`);
@@ -53,7 +53,7 @@ describe('d2l-insights-dropdown-filter', () => {
 			await new Promise(resolve => setTimeout(resolve, 0)); // allow fetch to run
 			await el.updateComplete;
 
-			const filter = el.shadowRoot.querySelector('d2l-filter-dropdown');
+			const filter = el.shadowRoot.querySelector('d2l-labs-filter-dropdown');
 			expect(filter.openerText).to.equal(`${name}: All`);
 			expect(filter.openerTextSingle).to.equal(`${name}: ${data[0].name}`);
 			expect(filter.openerTextMultiple).to.equal(`${name}: ${data[0].name}`);
@@ -68,14 +68,14 @@ describe('d2l-insights-dropdown-filter', () => {
 			await new Promise(resolve => setTimeout(resolve, 0)); // allow fetch to run
 			await el.updateComplete;
 
-			const filter = el.shadowRoot.querySelector('d2l-filter-dropdown');
+			const filter = el.shadowRoot.querySelector('d2l-labs-filter-dropdown');
 			expect(filter.openerText).to.equal(`${name}: All`);
 			expect(filter.openerTextSingle).to.equal(`${name}: 2 selected`);
 			expect(filter.openerTextMultiple).to.equal(`${name}: 2 selected`);
 		});
 
 		it('should render with the correct checkbox elements', () => {
-			const checkboxList = Array.from(el.shadowRoot.querySelectorAll('d2l-filter-dropdown-option'));
+			const checkboxList = Array.from(el.shadowRoot.querySelectorAll('d2l-labs-filter-dropdown-option'));
 			expect(checkboxList.length).to.equal(2);
 			checkboxList.forEach((checkbox, idx) => {
 				expect(checkbox.value).to.equal(testData[idx].id);
@@ -85,7 +85,7 @@ describe('d2l-insights-dropdown-filter', () => {
 		});
 
 		it('should render search panel', () => {
-			const category = el.shadowRoot.querySelector('d2l-filter-dropdown-category');
+			const category = el.shadowRoot.querySelector('d2l-labs-filter-dropdown-category');
 			expect(category.disableSearch).to.be.false;
 		});
 
@@ -94,7 +94,7 @@ describe('d2l-insights-dropdown-filter', () => {
 			await new Promise(resolve => setTimeout(resolve, 0)); // allow fetch to run
 			await el.updateComplete;
 
-			const category = el.shadowRoot.querySelector('d2l-filter-dropdown-category');
+			const category = el.shadowRoot.querySelector('d2l-labs-filter-dropdown-category');
 			expect(category.disableSearch).to.be.true;
 		});
 
@@ -102,7 +102,7 @@ describe('d2l-insights-dropdown-filter', () => {
 			// everything should be deselected initially
 			expect(el.selected).to.deep.equal([]);
 
-			const checkboxes = Array.from(el.shadowRoot.querySelectorAll('d2l-filter-dropdown-option'));
+			const checkboxes = Array.from(el.shadowRoot.querySelectorAll('d2l-labs-filter-dropdown-option'));
 
 			checkboxes.find(checkbox => checkbox.value === '1').click();
 			checkboxes.find(checkbox => checkbox.value === '2').click();
@@ -116,19 +116,19 @@ describe('d2l-insights-dropdown-filter', () => {
 	});
 
 	describe('search', () => {
-		it('should filter the items when d2l-filter-dropdown-category-searched is handled', async() => {
+		it('should filter the items when d2l-labs-filter-dropdown-category-searched is handled', async() => {
 			const dropdownCategorySearchedEvent = { detail: { value: '2' } };
 
 			el._handleSearchedClick(dropdownCategorySearchedEvent);
 			await el.updateComplete;
 
-			const checkboxList = [...el.shadowRoot.querySelectorAll('d2l-filter-dropdown-option')];
+			const checkboxList = [...el.shadowRoot.querySelectorAll('d2l-labs-filter-dropdown-option')];
 			expect(checkboxList[0].hidden).to.be.true;
 			expect(checkboxList[1].hidden).to.be.not.true;
 		});
 
 		it('should maintain selected state across searches', async() => {
-			const checkboxList = [...el.shadowRoot.querySelectorAll('d2l-filter-dropdown-option')];
+			const checkboxList = [...el.shadowRoot.querySelectorAll('d2l-labs-filter-dropdown-option')];
 
 			el._handleSearchedClick({ detail: { value: '2' } });
 			await el.updateComplete;
@@ -152,7 +152,7 @@ describe('d2l-insights-dropdown-filter', () => {
 			el._handleSearchedClick(dropdownCategorySearchedEvent);
 			await el.updateComplete;
 
-			const checkboxList = [...el.shadowRoot.querySelectorAll('d2l-filter-dropdown-option')];
+			const checkboxList = [...el.shadowRoot.querySelectorAll('d2l-labs-filter-dropdown-option')];
 			expect(checkboxList[0].hidden).to.be.true;
 			expect(checkboxList[1].hidden).to.be.not.true;
 		});
@@ -161,7 +161,7 @@ describe('d2l-insights-dropdown-filter', () => {
 	describe('eventing', () => {
 		it('should fire a `selected` event whenever one of the checkboxes is clicked', async() => {
 			let listener = oneEvent(el, 'd2l-insights-dropdown-filter-selected');
-			const checkboxList = Array.from(el.shadowRoot.querySelectorAll('d2l-filter-dropdown-option'));
+			const checkboxList = Array.from(el.shadowRoot.querySelectorAll('d2l-labs-filter-dropdown-option'));
 
 			checkboxList[0].click();
 
@@ -174,7 +174,7 @@ describe('d2l-insights-dropdown-filter', () => {
 			expect(el.selected[0]).to.equal('1');
 
 			//  verify opener textes are changed
-			let filter = el.shadowRoot.querySelector('d2l-filter-dropdown');
+			let filter = el.shadowRoot.querySelector('d2l-labs-filter-dropdown');
 			expect(filter.openerText).to.equal(`${name}: All`);
 			expect(filter.openerTextSingle).to.equal(`${name}: ${testData[0].name}`);
 			expect(filter.openerTextMultiple).to.equal(`${name}: ${testData[0].name}`);
@@ -191,7 +191,7 @@ describe('d2l-insights-dropdown-filter', () => {
 			expect(el.selected.length).to.equal(0);
 
 			// verify opener texts are changed
-			filter = el.shadowRoot.querySelector('d2l-filter-dropdown');
+			filter = el.shadowRoot.querySelector('d2l-labs-filter-dropdown');
 			expect(filter.openerText).to.equal(`${name}: All`);
 			expect(filter.openerTextSingle).to.equal(`${name}: 0 selected`);
 			expect(filter.openerTextMultiple).to.equal(`${name}: 0 selected`);

--- a/test/components/semester-filter.test.js
+++ b/test/components/semester-filter.test.js
@@ -96,7 +96,7 @@ describe('d2l-insights-semester-filter', () => {
 			const checkboxes = Array.from(
 				el
 					.shadowRoot.querySelector('d2l-insights-dropdown-filter')
-					.shadowRoot.querySelectorAll('d2l-filter-dropdown-option')
+					.shadowRoot.querySelectorAll('d2l-labs-filter-dropdown-option')
 			);
 
 			checkboxes.find(checkbox => checkbox.value === '10007').click();


### PR DESCRIPTION
Moving to `facet-filter-sort` version 4, which renamed all the components, files and events to indicate these components are in labs - no functionality changes. This version is also published to npm, which cleans up the `package.json` entry.

This needs to be merged at the same time as the PRs in `my-courses` (https://github.com/Brightspace/d2l-my-courses-ui/pull/882), `common` (https://github.com/BrightspaceHypermediaComponents/common/pull/43) and `discovery-fra` (https://github.com/Brightspace/discovery-fra/pull/305) to avoid any BSI downtime.