### PR TITLE
Fixed a bunch of AXE tests that started to fail after axe-core 4.2.0 is released

### DIFF
--- a/components/courses-legend.js
+++ b/components/courses-legend.js
@@ -267,7 +267,7 @@ class CoursesLegend extends SkeletonMixin(Localizer(MobxLitElement)) {
 	render() {
 		return html`
 			<!-- Use Event Delegation for the click, and direct event handling for the keyboard -->
-			<div role="button" @click="${this._handleInteraction}" @keypress=${this._handleInteraction} class="d2l-insights-user-course-legend">
+			<div @click="${this._handleInteraction}" @keypress=${this._handleInteraction} class="d2l-insights-user-course-legend">
 				${this._renderCourses()}
 			</div>
 		`;

--- a/components/expander-with-control.js
+++ b/components/expander-with-control.js
@@ -42,6 +42,7 @@ class ExpanderWithControl extends RtlMixin(Localizer(LitElement)) {
 
 			.d2l-insights-expand-collapse-control-text {
 				color: var(--d2l-color-celestine);
+				cursor: pointer;
 				display: inline-flex;
 				margin: 0;
 			}
@@ -64,7 +65,7 @@ class ExpanderWithControl extends RtlMixin(Localizer(LitElement)) {
 		// Note: when Enter/Spacebar is pressed on a focused button, it fires a KeyboardEvent, as well as a MouseEvent
 		return html`
 			<div
-				role="button"
+				role="presentation"
 				class="d2l-insights-expand-collapse-control"
 				@click="${this._toggleExpanded}">
 

--- a/test/components/card-selection-list.test.js
+++ b/test/components/card-selection-list.test.js
@@ -16,7 +16,7 @@ describe('d2l-insights-engagement-card-selection-list', () => {
 			const el = await fixture(html`<d2l-insights-engagement-card-selection-list></d2l-insights-engagement-card-selection-list>`);
 			await expect(el).to.be.accessible({
 				ignoredRules: [
-					'aria-allowed-attr' // TODO Fix later
+					'aria-allowed-attr' // Requires d2l-list-item component fix
 				]
 			});
 		});

--- a/test/components/column-configuration.test.js
+++ b/test/components/column-configuration.test.js
@@ -16,7 +16,7 @@ describe('d2l-insights-engagement-column-configuration', () => {
 			const el = await fixture(html`<d2l-insights-engagement-column-configuration></d2l-insights-engagement-column-configuration>`);
 			await expect(el).to.be.accessible({
 				ignoredRules: [
-					'aria-allowed-attr' // TODO Fix later
+					'aria-allowed-attr' // Requires d2l-list-item component fix
 				]
 			});
 		});

--- a/test/components/courses-legend.test.js
+++ b/test/components/courses-legend.test.js
@@ -43,11 +43,7 @@ describe('d2l-insights-course-legend', () => {
 				.data="${data}">
 			</d2l-insights-courses-legend>`);
 			filter.set([]);
-			await expect(el).to.be.accessible({
-				ignoredRules: [
-					'nested-interactive' // TODO Fix later
-				]
-			});
+			await expect(el).to.be.accessible();
 		});
 	});
 

--- a/test/components/expander-with-control.test.js
+++ b/test/components/expander-with-control.test.js
@@ -40,16 +40,8 @@ describe('d2l-insights-expander-with-control', () => {
 
 	describe('accessibility', () => {
 		it('should pass all axe tests', async() => {
-			await expect(elCollapsed).to.be.accessible({
-				ignoredRules: [
-					'nested-interactive' // TODO Fix later
-				]
-			});
-			await expect(elExpanded).to.be.accessible({
-				ignoredRules: [
-					'nested-interactive' // TODO Fix later
-				]
-			});
+			await expect(elCollapsed).to.be.accessible();
+			await expect(elExpanded).to.be.accessible();
 		});
 	});
 

--- a/test/components/user-level-card-selection-list.test.js
+++ b/test/components/user-level-card-selection-list.test.js
@@ -16,7 +16,7 @@ describe('d2l-insights-engagement-user-card-selection-list', () => {
 			const el = await fixture(html`<d2l-insights-engagement-user-card-selection-list></d2l-insights-engagement-user-card-selection-list>`);
 			await expect(el).to.be.accessible({
 				ignoredRules: [
-					'aria-allowed-attr' // TODO Fix later
+					'aria-allowed-attr' // Requires d2l-list-item component fix
 				]
 			});
 		});


### PR DESCRIPTION
* Functional Testing 
  * [x] Browsers (Chrome, FF, Edge)
  * [x] Accessibility
    * Course legend can be selected with keyboard
    * Course legend allows toggling a course with keyboard/mouse
    * Engagement Dashboard Default View dialog allows selecting expand arrow.
    * Engagement Dashboard Default View dialog allows expanding/contraction the courses list with keyboard/mouse
    * NVDA works the same on Course legend and Engagement Dashboard Default View dialog
* Security, devops, perf: N/A
* UX and docs

@NicholasHallman 