### PR TITLE
Use intl library to get decimal and thousands separator symbols

### DIFF
--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -6,6 +6,7 @@ import '../overlay';
 
 import { css, html, LitElement } from 'lit-element';
 import { getDateTimeDescriptor } from '@brightspace-ui/intl/lib/dateTime';
+import { getNumberDescriptor } from '@brightspace-ui/intl/lib/number';
 import { Localizer } from '../../locales/localizer';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
@@ -182,18 +183,19 @@ class Chart extends SkeletonMixin(Localizer(LitElement)) {
 	}
 
 	get _langOptions() {
-		const descriptor = getDateTimeDescriptor();
+		const dateTimeDescriptor = getDateTimeDescriptor();
+		const numberDescriptor = getNumberDescriptor();
 
 		return {
 			loading: this.localize('chart:loading'),
-			months:  descriptor.calendar.months.long,
-			shortMonths:  descriptor.calendar.months.short,
-			weekdays: descriptor.calendar.days.long,
+			months:  dateTimeDescriptor.calendar.months.long,
+			shortMonths:  dateTimeDescriptor.calendar.months.short,
+			weekdays: dateTimeDescriptor.calendar.days.long,
 
-			decimalPoint: this.localize('chart:decimalPoint'),
+			decimalPoint: numberDescriptor.symbols.decimal,
 			resetZoom: this.localize('chart:resetZoom'),
 			resetZoomTitle: this.localize('chart:resetZoomTitle'),
-			thousandsSep: this.localize('chart:thousandsSeparator'),
+			thousandsSep: numberDescriptor.symbols.group,
 		};
 	}
 }

--- a/components/chart/chart.js
+++ b/components/chart/chart.js
@@ -152,6 +152,9 @@ class Chart extends SkeletonMixin(Localizer(LitElement)) {
 					screenReaderSection: {
 						// fixes axe error: Landmarks must have a unique role or role/label/title
 						beforeRegionLabel: ''
+					},
+					zoom: {
+						resetZoomButton: this.localize('chart:resetZoom')
 					}
 				}
 			};

--- a/locales/ar.js
+++ b/locales/ar.js
@@ -234,8 +234,6 @@ export default {
 	"gradesTrendCard:currentGrade": "العلامة الحالية (%)",
 
 	"chart:loading": "يتم الآن التحميل...",
-	"chart:decimalPoint": ".",
 	"chart:resetZoom": "Reset zoom",
 	"chart:resetZoomTitle": "Reset zoom level 1:1",
-	"chart:thousandsSeparator": " ",
 };

--- a/locales/cy-gb.js
+++ b/locales/cy-gb.js
@@ -234,8 +234,6 @@ export default {
 	"gradesTrendCard:currentGrade": "Gradd Bresennol (%)",
 
 	"chart:loading": "Wrthi'n llwytho...",
-	"chart:decimalPoint": ".",
 	"chart:resetZoom": "Reset zoom",
 	"chart:resetZoomTitle": "Reset zoom level 1:1",
-	"chart:thousandsSeparator": " ",
 };

--- a/locales/da.js
+++ b/locales/da.js
@@ -234,8 +234,6 @@ export default {
 	"gradesTrendCard:currentGrade": "Aktuel karakter (%)",
 
 	"chart:loading": "Loading...",
-	"chart:decimalPoint": ".",
 	"chart:resetZoom": "Reset zoom",
 	"chart:resetZoomTitle": "Reset zoom level 1:1",
-	"chart:thousandsSeparator": " ",
 };

--- a/locales/de.js
+++ b/locales/de.js
@@ -234,8 +234,6 @@ export default {
 	"gradesTrendCard:currentGrade": "Aktuelle Note (%)",
 
 	"chart:loading": "Laden...",
-	"chart:decimalPoint": ".",
 	"chart:resetZoom": "Reset zoom",
 	"chart:resetZoomTitle": "Reset zoom level 1:1",
-	"chart:thousandsSeparator": " ",
 };

--- a/locales/en.js
+++ b/locales/en.js
@@ -234,8 +234,6 @@ export default {
 	"gradesTrendCard:currentGrade": "Current Grade (%)",
 
 	"chart:loading": "Loading...",
-	"chart:decimalPoint": ".",
 	"chart:resetZoom": "Reset zoom",
 	"chart:resetZoomTitle": "Reset zoom level 1:1",
-	"chart:thousandsSeparator": " ",
 };

--- a/locales/es-es.js
+++ b/locales/es-es.js
@@ -234,8 +234,6 @@ export default {
 	"gradesTrendCard:currentGrade": "Calificación actual (%)",
 
 	"chart:loading": "Cargando…",
-	"chart:decimalPoint": ".",
 	"chart:resetZoom": "Reset zoom",
 	"chart:resetZoomTitle": "Reset zoom level 1:1",
-	"chart:thousandsSeparator": " ",
 };

--- a/locales/es.js
+++ b/locales/es.js
@@ -234,8 +234,6 @@ export default {
 	"gradesTrendCard:currentGrade": "Calificación actual (%)",
 
 	"chart:loading": "Loading...",
-	"chart:decimalPoint": ".",
 	"chart:resetZoom": "Reset zoom",
 	"chart:resetZoomTitle": "Reset zoom level 1:1",
-	"chart:thousandsSeparator": " ",
 };

