### PR TITLE
US123807 Apply predicted grade col setting to table

### DIFF
--- a/components/user-drill-courses-table.js
+++ b/components/user-drill-courses-table.js
@@ -40,7 +40,7 @@ class UserDrillCoursesTable extends SortMixin(SkeletonMixin(Localizer(MobxLitEle
 		return {
 			data: { type: Object, attribute: false },
 			user: { type: Object, attribute: false },
-			isActiveTable: { type: Boolean, attribute: false, reflect: true },
+			isActiveTable: { type: Boolean, attribute: 'active-table', reflect: true },
 			_currentPage: { type: Number, attribute: false },
 			_pageSize: { type: Number, attribute: false },
 			selectedCourses: { type: Object, attribute: false },
@@ -77,6 +77,8 @@ class UserDrillCoursesTable extends SortMixin(SkeletonMixin(Localizer(MobxLitEle
 		this._sortColumn = TABLE_COLUMNS.COURSE_NAME;
 		this._currentPage = 1;
 		this._pageSize = DEFAULT_PAGE_SIZE;
+
+		this.isActiveTable = false;
 
 		this.showDiscussionsCol = false;
 		this.showGradeCol = false;

--- a/components/user-drill-courses-table.js
+++ b/components/user-drill-courses-table.js
@@ -43,12 +43,14 @@ class UserDrillCoursesTable extends SortMixin(SkeletonMixin(Localizer(MobxLitEle
 			isActiveTable: { type: Boolean, attribute: false, reflect: true },
 			_currentPage: { type: Number, attribute: false },
 			_pageSize: { type: Number, attribute: false },
-			isStudentSuccessSys: { type: Boolean, attribute: false },
 			selectedCourses: { type: Object, attribute: false },
+
+			s3Enabled: { type: Boolean, attribute: 'student-success-system-enabled' },
 			showDiscussionsCol: { type: Boolean, attribute: 'discussions-col', reflect: true },
 			showGradeCol: { type: Boolean, attribute: 'grade-col', reflect: true },
 			showLastAccessCol: { type: Boolean, attribute: 'last-access-col', reflect: true },
-			showTicCol: { type: Boolean, attribute: 'tic-col', reflect: true }
+			showTicCol: { type: Boolean, attribute: 'tic-col', reflect: true },
+			showPredictedGradeCol: { type: Boolean, attribute: 'predicted-grade-col', reflect: true },
 		};
 	}
 
@@ -76,11 +78,12 @@ class UserDrillCoursesTable extends SortMixin(SkeletonMixin(Localizer(MobxLitEle
 		this._currentPage = 1;
 		this._pageSize = DEFAULT_PAGE_SIZE;
 
-		this.isStudentSuccessSys = false;
 		this.showDiscussionsCol = false;
 		this.showGradeCol = false;
 		this.showLastAccessCol = false;
 		this.showTicCol = false;
+		this.showPredictedGradeCol = false;
+		this.s3Enabled = false;
 
 		this.sorts = [
 			courseNameSort,
@@ -199,12 +202,12 @@ class UserDrillCoursesTable extends SortMixin(SkeletonMixin(Localizer(MobxLitEle
 	}
 
 	_getVisibleColumns(isExport) {
-		const includePredictedGrade = this.isActiveTable || isExport;
+		const includePredictedGrade = (this.isActiveTable || isExport) && this.s3Enabled && this.showPredictedGradeCol;
 		const includeSemester = !this.isActiveTable || isExport;
 		const columns = [TABLE_COLUMNS.COURSE_NAME];
 
 		if (this.showGradeCol) columns.push(TABLE_COLUMNS.CURRENT_GRADE);
-		if (includePredictedGrade && this.isStudentSuccessSys) columns.push(TABLE_COLUMNS.PREDICTED_GRADE);
+		if (includePredictedGrade) columns.push(TABLE_COLUMNS.PREDICTED_GRADE);
 		if (this.showTicCol) columns.push(TABLE_COLUMNS.TIME_IN_CONTENT);
 		if (this.showDiscussionsCol) columns.push(TABLE_COLUMNS.DISCUSSION_ACTIVITY);
 		if (this.showLastAccessCol) columns.push(TABLE_COLUMNS.COURSE_LAST_ACCESS);
@@ -281,7 +284,7 @@ class UserDrillCoursesTable extends SortMixin(SkeletonMixin(Localizer(MobxLitEle
 		const headers = [this.localize('activeCoursesTable:course')];
 
 		if (this.showGradeCol) headers.push(this.localize('activeCoursesTable:grade'));
-		if (this.isStudentSuccessSys) headers.push(this.localize('activeCoursesTable:predictedGrade'));
+		if (this.s3Enabled && this.showPredictedGradeCol) headers.push(this.localize('activeCoursesTable:predictedGrade'));
 		if (this.showTicCol) headers.push(this.localize('activeCoursesTable:timeInContent'));
 		if (this.showDiscussionsCol) {
 			headers.push(this.localize('discussionActivityCard:threads'));

--- a/components/user-drill-view.js
+++ b/components/user-drill-view.js
@@ -35,7 +35,6 @@ const demoDate = 1608000000000; //for unit test
 /**
  * @property {Object} data - an instance of Data from model/data.js
  * @property {Object} user - {firstName, lastName, username, userId}
- * @property {Boolean} isStudentSuccessSys - checking 'Access Student Success System' for org
  * @property {Object} orgUnitId - the org unit the user belongs too
  */
 class UserDrill extends SkeletonMixin(Localizer(MobxLitElement)) {
@@ -44,7 +43,7 @@ class UserDrill extends SkeletonMixin(Localizer(MobxLitElement)) {
 			user: { type: Object, attribute: false },
 			data: { type: Object, attribute: false },
 			isDemo: { type: Boolean, attribute: 'demo' },
-			isStudentSuccessSys: { type: Boolean, attribute: false },
+			s3Enabled: { type: Boolean, attribute: 'student-success-system-enabled' },
 			orgUnitId: { type: Number, attribute: 'org-unit-id' },
 			viewState: { type: Object, attribute: false },
 			metronEndpoint: { type: String, attribute: 'metron-endpoint' },
@@ -57,7 +56,8 @@ class UserDrill extends SkeletonMixin(Localizer(MobxLitElement)) {
 			showDiscussionsCol: { type: Boolean, attribute: 'discussions-col', reflect: true },
 			showGradeCol: { type: Boolean, attribute: 'grade-col', reflect: true },
 			showLastAccessCol: { type: Boolean, attribute: 'last-access-col', reflect: true },
-			showTicCol: { type: Boolean, attribute: 'tic-col', reflect: true }
+			showTicCol: { type: Boolean, attribute: 'tic-col', reflect: true },
+			showPredictedGradeCol: { type: Boolean, attribute: 'predicted-grade-col', reflect: true }
 		};
 	}
 
@@ -72,13 +72,13 @@ class UserDrill extends SkeletonMixin(Localizer(MobxLitElement)) {
 			firstName: null,
 			lastName: null
 		};
-		this.isStudentSuccessSys = false;
 		this.orgUnitId = 0;
 		this.viewState = null;
 
 		this.selectedCourses = new SelectedCourses();
 		this.lastFilteredOrgUnitIds = [];
 		this.metronEndpoint = '';
+		this.s3Enabled = false;
 
 		this.showOverdueCard = false;
 		this.showSystemAccessCard = false;
@@ -90,6 +90,7 @@ class UserDrill extends SkeletonMixin(Localizer(MobxLitElement)) {
 		this.showGradeCol = false;
 		this.showLastAccessCol = false;
 		this.showTicCol = false;
+		this.showPredictedGradeCol = false;
 	}
 
 	static get styles() {
@@ -551,12 +552,13 @@ class UserDrill extends SkeletonMixin(Localizer(MobxLitElement)) {
 				.data="${this.data}"
 				.user="${this.user}"
 				.isActiveTable=${Boolean(true)}
-				.isStudentSuccessSys="${this.isStudentSuccessSys}"
-				?skeleton="${this.skeleton}"
+				?student-success-system-enabled="${this.s3Enabled}"
 				?discussions-col="${this.showDiscussionsCol}"
 				?grade-col="${this.showGradeCol}"
 				?last-access-col="${this.showLastAccessCol}"
 				?tic-col="${this.showTicCol}"
+				?predicted-grade-col="${this.showPredictedGradeCol}"
+				?skeleton="${this.skeleton}"
 				.selectedCourses="${this.selectedCourses}">
 			</d2l-insights-user-drill-courses-table>
 
@@ -565,11 +567,12 @@ class UserDrill extends SkeletonMixin(Localizer(MobxLitElement)) {
 				.data="${this.data}"
 				.user="${this.user}"
 				.isActiveTable=${Boolean(false)}
-				.isStudentSuccessSys="${this.isStudentSuccessSys}"
+				?student-success-system-enabled="${this.s3Enabled}"
 				?discussions-col="${this.showDiscussionsCol}"
 				?grade-col="${this.showGradeCol}"
 				?last-access-col="${this.showLastAccessCol}"
 				?tic-col="${this.showTicCol}"
+				?predicted-grade-col="${this.showPredictedGradeCol}"
 				?skeleton="${this.skeleton}"
 				.selectedCourses="${this.selectedCourses}">
 			</d2l-insights-user-drill-courses-table>

--- a/components/user-drill-view.js
+++ b/components/user-drill-view.js
@@ -551,7 +551,7 @@ class UserDrill extends SkeletonMixin(Localizer(MobxLitElement)) {
 			<d2l-insights-user-drill-courses-table
 				.data="${this.data}"
 				.user="${this.user}"
-				.isActiveTable=${Boolean(true)}
+				active-table
 				?student-success-system-enabled="${this.s3Enabled}"
 				?discussions-col="${this.showDiscussionsCol}"
 				?grade-col="${this.showGradeCol}"
@@ -566,7 +566,6 @@ class UserDrill extends SkeletonMixin(Localizer(MobxLitElement)) {
 			<d2l-insights-user-drill-courses-table
 				.data="${this.data}"
 				.user="${this.user}"
-				.isActiveTable=${Boolean(false)}
 				?student-success-system-enabled="${this.s3Enabled}"
 				?discussions-col="${this.showDiscussionsCol}"
 				?grade-col="${this.showGradeCol}"

--- a/demo/index.html
+++ b/demo/index.html
@@ -61,7 +61,7 @@
 			system-access-card tic-col tic-grades-card
 			average-grade-summary-card
 			content-views-trend-card course-access-trend-card grades-trend-card system-access-card
-			student-success-system-enabled predicted-grade-col
+			predicted-grade-col
 			include-roles="600,700"
 		></d2l-insights-engagement-dashboard>
 	</body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -61,7 +61,7 @@
 			system-access-card tic-col tic-grades-card
 			average-grade-summary-card
 			content-views-trend-card course-access-trend-card grades-trend-card system-access-card
-			predicted-grade-col
+			student-success-system-enabled predicted-grade-col
 			include-roles="600,700"
 		></d2l-insights-engagement-dashboard>
 	</body>

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -274,7 +274,6 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				?demo="${this.isDemo}"
 				.data="${this._data}"
 				.user="${user}"
-				.isStudentSuccessSys="${this._serverData.serverData.isStudentSuccessSys}"
 				org-unit-id="${this.orgUnitId}"
 				.viewState="${this._viewState}"
 				.metronEndpoint="${this.metronEndpoint}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-engagement-dashboard",
-  "version": "1.2103.0",
+  "version": "1.2104.0",
   "description": "D2L Insights Engagement Dashboard",
   "repository": "https://github.com/Brightspace/insights-engagement-dashboard.git",
   "private": true,

--- a/test/components/user-drill-courses-table.test.js
+++ b/test/components/user-drill-courses-table.test.js
@@ -388,7 +388,7 @@ function getTableHtml({ data, s3Enabled, isActive }) {
 		<d2l-insights-user-drill-courses-table
 			.data="${data}"
 			.user="${user}"
-			.isActiveTable="${Boolean(isActive)}"
+			?active-table="${isActive}"
 			?student-success-system-enabled="${s3Enabled}"
 			discussions-col	grade-col last-access-col tic-col predicted-grade-col
 			.selectedCourses="${selectedCourses}">

--- a/test/components/user-drill-courses-table.test.js
+++ b/test/components/user-drill-courses-table.test.js
@@ -10,26 +10,24 @@ const semesterOrgUnitId = 100;
 
 const data = {
 	records: [
-		// ouId, userId, roleId, overdue, grade, tic, last access, threads, replies, reads, predicted
-
 		// active courses
 		[101, USER_ID, ROLE_ID, 0, 80, 6600, 1607979700000, 3, 3, 3, 0.90],
 		[102, USER_ID, ROLE_ID, 0, 85, 5400, 1607979760000, 2, 2, 2, 0.60],
 		[103, USER_ID, ROLE_ID, 0, null, 4200, 1607979820000, 5, 5, 5, 0.75],
-		[104, USER_ID, ROLE_ID, 0, 70, 4800, 1607979640000, 7, 7, 7], // no predicted grade
+		[104, USER_ID, ROLE_ID, 0, 70, 4800, 1607979640000, 7, 7, 7, null], // no predicted grade
 		[105, USER_ID, ROLE_ID, 0, 88, null, 1607979880000, 4, 4, 4, 0.20],
 		[106, USER_ID, ROLE_ID, 0, 48, 7800, null, 9, 9, 9, 0.55],
 
-		[199, 2, ROLE_ID, 0, 90, 6000, 1607979698265, 1, 2, 3], // should be ignored - not the current user
+		[199, 2, ROLE_ID, 0, 90, 6000, 1607979698265, 1, 2, 3, null], // should be ignored - not the current user
 
 		// inactive courses
-		[11, USER_ID, ROLE_ID, 0, 80, 6600, 1607979700000, 3, 3, 3],
-		[12, USER_ID, ROLE_ID, 0, 85, 5400, null, 2, 2, 2],
-		[13, USER_ID, ROLE_ID, 0, 75, 4200, 1607979820000, 5, 5, 5],
-		[14, USER_ID, ROLE_ID, 0, null, 4800, 1607979640000, 7, 7, 7],
-		[15, USER_ID, ROLE_ID, 0, 88, 7200, 1607979880000, 4, 4, 4],
+		[11, USER_ID, ROLE_ID, 0, 80, 6600, 1607979700000, 3, 3, 3, null],
+		[12, USER_ID, ROLE_ID, 0, 85, 5400, null, 2, 2, 2, null],
+		[13, USER_ID, ROLE_ID, 0, 75, 4200, 1607979820000, 5, 5, 5, null],
+		[14, USER_ID, ROLE_ID, 0, null, 4800, 1607979640000, 7, 7, 7, null],
+		[15, USER_ID, ROLE_ID, 0, 88, 7200, 1607979880000, 4, 4, 4, null],
 
-		[99, 2, ROLE_ID, 0, 90, 6000, 1607979698265, 5, 6, 7], // should be ignored - not the current user
+		[99, 2, ROLE_ID, 0, 90, 6000, 1607979698265, 5, 6, 7, null], // should be ignored - not the current user
 	],
 	orgUnitTree: {
 		isActive: (orgUnitId) => orgUnitId >= 100,
@@ -84,17 +82,7 @@ describe('d2l-insights-user-drill-courses-table', () => {
 	describe('active courses table', () => {
 		describe('accessibility', () => {
 			it('should pass all axe tests', async() => {
-				const [el] = await setupTable(html`
-					<d2l-insights-user-drill-courses-table
-						.data="${data}"
-						.user="${user}"
-						.isActiveTable="${Boolean(true)}"
-						.isStudentSuccessSys="${Boolean(true)}"
-						.selectedCourses="${selectedCourses}"
-						discussions-col	grade-col last-access-col tic-col
-					>
-					</d2l-insights-user-drill-courses-table>
-				`);
+				const [el] = await setupTable(getTableHtml({ data, s3Enabled: true, isActive: true }));
 
 				// see users-table a11y test for explanation
 				await expect(el).to.be.accessible({
@@ -107,17 +95,8 @@ describe('d2l-insights-user-drill-courses-table', () => {
 		});
 
 		describe('render table with correct data', () => {
-			it('should pass correct data to inner table if S3 enabled', async() => {
-				const [, innerTable] = await setupTable(html`
-					<d2l-insights-user-drill-courses-table
-						.data="${data}"
-						.user="${user}"
-						.isActiveTable="${Boolean(true)}"
-						.isStudentSuccessSys="${Boolean(true)}"
-						discussions-col	grade-col last-access-col tic-col
-						.selectedCourses="${selectedCourses}">
-					</d2l-insights-user-drill-courses-table>
-				`);
+			it('should pass correct data to inner table if S3 enabled and show predicted grade is true', async() => {
+				const [, innerTable] = await setupTable(getTableHtml({ data, s3Enabled: true, isActive: true }));
 
 				expect(innerTable.data).to.deep.equal(expected.active);
 				expect(innerTable.columnInfo.map(info => info.headerText)).to.deep.equal([
@@ -131,16 +110,7 @@ describe('d2l-insights-user-drill-courses-table', () => {
 			});
 
 			it('should pass correct data to inner table if S3 disabled', async() => {
-				const [, innerTable] = await setupTable(html`
-					<d2l-insights-user-drill-courses-table
-						.data="${data}"
-						.user="${user}"
-						.isActiveTable="${Boolean(true)}"
-						.isStudentSuccessSys="${Boolean(false)}"
-						discussions-col	grade-col last-access-col tic-col
-						.selectedCourses="${selectedCourses}">
-					</d2l-insights-user-drill-courses-table>
-				`);
+				const [, innerTable] = await setupTable(getTableHtml({ data, s3Enabled: false, isActive: true }));
 
 				const expectedWithoutPredictedGrade = expected.active.map(row => row.filter((val, idx) => idx !== 2));
 				expect(innerTable.data).to.deep.equal(expectedWithoutPredictedGrade);
@@ -154,16 +124,7 @@ describe('d2l-insights-user-drill-courses-table', () => {
 			});
 
 			it('should display no data error message if there was no data', async() => {
-				const el = await fixture(html`
-					<d2l-insights-user-drill-courses-table
-						.data="${emptyData}"
-						.user="${user}"
-						.isActiveTable="${Boolean(true)}"
-						.isStudentSuccessSys="${Boolean(false)}"
-						discussions-col	grade-col last-access-col tic-col
-						.selectedCourses="${selectedCourses}">
-					</d2l-insights-user-drill-courses-table>
-				`);
+				const el = await fixture(getTableHtml({ data: emptyData, s3Enabled: true, isActive: true }));
 
 				const errorMessage = el.shadowRoot.querySelector('d2l-insights-message-container');
 				expect(errorMessage.text).to.equal('No active course data in filtered ranges.');
@@ -171,26 +132,8 @@ describe('d2l-insights-user-drill-courses-table', () => {
 		});
 
 		describe('sorting', () => {
-			const tableHtml = html`
-				<d2l-insights-user-drill-courses-table
-					.data="${data}"
-					.user="${user}"
-					.isActiveTable="${Boolean(true)}"
-					.isStudentSuccessSys="${Boolean(true)}"
-					discussions-col	grade-col last-access-col tic-col
-					.selectedCourses="${selectedCourses}">
-				</d2l-insights-user-drill-courses-table>
-			`;
-			const noS3TableHtml = html`
-				<d2l-insights-user-drill-courses-table
-					.data="${data}"
-					.user="${user}"
-					.isActiveTable="${Boolean(true)}"
-					.isStudentSuccessSys="${Boolean(false)}"
-					discussions-col	grade-col last-access-col tic-col
-					.selectedCourses="${selectedCourses}">
-				</d2l-insights-user-drill-courses-table>
-			`;
+			const tableHtml = getTableHtml({ data, s3Enabled: true, isActive: true });
+			const noS3TableHtml = getTableHtml({ data, s3Enabled: false, isActive: true });
 
 			const testCases = [
 				['Course name', undefined, 0],
@@ -241,16 +184,7 @@ describe('d2l-insights-user-drill-courses-table', () => {
 			}
 
 			before(async() => {
-				[el, innerTable] = await setupTable(html`
-					<d2l-insights-user-drill-courses-table
-						.data="${data}"
-						.user="${user}"
-						.isActiveTable="${Boolean(true)}"
-						.isStudentSuccessSys="${Boolean(true)}"
-						discussions-col	grade-col last-access-col tic-col
-						.selectedCourses="${selectedCourses}">
-					</d2l-insights-user-drill-courses-table>
-				`);
+				[el, innerTable] = await setupTable(getTableHtml({ data, s3Enabled: true, isActive: true }));
 				pageSelector = el.shadowRoot.querySelector('d2l-labs-pagination');
 			});
 
@@ -266,15 +200,7 @@ describe('d2l-insights-user-drill-courses-table', () => {
 	describe('inactive courses table', () => {
 		describe('accessibility', () => {
 			it('should pass all axe tests', async() => {
-				const [el] = await setupTable(html`
-					<d2l-insights-user-drill-courses-table
-						.data="${data}"
-						.user="${user}"
-						.isActiveTable="${Boolean(false)}"
-						discussions-col	grade-col last-access-col tic-col
-						.selectedCourses="${selectedCourses}">
-					</d2l-insights-user-drill-courses-table>
-				`);
+				const [el] = await setupTable(getTableHtml({ data, s3Enabled: true, isActive: false }));
 
 				// see users-table a11y test for explanation
 				await expect(el).to.be.accessible({
@@ -288,21 +214,7 @@ describe('d2l-insights-user-drill-courses-table', () => {
 
 		describe('render', () => {
 			it('should pass correct data to inner table', async() => {
-
-				const el = await fixture(html`
-					<d2l-insights-user-drill-courses-table
-						.data="${data}"
-						.user="${user}"
-						.isActiveTable="${Boolean(false)}"
-						.isStudentSuccessSys="${Boolean(true)}"
-						discussions-col	grade-col last-access-col tic-col
-						.selectedCourses="${selectedCourses}">
-					</d2l-insights-user-drill-courses-table>
-				`);
-				await new Promise(resolve => setTimeout(resolve, 200));
-				await el.updateComplete;
-
-				const innerTable = el.shadowRoot.querySelector('d2l-insights-table');
+				const [, innerTable] = await setupTable(getTableHtml({ data, s3Enabled: true, isActive: false }));
 				expect(innerTable.data).to.deep.equal(expected.inactive);
 				expect(innerTable.columnInfo.map(info => info.headerText)).to.deep.equal([
 					'Course Name',
@@ -315,15 +227,7 @@ describe('d2l-insights-user-drill-courses-table', () => {
 			});
 
 			it('should display no data error message if there was no data', async() => {
-				const el = await fixture(html`
-					<d2l-insights-user-drill-courses-table
-						.data="${emptyData}"
-						.user="${user}"
-						.isActiveTable="${Boolean(false)}"
-						discussions-col	grade-col last-access-col tic-col
-						.selectedCourses="${selectedCourses}">
-					</d2l-insights-user-drill-courses-table>
-				`);
+				const el = await fixture(getTableHtml({ data: emptyData, s3Enabled: true, isActive: false }));
 
 				const errorMessage = el.shadowRoot.querySelector('d2l-insights-message-container');
 				expect(errorMessage.text).to.equal('No inactive course data in filtered ranges.');
@@ -331,26 +235,8 @@ describe('d2l-insights-user-drill-courses-table', () => {
 		});
 
 		describe('sorting', () => {
-			const tableHtml = html`
-				<d2l-insights-user-drill-courses-table
-					.data="${data}"
-					.user="${user}"
-					.isActiveTable="${Boolean(false)}"
-					.isStudentSuccessSys="${Boolean(true)}"
-					discussions-col	grade-col last-access-col tic-col
-					.selectedCourses="${selectedCourses}">
-				</d2l-insights-user-drill-courses-table>
-			`;
-			const noS3TableHtml = html`
-				<d2l-insights-user-drill-courses-table
-					.data="${data}"
-					.user="${user}"
-					.isActiveTable="${Boolean(false)}"
-					.isStudentSuccessSys="${Boolean(false)}"
-					discussions-col	grade-col last-access-col tic-col
-					.selectedCourses="${selectedCourses}">
-				</d2l-insights-user-drill-courses-table>
-			`;
+			const tableHtml = getTableHtml({ data, s3Enabled: true, isActive: false });
+			const noS3TableHtml = getTableHtml({ data, s3Enabled: false, isActive: false });
 
 			const testCases = [
 				['Course name', undefined],
@@ -400,15 +286,7 @@ describe('d2l-insights-user-drill-courses-table', () => {
 			}
 
 			before(async() => {
-				[el, innerTable, headers] = await setupTable(html`
-					<d2l-insights-user-drill-courses-table
-						.data="${data}"
-						.user="${user}"
-						.isActiveTable="${Boolean(false)}"
-						discussions-col	grade-col last-access-col tic-col
-						.selectedCourses="${selectedCourses}">
-					</d2l-insights-user-drill-courses-table>
-				`);
+				[el, innerTable, headers] = await setupTable(getTableHtml({ data, s3Enabled: true, isActive: false }));
 				pageSelector = el.shadowRoot.querySelector('d2l-labs-pagination');
 			});
 
@@ -453,58 +331,34 @@ describe('d2l-insights-user-drill-courses-table', () => {
 		});
 
 		describe('export', () => {
-			it('should get headersForExport and dataForExport[0] for inactive course when isStudentSuccessSys equals true', async() => {
-				const el = await fixture(html`
-					<d2l-insights-user-drill-courses-table
-						.data="${data}"
-						.user="${user}"
-						.isActiveTable="${Boolean(false)}"
-						.isStudentSuccessSys="${Boolean(true)}"
-						discussions-col	grade-col last-access-col tic-col
-						.selectedCourses="${selectedCourses}">
-					</d2l-insights-user-drill-courses-table>
-				`);
+			it('should get headersForExport and dataForExport[0] for inactive course when s3 is enabled', async() => {
+				const el = await fixture(getTableHtml({ data, s3Enabled: true, isActive: false }));
 				await new Promise(resolve => setTimeout(resolve, 200));
 				await el.updateComplete;
 				expect(el.dataForExport[0]).to.deep.equal(
 					['Course 11 (Id: 11)', '80 %', 'No predicted grade', '110', 3, 3, 3, getLocalDateTime(1607979700000), 'Semester 100 (Id: 100)', false]);
 				expect(el.headersForExport).to.deep.equal(['Course Name', 'Grade', 'Predicted Grade', 'Time in Content (mins)', 'Threads', 'Reads', 'Replies', 'Course Last Access', 'Semester', 'Is Active Course']);
 			});
-			it('should get headersForExport and dataForExport[0] for active course when isStudentSuccessSys equals true', async() => {
-				const el = await fixture(html`
-					<d2l-insights-user-drill-courses-table
-						.data="${data}"
-						.user="${user}"
-						.isActiveTable="${Boolean(true)}"
-						.isStudentSuccessSys="${Boolean(true)}"
-						discussions-col	grade-col last-access-col tic-col
-						.selectedCourses="${selectedCourses}">
-					</d2l-insights-user-drill-courses-table>
-				`);
+
+			it('should get headersForExport and dataForExport[0] for active course when s3 is enabled', async() => {
+				const el = await fixture(getTableHtml({ data, s3Enabled: true, isActive: true }));
 				await new Promise(resolve => setTimeout(resolve, 200));
 				await el.updateComplete;
 				expect(el.dataForExport[0]).to.deep.equal(
 					[ 'Course 101 (Id: 101)', '80 %', '90 %', '110', 3, 3, 3, getLocalDateTime(1607979700000), 'Semester 100 (Id: 100)', true]);
 				expect(el.headersForExport).to.deep.equal(['Course Name', 'Grade', 'Predicted Grade', 'Time in Content (mins)', 'Threads', 'Reads', 'Replies', 'Course Last Access', 'Semester', 'Is Active Course']);
 			});
-			it('should get headersForExport and dataForExport[0] for active course when isStudentSuccessSys equals false', async() => {
-				const el = await fixture(html`
-					<d2l-insights-user-drill-courses-table
-						.data="${data}"
-						.user="${user}"
-						.isActiveTable="${Boolean(true)}"
-						.isStudentSuccessSys="${Boolean(false)}"
-						discussions-col	grade-col last-access-col tic-col
-						.selectedCourses="${selectedCourses}">
-					</d2l-insights-user-drill-courses-table>
-				`);
+
+			it('should get headersForExport and dataForExport[0] for active course when s3 is not enabled', async() => {
+				const el = await fixture(getTableHtml({ data, s3Enabled: false, isActive: true }));
 				await new Promise(resolve => setTimeout(resolve, 200));
 				await el.updateComplete;
 				expect(el.dataForExport[0]).to.deep.equal(
 					[ 'Course 101 (Id: 101)', '80 %', '110', 3, 3, 3, getLocalDateTime(1607979700000), 'Semester 100 (Id: 100)', true]);
 				expect(el.headersForExport).to.deep.equal(['Course Name', 'Grade', 'Time in Content (mins)', 'Threads', 'Reads', 'Replies', 'Course Last Access', 'Semester', 'Is Active Course']);
 			});
-			it('should get headersForExport and dataForExport[0] for active course when isStudentSuccessSys equals false and course has no semester', async() => {
+
+			it('should get headersForExport and dataForExport[0] for active course when s3 is not enabled and course has no semester', async() => {
 				const data = {
 					records: [
 						[101, USER_ID, ROLE_ID, 0, 80, 6600, 1607979700000, 3, 3, 3, 0.90]
@@ -518,16 +372,7 @@ describe('d2l-insights-user-drill-courses-table', () => {
 					semesterTypeId : 5
 				};
 
-				const el = await fixture(html`
-					<d2l-insights-user-drill-courses-table
-						.data="${data}"
-						.user="${user}"
-						.isActiveTable="${Boolean(true)}"
-						.isStudentSuccessSys="${Boolean(false)}"
-						discussions-col	grade-col last-access-col tic-col
-						.selectedCourses="${selectedCourses}">
-					</d2l-insights-user-drill-courses-table>
-				`);
+				const el = await fixture(getTableHtml({ data, s3Enabled: false, isActive: true }));
 				await new Promise(resolve => setTimeout(resolve, 200));
 				await el.updateComplete;
 				expect(el.dataForExport[0]).to.deep.equal(
@@ -537,6 +382,19 @@ describe('d2l-insights-user-drill-courses-table', () => {
 		});
 	});
 });
+
+function getTableHtml({ data, s3Enabled, isActive }) {
+	return html`
+		<d2l-insights-user-drill-courses-table
+			.data="${data}"
+			.user="${user}"
+			.isActiveTable="${Boolean(isActive)}"
+			?student-success-system-enabled="${s3Enabled}"
+			discussions-col	grade-col last-access-col tic-col predicted-grade-col
+			.selectedCourses="${selectedCourses}">
+		</d2l-insights-user-drill-courses-table>
+	`;
+}
 
 async function setupTable(tableHtml) {
 	const el = await fixture(tableHtml);


### PR DESCRIPTION
Quality notes
* Testing
  * Table render [Draco LMS - E2E]
    * [x] When S3 is not enabled, predicted grade column does not appear
    * [x] When show predicted grade col is false, predicted grade column does not appear
    * [x] When S3 is enabled and show predicted grade col is true, predicted grade column appears
    * NB: Changes to show predicted grade col are applied without having to reload the page (but changes to s3Enabled are not)
  * Sorting [Demo page]
    * [x] Sorts correctly when predicted grade column is absent
    * [x] Sorts correctly when predicted grade column is present
  * Export [Draco LMS - E2E]
    * [x] Exports with predicted grade data if s3 is enabled and show predicted grade col is true
    * [x] Export w/o predicted grade data otherwise
* Security, perf, devops: N/A
* Demo: demoed
* Docs: see previous PR (#484)

FYI @NicholasHallman @anhill-D2L 