### PR TITLE
Roles are not selected if all roles are active

### DIFF
--- a/components/role-list.js
+++ b/components/role-list.js
@@ -97,8 +97,10 @@ class RoleList extends Localizer(LitElement) {
 
 	_setFilterData(roleData) {
 		const selected = new Set(this.includeRoles.map(String));
+		const all_selected = this.includeRoles.length === roleData.length;
+
 		this._filterData = roleData.map(obj => {
-			return { id: obj.Identifier, displayName: obj.DisplayName, selected: selected.has(obj.Identifier) };
+			return { id: obj.Identifier, displayName: obj.DisplayName, selected: all_selected ? false : selected.has(obj.Identifier) };
 		});
 	}
 


### PR DESCRIPTION
John pointed out this client side issue that came to light due to the new patch. 

If all roles are selected we want to visually show that none of them are selected.

Steps to reproduce

- Reset any role configs for InsightsPortal.Roles
- Create a new admin user and impersonate
- Open engagement dashboard
- Goto settings
- Notice that all roles are selected

After patch
- Create a new admin user and impersonate
- Open engagement dashboard
- Goto settings
- Notice that all roles are NOT selected