--- a/locales/fr-fr.js
+++ b/locales/fr-fr.js
@@ -234,8 +234,6 @@ export default {
 	"gradesTrendCard:currentGrade": "Note actuelle (%)",
 
 	"chart:loading": "Loading...",
-	"chart:decimalPoint": ".",
 	"chart:resetZoom": "Reset zoom",
 	"chart:resetZoomTitle": "Reset zoom level 1:1",
-	"chart:thousandsSeparator": " ",
 };

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -234,8 +234,6 @@ export default {
 	"gradesTrendCard:currentGrade": "Note d'appréciation actuelle (%)",
 
 	"chart:loading": "Chargement…",
-	"chart:decimalPoint": ".",
 	"chart:resetZoom": "Réinitialiser le zoom",
 	"chart:resetZoomTitle": "Reset zoom level 1:1",
-	"chart:thousandsSeparator": " ",
 };

--- a/locales/ja.js
+++ b/locales/ja.js
@@ -234,8 +234,6 @@ export default {
 	"gradesTrendCard:currentGrade": "現在の成績（%）",
 
 	"chart:loading": "読み込み中...",
-	"chart:decimalPoint": ".",
 	"chart:resetZoom": "Reset zoom",
 	"chart:resetZoomTitle": "Reset zoom level 1:1",
-	"chart:thousandsSeparator": " ",
 };

--- a/locales/ko.js
+++ b/locales/ko.js
@@ -234,8 +234,6 @@ export default {
 	"gradesTrendCard:currentGrade": "현재 평점(%)",
 
 	"chart:loading": "로드 중...",
-	"chart:decimalPoint": ".",
 	"chart:resetZoom": "Reset zoom",
 	"chart:resetZoomTitle": "Reset zoom level 1:1",
-	"chart:thousandsSeparator": " ",
 };

--- a/locales/nl.js
+++ b/locales/nl.js
@@ -234,8 +234,6 @@ export default {
 	"gradesTrendCard:currentGrade": "Huidige score (%)",
 
 	"chart:loading": "Laden...",
-	"chart:decimalPoint": ".",
 	"chart:resetZoom": "Reset zoom",
 	"chart:resetZoomTitle": "Reset zoom level 1:1",
-	"chart:thousandsSeparator": " ",
 };

--- a/locales/pt.js
+++ b/locales/pt.js
@@ -234,8 +234,6 @@ export default {
 	"gradesTrendCard:currentGrade": "Nota atual (%)",
 
 	"chart:loading": "Loading...",
-	"chart:decimalPoint": ".",
 	"chart:resetZoom": "Redefinir zoom",
 	"chart:resetZoomTitle": "Reset zoom level 1:1",
-	"chart:thousandsSeparator": " ",
 };

--- a/locales/sv.js
+++ b/locales/sv.js
@@ -234,8 +234,6 @@ export default {
 	"gradesTrendCard:currentGrade": "Aktuellt betyg (%)",
 
 	"chart:loading": "Läser in ...",
-	"chart:decimalPoint": ".",
 	"chart:resetZoom": "Reset zoom",
 	"chart:resetZoomTitle": "Reset zoom level 1:1",
-	"chart:thousandsSeparator": " ",
 };

--- a/locales/tr.js
+++ b/locales/tr.js
@@ -234,8 +234,6 @@ export default {
 	"gradesTrendCard:currentGrade": "Mevcut Not (%)",
 
 	"chart:loading": "Yükleniyor...",
-	"chart:decimalPoint": ".",
 	"chart:resetZoom": "Reset zoom",
 	"chart:resetZoomTitle": "Reset zoom level 1:1",
-	"chart:thousandsSeparator": " ",
 };

--- a/locales/zh-tw.js
+++ b/locales/zh-tw.js
@@ -234,8 +234,6 @@ export default {
 	"gradesTrendCard:currentGrade": "目前成績 (%)",
 
 	"chart:loading": "Loading...",
-	"chart:decimalPoint": ".",
 	"chart:resetZoom": "Reset zoom",
 	"chart:resetZoomTitle": "Reset zoom level 1:1",
-	"chart:thousandsSeparator": " ",
 };

--- a/locales/zh.js
+++ b/locales/zh.js
@@ -234,8 +234,6 @@ export default {
 	"gradesTrendCard:currentGrade": "当前成绩 (%)",
 
 	"chart:loading": "正在加载...",
-	"chart:decimalPoint": ".",
 	"chart:resetZoom": "Reset zoom",
 	"chart:resetZoomTitle": "Reset zoom level 1:1",
-	"chart:thousandsSeparator": " ",
 };


### PR DESCRIPTION
Originally we tried to have these symbols "translated", but the translators didn't understand what we wanted to do, and did nothing. (Except in zh where they used the _wrong_ symbol.)

Solution: use the intl library instead.

Quality notes:
* Testing: see screenshots
* Devops: this will be going into 20.21.03 as well
* Perf, security, UX, docs: N/A

Screenshots (demo page)
* English
![image](https://user-images.githubusercontent.com/11587338/109172449-c9b36b80-7750-11eb-8fe0-a2b167851915.png)

* German
![image](https://user-images.githubusercontent.com/11587338/109172554-e8b1fd80-7750-11eb-887e-c1988ee343cb.png)

* French
![image](https://user-images.githubusercontent.com/11587338/109172602-f49dbf80-7750-11eb-9447-6e4d06ea595e.png)

* Spanish
![image](https://user-images.githubusercontent.com/11587338/109172849-3464a700-7751-11eb-8027-9554711b0cb9.png)

* Spanish (Mexico) - same symbols as English
![image](https://user-images.githubusercontent.com/11587338/109172710-139c5180-7751-11eb-8121-5022e785d9dd.png)

* Chinese
![image](https://user-images.githubusercontent.com/11587338/109172763-20b94080-7751-11eb-8c62-68ed1e14c573.png)

@NicholasHallman @anhill-D2L