### PR TITLE
Detailed Filter Tags 2 US126898

### DIFF
--- a/components/applied-filters.js
+++ b/components/applied-filters.js
@@ -53,8 +53,8 @@ class AppliedFilters extends SkeletonMixin(Localizer(MobxLitElement)) {
 			}
 
 			.d2l-insights-tag-item.d2l-insights-blue-text:hover {
-				background-color: white;
-				border-color: white;
+				background-color: var(--d2l-color-gypsum);
+				border-color: var(--d2l-color-gypsum);
 				color: var(--d2l-color-celestine-minus-1);
 			}
 
@@ -227,7 +227,7 @@ class AppliedFilters extends SkeletonMixin(Localizer(MobxLitElement)) {
 
 		const filters = this.data.filters.map(f => {
 			const title = f.descriptiveTitle ?
-				f.descriptiveTitle(this.localize(f.title)) :
+				f.descriptiveTitle(localizer) :
 				this.localize(f.title);
 
 			return {

--- a/components/applied-filters.js
+++ b/components/applied-filters.js
@@ -225,7 +225,7 @@ class AppliedFilters extends SkeletonMixin(Localizer(MobxLitElement)) {
 
 		const localizer = (term, options) => this.localize(term, options);
 
-		const filters = this.data.filters.map(f => {
+		const filters = this._getActiveFilters(this.data.filters).map(f => {
 			const title = f.descriptiveTitle ?
 				f.descriptiveTitle(localizer) :
 				this.localize(f.title);

--- a/components/course-last-access-card.js
+++ b/components/course-last-access-card.js
@@ -84,19 +84,27 @@ export class CourseLastAccessFilter extends CategoryFilter {
 
 	descriptiveTitle(localizer) {
 		const pairs = this.mergeCategories(localizer);
-		if (pairs.length === 1)
-			return `${localizer(this.title)}: ${pairs.map(pair => pair.join('-')).join(' ')}`;
+		if (pairs.length === 1) {
+			return `${localizer(this.title)}: ${pairs.map(pair => {
+				if (pair.length === 1) return pair;
+				return `${pair.join('-')} ${localizer('courseLastAccessCard:daysAgo')}`;
+			}).join(' ')}
+			`;
+		}
 		return `${localizer(this.title)}`;
 	}
 
 	axeDescription(localizer, categoryTerm) {
-		const chartName = { chartName: localizer(this.title) };
-		const pairs = this.mergeCategories();
+		const chartName = { chartName : localizer('courseLastAccessCard:courseAccess') };
 
-		if (pairs.length === 0) return localizer('alert:axeNotFiltering', chartName);
+		const categories = ([...this.selectedCategories]);
+		if (categories.length === 0) return localizer('alert:axeNotFiltering', chartName);
 
+		const pairs = this.mergeCategories(localizer);
+
+		const message = localizer(categoryTerm, chartName);
 		const descriptions = pairs.map(pair => pair.join(` ${localizer('alert:this-To-That')} `)).join(', ');
-		return `${localizer(categoryTerm, chartName)} ${descriptions}`;
+		return `${message} ${descriptions}`;
 	}
 
 	//for Urlstate
@@ -266,20 +274,6 @@ class CourseLastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 		</div>`;
 	}
 
-	getAxeDescription() {
-
-		const chartName = { chartName : this.localize('courseLastAccessCard:courseAccess') };
-
-		const categories = ([...this.filter.selectedCategories]);
-		if (categories.length === 0) return this.localize('alert:axeNotFiltering', chartName);
-
-		const pairs = this.filter.mergeCategories();
-
-		const message = this.localize('alert:axeDescriptionRange', chartName);
-		const descriptions = pairs.map(pair => pair.join(` ${this.localize('alert:this-To-That')} `)).join(', ');
-		return `${message} ${descriptions}`;
-	}
-
 	get chartOptions() {
 		const that = this;
 		return {
@@ -371,9 +365,10 @@ class CourseLastAccessCard extends SkeletonMixin(Localizer(MobxLitElement)) {
 						events: {
 							click: function() {
 								that.filter.toggleCategory(this.index);
+								const localizer = (term, options) => that.localize(term, options);
 								filterEventQueue.add(
 									that.localize('alert:updatedFilter', { chartName: that.localize('courseLastAccessCard:courseAccess') }),
-									that.getAxeDescription()
+									that.filter.axeDescription(localizer, 'alert:axeDescriptionRange')
 								);
 							}
 						}

--- a/components/current-final-grade-card.js
+++ b/components/current-final-grade-card.js
@@ -38,12 +38,12 @@ export class CurrentFinalGradesFilter extends CategoryFilter {
 		this._urlState = new UrlState(this);
 	}
 
-	get descriptiveTitle() {
+	descriptiveTitle(localizer) {
 		const pairs = this.mergeCategories();
 		if (pairs.length === 1)
-			return (translatedTile) => `${translatedTile}: ${pairs.map(pair => pair.join('-')).join(' ')}`;
+			return `${localizer(this.title)}: ${pairs.map(pair => pair.join('-')).join(' ')}`;
 
-		return (translatedTitle) => `${translatedTitle}`;
+		return `${localizer(this.title)}`;
 	}
 
 	mergeCategories() {

--- a/components/discussion-activity-card.js
+++ b/components/discussion-activity-card.js
@@ -63,7 +63,7 @@ export class DiscussionActivityFilter extends CategoryFilter {
 		const chartName = { chartName : localizer('discussionActivityCard:cardTitle') };
 		if (categories.length === 0) return localizer('alert:axeNotFiltering', chartName);
 
-		return `${localizer(categoryTerm, chartName)} ${terms.join(', ')} `;
+		return `${localizer(categoryTerm, chartName)} ${terms.join(', ')}`;
 	}
 
 	descriptiveTitle(localizer) {

--- a/components/last-access-card.js
+++ b/components/last-access-card.js
@@ -30,6 +30,11 @@ export class LastAccessFilter {
 		return this.isWithoutRecentAccess(user);
 	}
 
+	axeDescription(localizer, term) {
+		const chartName = { chartName: localizer(this.title) };
+		return localizer(term, chartName);
+	}
+
 	// for UrlState
 	get persistenceKey() { return 'saf'; }
 

--- a/components/overdue-assignments-card.js
+++ b/components/overdue-assignments-card.js
@@ -23,6 +23,11 @@ export class OverdueAssignmentsFilter {
 		return record[RECORD.OVERDUE] > 0;
 	}
 
+	axeDescription(localizer, term) {
+		const chartName = { chartName: localizer(this.title) };
+		return localizer(term, chartName);
+	}
+
 	// for UrlState
 	get persistenceKey() { return 'oaf'; }
 

--- a/components/time-in-content-vs-grade-card.js
+++ b/components/time-in-content-vs-grade-card.js
@@ -115,6 +115,19 @@ export class TimeInContentVsGradeFilter {
 		}
 	}
 
+	descriptiveTitle(localizer) {
+		switch (this.quadrant) {
+			case 'rightTop' :
+				return `${localizer(this.title)}:  ${localizer('timeInContentVsGradeCard:highTimeHighGrade')}`;
+			case 'rightBottom' :
+				return `${localizer(this.title)}:  ${localizer('timeInContentVsGradeCard:highTimeLowGrade')}`;
+			case 'leftTop' :
+				return `${localizer(this.title)}:  ${localizer('timeInContentVsGradeCard:lowTimeHighGrade')}`;
+			case 'leftBottom' :
+				return `${localizer(this.title)}:  ${localizer('timeInContentVsGradeCard:lowTimeLowGrade')}`;
+		}
+	}
+
 	//for Urlstate
 	get persistenceKey() { return 'tcgf'; }
 

--- a/locales/en.js
+++ b/locales/en.js
@@ -113,6 +113,7 @@ export default {
 	"courseLastAccessCard:textLabel": "This chart displays the current final grade for each user per course",
 	"courseLastAccessCard:lastDateSinceAccess": "Last Time a User Accessed a Course",
 	"courseLastAccessCard:never": "Never",
+	"courseLastAccessCard:daysAgo": "days ago",
 	"courseLastAccessCard:moreThanFourteenDaysAgo": "> 14 days ago",
 	"courseLastAccessCard:sevenToFourteenDaysAgo": "7-14 days ago",
 	"courseLastAccessCard:fiveToSevenDaysAgo": "5-7 days ago",
@@ -146,6 +147,7 @@ export default {
 	"contentViewHistogram:userZeroTimes": "1 user has accessed the content 0 times",
 	"contentViewHistogram:usersGreaterTimes": "{numUsers} users have accessed the content greater than {start} times",
 	"contentViewHistogram:userGreaterTimes": "1 user has accessed the content greater than {start} times",
+	"contentViewHistogram:views": "views",
 
 	"discussionActivityCard:cardTitle": "Discussion Activity",
 	"discussionActivityCard:threads": "Threads",

--- a/locales/en.js
+++ b/locales/en.js
@@ -95,10 +95,10 @@ export default {
 	"timeInContentVsGradeCard:rightTop": " {numberOfUsers} user enrollments are getting an above average grade and spending above average time in content.",
 	"timeInContentVsGradeCard:leftBottom": "{numberOfUsers} user enrollments are getting a below average grade and spending below average time in content.",
 	"timeInContentVsGradeCard:rightBottom": "{numberOfUsers} user enrollments are getting a below average grade and spending above average time in content.",
-	"timeInContentVsGradeCard:highTimeHighGrade": "high time in content and high grade",
-	"timeInContentVsGradeCard:highTimeLowGrade": "high time in content and low grade",
-	"timeInContentVsGradeCard:lowTimeHighGrade": "low time in content and high grade",
-	"timeInContentVsGradeCard:lowTimeLowGrade": "low time in content and low grade",
+	"timeInContentVsGradeCard:highTimeHighGrade": "High time and high grade.",
+	"timeInContentVsGradeCard:highTimeLowGrade": "High time and low grade.",
+	"timeInContentVsGradeCard:lowTimeHighGrade": "Low time and high grade.",
+	"timeInContentVsGradeCard:lowTimeLowGrade": "Low time and low grade.",
 
 	"currentFinalGradeCard:currentGrade": "Current Grade",
 	"currentFinalGradeCard:numberOfStudents": "Number of Users",
@@ -162,7 +162,7 @@ export default {
 	"appliedFilters:showMore": "+{numHidden} more",
 	"appliedFilters:hideExtra": "Collapse",
 	"appliedFilters:labelText": "Showing only:",
-	"appliedFilters:axeDescriptionCategories": "Filtering users with {chartName} in these categories ",
+	"appliedFilters:axeDescriptionCategories": "Filtering {chartName}, ",
 	"appliedFilters:axeDescriptionApplied": "Filtering users with {chartName}",
 
 	"ariaLoadingProgress:loadingStart": "Loading is in progress",

--- a/test/components/applied-filters.test.js
+++ b/test/components/applied-filters.test.js
@@ -91,7 +91,7 @@ describe('d2l-insights-applied-filters', () => {
 
 		it('should use the descriptive title if available', async() => {
 			data.filters = [
-				{ id: 'filter-key-1', title: 'simpleFilter:searchLabel', descriptiveTitle: (title) => (`${title} descriptive`), isApplied: true },
+				{ id: 'filter-key-1', title: 'simpleFilter:searchLabel', descriptiveTitle: (localizer) => (`${localizer('simpleFilter:searchLabel')} descriptive`), isApplied: true },
 				{ id: 'filter-key-2', title: 'filter 2', isApplied: true }
 			];
 			const el = await fixture(html`<d2l-insights-applied-filters .data="${data}"></d2l-insights-applied-filters>`);

--- a/test/components/content-view-histogram.test.js
+++ b/test/components/content-view-histogram.test.js
@@ -1,13 +1,36 @@
 import { expect, fixture, html } from '@open-wc/testing';
 import { ContentViewHistogramFilter } from '../../components/content-view-histogram';
+import en from '../../locales/en.js';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
-
 const filter = new ContentViewHistogramFilter();
 
 const mapFromViews = (views) => {
 	const map = new Map();
 	views.forEach((v, i) => map.set(i, [i, 0, 0, 0, 0, v]));
 	return map;
+};
+
+const localizer = (term, options) => {
+	let result = en[term];
+	if (!result) return '';
+	if (options) {
+		let resultParts = result.split('{');
+		resultParts = resultParts.map(part => part.split('}'));
+		resultParts.forEach((part, i) => {
+			if (part.length === 1) {
+				resultParts[i] = part[0];
+				return;
+			} else {
+				const key = part[0];
+				term = options[key];
+				part[0] = term;
+				resultParts[i] = part.join('');
+			}
+		});
+		console.log('after', resultParts);
+		result = resultParts.join('');
+	}
+	return result;
 };
 
 const records = [
@@ -235,8 +258,7 @@ describe('content-view-histogram', () => {
 
 			filter.selectedCategories.clear();
 			filter.toggleCategory(0);
-
-			const description = el.getAxeDescription();
+			const description = filter.axeDescription(localizer, 'alert:axeDescriptionRange');
 
 			expect(description).to.equal('Viewing learners with Content View in these categories  41 to 50');
 		});
@@ -251,7 +273,7 @@ describe('content-view-histogram', () => {
 			filter.toggleCategory(0);
 			filter.toggleCategory(1);
 
-			const description = el.getAxeDescription();
+			const description = el.filter.axeDescription(localizer, 'alert:axeDescriptionRange');
 
 			expect(description).to.equal('Viewing learners with Content View in these categories  31 to 50');
 		});
@@ -266,7 +288,7 @@ describe('content-view-histogram', () => {
 			filter.toggleCategory(5);
 			filter.toggleCategory(3);
 
-			const description = el.getAxeDescription();
+			const description = el.filter.axeDescription(localizer, 'alert:axeDescriptionRange');
 
 			expect(description).to.equal('Viewing learners with Content View in these categories  0, 11 to 20');
 		});
@@ -280,7 +302,7 @@ describe('content-view-histogram', () => {
 			filter.selectedCategories.clear();
 			filter.toggleCategory(0);
 
-			const description = el.getAxeDescription();
+			const description = el.filter.axeDescription(localizer, 'alert:axeDescriptionRange');
 
 			expect(description).to.equal('Viewing learners with Content View in these categories  greater than 50');
 		});
@@ -295,7 +317,7 @@ describe('content-view-histogram', () => {
 			filter.toggleCategory(0);
 			filter.toggleCategory(1);
 
-			const description = el.getAxeDescription();
+			const description = el.filter.axeDescription(localizer, 'alert:axeDescriptionRange');
 
 			expect(description).to.equal('Viewing learners with Content View in these categories  greater than 40');
 		});

--- a/test/components/course-last-access-card.test.js
+++ b/test/components/course-last-access-card.test.js
@@ -1,8 +1,32 @@
 import { disableUrlStateForTesting, enableUrlState, setStateForTesting } from '../../model/urlState';
 import { expect, fixture, html } from '@open-wc/testing';
 import { CourseLastAccessFilter } from '../../components/course-last-access-card';
+import en from '../../locales/en';
 import { records } from '../model/mocks';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
+
+const localizer = (term, options) => {
+	let result = en[term];
+	if (!result) return '';
+	if (options) {
+		let resultParts = result.split('{');
+		resultParts = resultParts.map(part => part.split('}'));
+		resultParts.forEach((part, i) => {
+			if (part.length === 1) {
+				resultParts[i] = part[0];
+				return;
+			} else {
+				const key = part[0];
+				term = options[key];
+				part[0] = term;
+				resultParts[i] = part.join('');
+			}
+		});
+		console.log('after', resultParts);
+		result = resultParts.join('');
+	}
+	return result;
+};
 
 describe('d2l-insights-course-last-access-card', () => {
 	before(() => disableUrlStateForTesting());
@@ -99,12 +123,10 @@ describe('d2l-insights-course-last-access-card', () => {
 		it('should create an axe description', async() => {
 			setStateForTesting('caf', '');
 
-			const courseAccessEl = await fixture(html`<d2l-insights-course-last-access-card .data="${data}"></d2l-insights-course-last-access-card>`);
-
 			filter.selectedCategories.clear();
 			filter.toggleCategory(0);
 
-			const description = courseAccessEl.getAxeDescription();
+			const description = filter.axeDescription(localizer, 'alert:axeDescriptionRange');
 
 			expect(description).to.equal('Viewing learners with Course Access in these categories  Never');
 		});
@@ -112,13 +134,11 @@ describe('d2l-insights-course-last-access-card', () => {
 		it('should merge categories in axe description', async() => {
 			setStateForTesting('caf', '');
 
-			const courseAccessEl = await fixture(html`<d2l-insights-course-last-access-card .data="${data}"></d2l-insights-course-last-access-card>`);
-
 			filter.selectedCategories.clear();
 			filter.toggleCategory(5);
 			filter.toggleCategory(4);
 
-			const description = courseAccessEl.getAxeDescription();
+			const description = filter.axeDescription(localizer, 'alert:axeDescriptionRange');
 
 			expect(description).to.equal('Viewing learners with Course Access in these categories  1 to 5');
 		});
@@ -126,13 +146,11 @@ describe('d2l-insights-course-last-access-card', () => {
 		it('should seperate skipped categories in axe description', async() => {
 			setStateForTesting('caf', '');
 
-			const courseAccessEl = await fixture(html`<d2l-insights-course-last-access-card .data="${data}"></d2l-insights-course-last-access-card>`);
-
 			filter.selectedCategories.clear();
 			filter.toggleCategory(5);
 			filter.toggleCategory(3);
 
-			const description = courseAccessEl.getAxeDescription();
+			const description = filter.axeDescription(localizer, 'alert:axeDescriptionRange');
 
 			expect(description).to.equal('Viewing learners with Course Access in these categories  1 to 3, 5 to 7');
 		});

--- a/test/components/discussion-activity-card.test.js
+++ b/test/components/discussion-activity-card.test.js
@@ -2,8 +2,32 @@ import '../../components/discussion-activity-card.js';
 import { disableUrlStateForTesting, enableUrlState, setStateForTesting } from '../../model/urlState';
 import { expect, fixture, html } from '@open-wc/testing';
 import { DiscussionActivityFilter } from '../../components/discussion-activity-card';
+import en from '../../locales/en';
 import { RECORD } from '../../consts.js';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
+
+const localizer = (term, options) => {
+	let result = en[term];
+	if (!result) return '';
+	if (options) {
+		let resultParts = result.split('{');
+		resultParts = resultParts.map(part => part.split('}'));
+		resultParts.forEach((part, i) => {
+			if (part.length === 1) {
+				resultParts[i] = part[0];
+				return;
+			} else {
+				const key = part[0];
+				term = options[key];
+				part[0] = term;
+				resultParts[i] = part.join('');
+			}
+		});
+		console.log('after', resultParts);
+		result = resultParts.join('');
+	}
+	return result;
+};
 
 describe('d2l-insights-discussion-activity-card', () => {
 	before(() => disableUrlStateForTesting());
@@ -104,14 +128,12 @@ describe('d2l-insights-discussion-activity-card', () => {
 		it('should create an axe description', async() => {
 			setStateForTesting('caf', '');
 
-			const discussionEl = await fixture(html`<d2l-insights-discussion-activity-card .data="${data}"></d2l-insights-discussion-activity-card>`);
-
 			filter.selectedCategories.clear();
 			filter.toggleCategory(7);
 
-			const description = discussionEl.getAxeDescription();
+			const description = filter.axeDescription(localizer, 'alert:axeDescriptionRange');
 
-			expect(description).to.equal('Viewing learners with Discussion Activity in these categories  Threads ');
+			expect(description).to.equal('Viewing learners with Discussion Activity in these categories  Threads');
 		});
 
 	});


### PR DESCRIPTION
Continuation of #533 

![summary view](https://user-images.githubusercontent.com/14355188/115768838-d4693600-a378-11eb-9f04-21af99bfb3d0.PNG)

Implementation Notes
 
Moved the axe description from the charts into the filter for 
  - Content View
  - Discussion Activity
  - Course Access
  - Time in Content vs Grade

Also, created descriptive titles and moved merge functions of the above charts into their filters.

Quality Notes

Testing
  - Updated tests to check the accessible description in the filters
  - Manually tested descriptive titles
    - Course access merged categories and vague tag
    - Time in content categories
    - Discussion activity categories and vague tag
    - Content view category merging, 0 and infinity

UX - Descriptive titles for filter tags

Docs - N/A
Performance - N/A
Security - N/A

FYI: @anhill-D2L @Vitalii-Misechko @hyehayes 