### PR TITLE
Remove puppeteer and visual-diff from dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,15 @@ Note: Place all visual tests in the ./test/visual-diff folder or they will be ig
 To run diff tests locally
 
 ```
+# install puppeteer and visual-diff locally
+npm i mocha -g
+npm i @brightspace-ui/visual-diff puppeteer --no-save
+
 # for powershell
 $Env:GITHUB_REPOSITORY="Brightspace/insights-engagement-dashboard"
 
 # for bash
 export GITHUB_REPOSITORY=Brightspace/insights-engagement-dashboard
-
 
 npm run test:diff:golden
 # make some changes

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:lit": "lit-analyzer engagement-dashboard.js demo test components",
     "lint:style": "stylelint \"**/*.js\"",
     "start": "es-dev-server --app-index demo/index.html --node-resolve --dedupe --open --watch",
-    "test": "npm run lint && npm run test:headless && npm run test:diff",
+    "test": "npm run lint && npm run test:headless",
     "test:diff": "mocha ./test/visual-diff/**/*.visual-diff.js -t 40000",
     "test:diff:golden": "mocha ./test/visual-diff/**/*.visual-diff.js -t 40000 --golden",
     "test:diff:golden:commit": "commit-goldens",
@@ -22,7 +22,6 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@brightspace-ui/stylelint-config": "0.0.3",
-    "@brightspace-ui/visual-diff": "^2",
     "@open-wc/testing": "^2",
     "@open-wc/testing-karma": "^4.0.1",
     "@polymer/polymer": "^3.4.1",
@@ -40,7 +39,6 @@
     "frau-ci": "^1",
     "karma-sauce-launcher": "^4",
     "lit-analyzer": "^1.2.0",
-    "puppeteer": "^5",
     "sinon": "^9.0.3",
     "stylelint": "^13.6.1"
   },


### PR DESCRIPTION
They're not needed since the visual diff CI job installs its own dependencies, and they slow down `npm install`ing quite a bit. Plus puppeteer is about to get updated and that might cause sync issues if we don't keep up.

A better option is just to install locally when needed as described in the readme.

More context: https://d2l.slack.com/archives/C0PHG3QB0/p1612808089086800

FYI @anhill-D2L @Vitalii-Misechko @johngwilkinson 