### PR TITLE
fix the version for puppeteer to match the version with visual-diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7",
     "@babel/plugin-proposal-class-properties": "^7.13.0",
-    "@brightspace-ui/visual-diff": "^3.0.0",
     "@brightspace-ui/stylelint-config": "0.1.0",
+    "@brightspace-ui/visual-diff": "^4.0.0",
     "@open-wc/testing": "^2",
     "@open-wc/testing-karma": "^4.0.1",
     "@polymer/polymer": "^3.4.1",


### PR DESCRIPTION
insights-engagement-dashboard is using puppeteer version 8
and visual-diff version 3.0.0 is using puppeteer version 7
and visual-diff version 4.0.0 is using puppeteer version 8
NPM install failed due to mismatch of puppeteer versions, change the version of visual-diff from 3.0.0 to 4.0.0 fixed the issue for me 

Functional Testing
NPM install works 

Performance
NA

Security
NA

Dev-Ops
NA

Cost
NA

UX
NA

FYI @anhill-D2L  @hyehayes @johngwilkinson @Vitalii-Misechko 
