### PR TITLE
US123549: stub learner dashboard entrance

### DIFF
--- a/components/immersive-nav.js
+++ b/components/immersive-nav.js
@@ -59,7 +59,7 @@ class InsightsImmersiveNav extends Localizer(MobxLitElement) {
 		switch (this.view) {
 			case 'home': return this.localize('dashboard:title');
 			case 'user': return this.localize('dashboard:userView:title');
-			case 'userSelection': return this.localize('dashboard:learner:title');
+			case 'userSelection': return this.localize('dashboard:userView:title');
 			case 'settings': return this.localize('settings:title');
 		}
 		return this.localize('dashboard:title');

--- a/components/immersive-nav.js
+++ b/components/immersive-nav.js
@@ -59,6 +59,7 @@ class InsightsImmersiveNav extends Localizer(MobxLitElement) {
 		switch (this.view) {
 			case 'home': return this.localize('dashboard:title');
 			case 'user': return this.localize('dashboard:userView:title');
+			case 'userSelection': return this.localize('dashboard:learner:title');
 			case 'settings': return this.localize('settings:title');
 		}
 		return this.localize('dashboard:title');
@@ -107,7 +108,7 @@ class InsightsImmersiveNav extends Localizer(MobxLitElement) {
 	}
 
 	_backLinkClickHandler(e) {
-		if (this.view === 'home') {
+		if (this.view === 'home' || this.view === 'userSelection') {
 			return true;
 		}
 

--- a/components/user-selector.js
+++ b/components/user-selector.js
@@ -1,0 +1,38 @@
+import { css, html } from 'lit-element';
+import { Localizer } from '../locales/localizer';
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin';
+
+class UserSelector extends SkeletonMixin(Localizer(MobxLitElement)) {
+	static get properties() {
+		return {
+			isDemo: { type: Boolean, attribute: 'demo' },
+			viewState: { type: Object, attribute: false }
+		};
+	}
+
+	static get styles() {
+		return [
+			css`
+				:host {
+					display: block;
+				}
+				:host([hidden]) {
+					display: none;
+				}
+			`
+		];
+	}
+
+	constructor() {
+		super();
+
+		this.isDemo = false;
+		this.viewState = null;
+	}
+
+	render() {
+		return html`user selector`;
+	}
+}
+customElements.define('d2l-insights-user-selector', UserSelector);

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -22,6 +22,7 @@ import './components/course-last-access-card.js';
 import './components/results-card.js';
 import './components/overdue-assignments-card.js';
 import './components/content-view-histogram.js';
+import './components/user-selector.js';
 
 import { css, html } from 'lit-element/lit-element.js';
 import { DefaultViewState, ViewState } from './model/view-state';
@@ -221,7 +222,9 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 
 	firstUpdated() {
 		// moved loadData call here because its inderect call in render function via _data getter causes nested render call with exception
-		this._serverData.loadData({ defaultView: isDefault() });
+		if (this.currentView !== 'userSelection') {
+			this._serverData.loadData({ defaultView: isDefault() });
+		}
 	}
 
 	get currentView() {
@@ -236,6 +239,9 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 				break;
 			case 'user':
 				innerView = this._renderUserDrillView();
+				break;
+			case 'userSelection':
+				innerView = this._renderUserSelectionView();
 				break;
 			case 'settings':
 				innerView = this._renderSettingsView();
@@ -306,6 +312,16 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 					${this._renderAlerts()}
 				</div>
 			</d2l-insights-user-drill-view>
+		`;
+	}
+
+	_renderUserSelectionView() {
+		return html`
+			<d2l-insights-user-selector
+				?demo="${this.isDemo}"
+				.viewState="${this._viewState}"
+			>
+			</d2l-insights-user-selector>
 		`;
 	}
 

--- a/locales/en.js
+++ b/locales/en.js
@@ -2,7 +2,6 @@
 
 export default {
 	"dashboard:title": "Engagement Dashboard",
-	"dashboard:learner:title": "Learner Engagement Dashboard",
 	"dashboard:userView:title": "Learner Engagement Dashboard",
 	"dashboard:backToInsightsPortal": "Back to Insights Portal",
 	"dashboard:backToEngagementDashboard": "Back to Engagement Dashboard",

--- a/locales/en.js
+++ b/locales/en.js
@@ -2,6 +2,7 @@
 
 export default {
 	"dashboard:title": "Engagement Dashboard",
+	"dashboard:learner:title": "Learner Engagement Dashboard",
 	"dashboard:userView:title": "Learner Engagement Dashboard",
 	"dashboard:backToInsightsPortal": "Back to Insights Portal",
 	"dashboard:backToEngagementDashboard": "Back to Engagement Dashboard",

--- a/model/view-state.js
+++ b/model/view-state.js
@@ -19,6 +19,12 @@ export class ViewState {
 		if (this._urlState) this._urlState.save();
 	}
 
+	setUserSelectionView() {
+		this.currentView = 'userSelection';
+		this.userViewUserId = 0;
+		if (this._urlState) this._urlState.save();
+	}
+
 	setHomeView() {
 		this.currentView = 'home';
 		this.userViewUserId = 0;
@@ -56,6 +62,8 @@ export class ViewState {
 			case 'home': this.setHomeView();
 				break;
 			case 'user': this.setUserView(Number(userId));
+				break;
+			case 'userSelection': this.setUserSelectionView();
 				break;
 			case 'settings': this.setSettingsView();
 				break;

--- a/test/model/view-state.test.js
+++ b/test/model/view-state.test.js
@@ -31,6 +31,16 @@ describe('ViewState', () => {
 			expect(sut.persistenceValue).equals('user,321');
 		});
 
+		it('should load user selection view from the url', async() => {
+			setStateForTesting(KEY, 'userSelection,0');
+
+			const sut = new ViewState();
+
+			expect(sut.currentView).equals('userSelection');
+			expect(sut.userViewUserId).equals(0);
+			expect(sut.persistenceValue).equals('userSelection,0');
+		});
+
 		it('should load settings view from url', async() => {
 			setStateForTesting(KEY, 'settings,0');
 
@@ -68,6 +78,20 @@ describe('ViewState', () => {
 
 			const searchParams = new URLSearchParams(window.location.search);
 			expect(searchParams.get(KEY)).equals('user,321');
+		});
+
+		it('should save user selection view to the url', async() => {
+			setStateForTesting(KEY, 'home,0');
+
+			const sut = new ViewState();
+
+			sut.setUserSelectionView();
+
+			expect(sut.currentView).equals('userSelection');
+			expect(sut.persistenceValue).equals('userSelection,0');
+
+			const searchParams = new URLSearchParams(window.location.search);
+			expect(searchParams.get(KEY)).equals('userSelection,0');
 		});
 
 		it('should save settings view to the url', async() => {


### PR DESCRIPTION
Quality Notes

- functional
  - click on Insights Portal tile for Learner Engagement Dashboard: loads as expected (image below)
    - hit f5; reloads user selector page
  - click on "Back to Insights Portal": returns to insights portal
  - click on tile for Engagement Dashboard; goes to regular engagement dashboard
- perf
  - does not try to load dashboard data when hitting user selector
- security, ux/docs, devops: n/a

![image](https://user-images.githubusercontent.com/11181217/114617363-080bd800-9c76-11eb-90fa-c07ed2273e97.png)

FYI @Vitalii-Misechko @anhill-D2L 