### PR TITLE
fix 401 when metron endpoint has a trailing slash

### DIFF
--- a/model/dataApiClient.js
+++ b/model/dataApiClient.js
@@ -16,7 +16,7 @@ const dataEndpoint = '/d2l/api/ap/unstable/insights/data/engagement';
 const relevantChildrenEndpoint = orgUnitId => `/d2l/api/ap/unstable/insights/data/orgunits/${orgUnitId}/children`;
 const ouSearchEndpoint = '/d2l/api/ap/unstable/insights/data/orgunits';
 const saveSettingsEndpoint = '/d2l/api/ap/unstable/insights/mysettings/engagement';
-const userDrillDataEndpoint = '/unstable/insights/data/userdrill';
+const userDrillDataEndpoint = 'unstable/insights/data/userdrill';
 
 /**
  * @param {[Number]} roleIds
@@ -49,13 +49,13 @@ export async function fetchData({ roleIds = [], semesterIds = [], orgUnitIds = [
  * @param {String} metronEndpoint
  */
 export async function fetchUserData(orgUnitIds = [], userId = 0, metronEndpoint) {
-	const url = new URL(`${metronEndpoint}${userDrillDataEndpoint}`, window.location.origin);
+	const url = metronEndpoint + (metronEndpoint.endsWith('/') ? '' : '/') + userDrillDataEndpoint;
 	const userDrillBody = {
 		selectedUserId: userId,
 		selectedOrgUnitIds: orgUnitIds,
 		metrics: true
 	};
-	const response = await d2lfetch.fetch(new Request(url.toString(), {
+	const response = await d2lfetch.fetch(new Request(url, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json'

--- a/test/model/dataApiClient.test.js
+++ b/test/model/dataApiClient.test.js
@@ -329,14 +329,23 @@ describe('Lms', () => {
 
 	describe('fetchUserData', () => {
 		it('should throw an error if the query fails', async() => {
-			fetchMock.post('', 403);
+			fetchMock.post('path:/d2l/lp/auth/oauth2/token', {});
+			fetchMock.post('https://data.example.com/unstable/insights/data/userdrill', 403);
 			let error;
 			try {
 				await fetchUserData([], 1234, 'https://data.example.com');
 			} catch (err) {
 				error = err.toString();
 			}
-			expect(error).to.exist;
+			expect(error).to.equal('Error: query-failure');
+		});
+
+		it('should not add a redundant slash', async() => {
+			fetchMock.post('path:/d2l/lp/auth/oauth2/token', {});
+			fetchMock.post('https://data.example.com/unstable/insights/data/userdrill', { the: 'data' });
+			// note trailing slash here
+			const actual = await fetchUserData([], 1234, 'https://data.example.com/');
+			expect(actual).to.deep.equal({ the: 'data' });
 		});
 	});
 });


### PR DESCRIPTION
We saw this issue on Spark.

Quality Notes
- functional: local e2e with and without trailing slash in metron config
- security, perf, devops, ux/docs: n/a

I looked for a lib to do this, but the one I found that looked good, url-join, doesn't seem to support esm imports - at least, I couldn't figure it out.

FYI @bemailloux @MykolaGalian 