### PR TITLE
US127900 [Engagement] Remove unused LMS metrics code. bdp-query overrides the metrics param to false

### DIFF
--- a/model/dataApiClient.js
+++ b/model/dataApiClient.js
@@ -76,8 +76,7 @@ export async function fetchUserData(orgUnitIds = [], userId = 0, metronEndpoint)
 	const url = concatMetronUrl(metronEndpoint, userDrillDataEndpoint);
 	const userDrillBody = {
 		selectedUserId: userId,
-		selectedOrgUnitIds: orgUnitIds,
-		metrics: true
+		selectedOrgUnitIds: orgUnitIds
 	};
 	const response = await d2lfetch.fetch(new Request(url, {
 		method: 'POST',


### PR DESCRIPTION
[US127900](https://rally1.rallydev.com/#/23525809118d/search?detail=%2Fuserstory%2F23c9cc05-07a5-4a2d-95c2-fd72db5d0af8&keywords=Remove%20unused&fdp=true?fdp=true): [Engagement] Remove unused LMS metrics code

Related PRs: 
https://github.com/Brightspace/lms/pull/10258
https://github.com/Brightspace/lms/pull/10321

* Functional Testing 
  * [x] Unit tests pass
  * [x] E2E is planed when all LMS parts are merged and get deployed to Draco stack
* Security, devops, perf: N/A
* UX and docs : N/A
  
FYI @anhill-D2L @hyehayes @NicholasHallman

