### PR TITLE
remove overrides for scroll-wrapper action colours

### DIFF
--- a/components/table.js
+++ b/components/table.js
@@ -166,11 +166,6 @@ class Table extends SkeletonMixin(Localizer(RtlMixin(LitElement))) {
 				min-width: 30px;
 			}
 
-			d2l-scroll-wrapper {
-				--d2l-scroll-wrapper-border-color: var(--d2l-color-galena);
-				--d2l-scroll-wrapper-background-color: var(--d2l-color-sylvite);
-			}
-
 			td.d2l-insights-discussion-info {
 				vertical-align: top;
 			}


### PR DESCRIPTION
We're [changing scroll-wrapper](https://github.com/BrightspaceUI/table/pull/234/files) so that the action button colours are no longer configurable -- they just use nice defaults that should work for everyone.

So setting these variables is no longer necessary.