### PR TITLE
US126962 [Engagement] Learner Engagement Dashboard Page. Search

### DIFF
--- a/components/immersive-nav.js
+++ b/components/immersive-nav.js
@@ -71,7 +71,7 @@ class InsightsImmersiveNav extends Localizer(MobxLitElement) {
 				return this.localize('dashboard:backToInsightsPortal');
 			case 'user':
 				if (this.viewState.isSingleLearner) return 'Select a Different User'; // TODO: localize
-				else return this.localize('dashboard:backToEngagementDashboard')
+				else return this.localize('dashboard:backToEngagementDashboard');
 			case 'settings':
 				return this.localize('dashboard:backToEngagementDashboard');
 		}

--- a/components/user-selector.js
+++ b/components/user-selector.js
@@ -34,9 +34,9 @@ class UserSelector extends SkeletonMixin(Localizer(MobxLitElement)) {
 				.d2l-insights-user-selector-search {
 					display: flex;
 					flex-wrap: nowrap;
+					max-width: 334px;
 					padding-bottom: 26px;
 					padding-top: 4px;
-					max-width: 334px;
 				}
 			`
 		];

--- a/components/user-selector.js
+++ b/components/user-selector.js
@@ -2,7 +2,7 @@ import '@brightspace-ui/core/components/list/list.js';
 import '@brightspace-ui/core/components/list/list-item-button.js';
 import 'd2l-users/components/d2l-profile-image';
 
-import { bodySmallStyles, bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import { bodySmallStyles, bodyStandardStyles, heading1Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element';
 import { Localizer } from '../locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
@@ -19,6 +19,8 @@ class UserSelector extends SkeletonMixin(Localizer(MobxLitElement)) {
 
 	static get styles() {
 		return [
+			super.styles,
+			heading1Styles,
 			bodySmallStyles,
 			bodyStandardStyles,
 			css`
@@ -47,7 +49,7 @@ class UserSelector extends SkeletonMixin(Localizer(MobxLitElement)) {
 
 	render() {
 		return html`
-			<h2>Learner Engagement Dashboard</h2>
+			<h2 class="d2l-heading-1">Learner Engagement Dashboard</h2>
 			<d2l-list>
 				${this.users.map(u => this.userListItem(u))}
 			</d2l-list>

--- a/components/user-selector.js
+++ b/components/user-selector.js
@@ -57,7 +57,7 @@ class UserSelector extends SkeletonMixin(Localizer(MobxLitElement)) {
 
 	render() {
 		return html`
-			<h2 class="d2l-heading-1">Learner Engagement Dashboard</h2>
+			<h2 class="d2l-heading-1">${this.localize('learnerEngagementDashboard:title')}</h2>
 
 			<div class="d2l-insights-user-selector-search">
 				<d2l-input-search
@@ -86,10 +86,10 @@ class UserSelector extends SkeletonMixin(Localizer(MobxLitElement)) {
 					medium
 				></d2l-profile-image>
 				<div>
-					<div class="d2l-body-standard">
+					<div class="d2l-body-standard d2l-skeletize">
 						${u.last}, ${u.first}
 					</div>
-					<div class="d2l-body-small">
+					<div class="d2l-body-small d2l-skeletize">
 						${u.login} - ${u.id}
 					</div>
 				</div>
@@ -107,8 +107,38 @@ class UserSelector extends SkeletonMixin(Localizer(MobxLitElement)) {
 		return this.isDemo ? Promise.resolve('token') : D2L.LP.Web.Authentication.OAuth2.GetToken('users:profile:read');
 	}
 
-	_onSearch() {
-		// TODO
+	_onSearch(e) {
+		this._search(e.detail.value, true);
+	}
+
+	_search(searchText, ascending) {
+		const cleared = searchText === '';
+
+		console.log(`searchText: ${searchText}; ascending: ${ascending}; cleared: ${cleared}`);
+
+		this.skeleton = true;
+
+		this.users = this._usersForSkeleton();
+
+		setTimeout(() => {
+			this.users = [
+				{ id: 11053, first: 'Beverly', last: 'Aadland', login: 'baadland' },
+				{ id: 11054, first: 'Maybe', last: 'Another', login: 'manother' }
+			];
+
+			this.skeleton = false;
+		}, 2000);
+
+	}
+
+	_usersForSkeleton() {
+		return Array.from(Array(10).keys())
+			.map(i => ({
+				id: i,
+				first: 'first',
+				last: 'last',
+				login: 'login'
+			}));
 	}
 }
 customElements.define('d2l-insights-user-selector', UserSelector);

--- a/components/user-selector.js
+++ b/components/user-selector.js
@@ -36,7 +36,7 @@ class UserSelector extends SkeletonMixin(Localizer(MobxLitElement)) {
 					flex-wrap: nowrap;
 					padding-bottom: 26px;
 					padding-top: 4px;
-					width: 334px;
+					max-width: 334px;
 				}
 			`
 		];

--- a/components/user-selector.js
+++ b/components/user-selector.js
@@ -30,6 +30,14 @@ class UserSelector extends SkeletonMixin(Localizer(MobxLitElement)) {
 				:host([hidden]) {
 					display: none;
 				}
+
+				.d2l-insights-user-selector-search {
+					display: flex;
+					flex-wrap: nowrap;
+					padding-bottom: 26px;
+					padding-top: 4px;
+					width: 334px;
+				}
 			`
 		];
 	}
@@ -50,6 +58,15 @@ class UserSelector extends SkeletonMixin(Localizer(MobxLitElement)) {
 	render() {
 		return html`
 			<h2 class="d2l-heading-1">Learner Engagement Dashboard</h2>
+
+			<div class="d2l-insights-user-selector-search">
+				<d2l-input-search
+					label="${this.localize('treeSelector:searchLabel')}"
+					placeholder="${this.localize('treeSelector:searchPlaceholder')}"
+					@d2l-input-search-searched="${this._onSearch}"
+				></d2l-input-search>
+			</div>
+
 			<d2l-list>
 				${this.users.map(u => this.userListItem(u))}
 			</d2l-list>
@@ -88,6 +105,10 @@ class UserSelector extends SkeletonMixin(Localizer(MobxLitElement)) {
 
 	_tokenPromise() {
 		return this.isDemo ? Promise.resolve('token') : D2L.LP.Web.Authentication.OAuth2.GetToken('users:profile:read');
+	}
+
+	_onSearch() {
+		// TODO
 	}
 }
 customElements.define('d2l-insights-user-selector', UserSelector);

--- a/locales/en.js
+++ b/locales/en.js
@@ -275,5 +275,7 @@ export default {
 	"alert:this-To-That" : "to",
 	"alert:greaterThanThis" : "greater than {num}",
 	"alert:axeDescriptionCourses" : "Viewing learner data in these courses ",
-	"alert:axeDescriptionCoursesOff" : "Viewing learner data in all courses."
+	"alert:axeDescriptionCoursesOff" : "Viewing learner data in all courses.",
+
+	"learnerEngagementDashboard:title": "Learner Engagement Dashboard"
 };

--- a/test/model/view-state.test.js
+++ b/test/model/view-state.test.js
@@ -18,7 +18,7 @@ describe('ViewState', () => {
 
 			expect(sut.currentView).equals('home');
 			expect(sut.userViewUserId).equals(0);
-			expect(sut.persistenceValue).equals('home,0');
+			expect(sut.persistenceValue).equals('home,0,');
 		});
 
 		it('should load user view from the url', async() => {
@@ -28,17 +28,17 @@ describe('ViewState', () => {
 
 			expect(sut.currentView).equals('user');
 			expect(sut.userViewUserId).equals(321);
-			expect(sut.persistenceValue).equals('user,321');
+			expect(sut.persistenceValue).equals('user,321,');
 		});
 
 		it('should load user selection view from the url', async() => {
-			setStateForTesting(KEY, 'userSelection,0');
+			setStateForTesting(KEY, 'userSelection,0,');
 
 			const sut = new ViewState();
 
 			expect(sut.currentView).equals('userSelection');
 			expect(sut.userViewUserId).equals(0);
-			expect(sut.persistenceValue).equals('userSelection,0');
+			expect(sut.persistenceValue).equals('userSelection,0,');
 		});
 
 		it('should load settings view from url', async() => {
@@ -47,7 +47,7 @@ describe('ViewState', () => {
 			const sut = new ViewState();
 
 			expect(sut.currentView).equals('settings');
-			expect(sut.persistenceValue).equals('settings,0');
+			expect(sut.persistenceValue).equals('settings,0,');
 		});
 
 		it('should save home view to the url', async() => {
@@ -59,10 +59,10 @@ describe('ViewState', () => {
 
 			expect(sut.currentView).equals('home');
 			expect(sut.userViewUserId).equals(0);
-			expect(sut.persistenceValue).equals('home,0');
+			expect(sut.persistenceValue).equals('home,0,');
 
 			const searchParams = new URLSearchParams(window.location.search);
-			expect(searchParams.get(KEY)).equals('home,0');
+			expect(searchParams.get(KEY)).equals('home,0,');
 		});
 
 		it('should save user view to the url', async() => {
@@ -74,10 +74,10 @@ describe('ViewState', () => {
 
 			expect(sut.currentView).equals('user');
 			expect(sut.userViewUserId).equals(321);
-			expect(sut.persistenceValue).equals('user,321');
+			expect(sut.persistenceValue).equals('user,321,');
 
 			const searchParams = new URLSearchParams(window.location.search);
-			expect(searchParams.get(KEY)).equals('user,321');
+			expect(searchParams.get(KEY)).equals('user,321,');
 		});
 
 		it('should save user selection view to the url', async() => {
@@ -88,10 +88,10 @@ describe('ViewState', () => {
 			sut.setUserSelectionView();
 
 			expect(sut.currentView).equals('userSelection');
-			expect(sut.persistenceValue).equals('userSelection,0');
+			expect(sut.persistenceValue).equals('userSelection,0,');
 
 			const searchParams = new URLSearchParams(window.location.search);
-			expect(searchParams.get(KEY)).equals('userSelection,0');
+			expect(searchParams.get(KEY)).equals('userSelection,0,');
 		});
 
 		it('should save settings view to the url', async() => {
@@ -102,10 +102,10 @@ describe('ViewState', () => {
 			sut.setSettingsView();
 
 			expect(sut.currentView).equals('settings');
-			expect(sut.persistenceValue).equals('settings,0');
+			expect(sut.persistenceValue).equals('settings,0,');
 
 			const searchParams = new URLSearchParams(window.location.search);
-			expect(searchParams.get(KEY)).equals('settings,0');
+			expect(searchParams.get(KEY)).equals('settings,0,');
 		});
 	});
 });


### PR DESCRIPTION
[US126962](https://rally1.rallydev.com/#/23525809118d/iterationstatus?detail=%2Fuserstory%2F521050018628&sharedViewId=328666453148&view=dc9e7043-1cf6-486d-a4aa-3a212976e789&fdp=true?fdp=true): [Engagement] Learner Engagement Dashboard Page

This PR includes only `search` input and its behavior. It was made to make early integration with John's branch

* Functional Testing 
  * [x] Browsers (Chrome, FF, Edge)
  * [x] Accessibility. The search can be fired with a keyboard
  * [x] Test cases
     * The page shows skeleton list of 10 items when a user hits the search button
* Security, devops, perf: N/A
* UX and docs
  ~* [ ] Demo to Kevin~ Will demo when I finish all components of the story
  
 FYI @NicholasHallman @anhill-D2L 
  
  
![image](https://user-images.githubusercontent.com/9429561/115577893-759ab280-a2cd-11eb-8b4e-28be4ccd720e.png)
