### PR TITLE
Add required labels to selectable d2l-list-items.

### DIFF
--- a/components/card-selection-list.js
+++ b/components/card-selection-list.js
@@ -109,7 +109,7 @@ class CardSelectionList extends RtlMixin(Localizer(LitElement)) {
 
 		return html`
 			<d2l-list id="card-selection-list" @d2l-list-selection-change="${this._handleCardSelectionListChange}">
-				<d2l-list-item key="showGradesCard" selectable ?selected="${this.showGradesCard}">
+				<d2l-list-item key="showGradesCard" label="${this.localize('currentFinalGradeCard:currentGrade')}" selectable ?selected="${this.showGradesCard}">
 					<div class="d2l-insights-list-flex-container">
 						<d2l-insights-current-grade-thumbnail class="d2l-demo-card" aria-hidden="true"></d2l-insights-current-grade-thumbnail>
 						<div class="d2l-card-selection-text">
@@ -122,7 +122,7 @@ class CardSelectionList extends RtlMixin(Localizer(LitElement)) {
 					</div>
 				</d2l-list-item>
 
-				<d2l-list-item key="showCourseAccessCard" selectable ?selected="${this.showCourseAccessCard}">
+				<d2l-list-item key="showCourseAccessCard" label="${this.localize('courseLastAccessCard:courseAccess')}" selectable ?selected="${this.showCourseAccessCard}">
 					<div class="d2l-insights-list-flex-container">
 						<d2l-insights-course-access-thumbnail class="d2l-demo-card" aria-hidden="true"></d2l-insights-course-access-thumbnail>
 						<div class="d2l-card-selection-text">
@@ -135,7 +135,7 @@ class CardSelectionList extends RtlMixin(Localizer(LitElement)) {
 					</div>
 				</d2l-list-item>
 
-				<d2l-list-item key="showTicGradesCard" selectable ?selected="${this.showTicGradesCard}">
+				<d2l-list-item key="showTicGradesCard" label="${this.localize('timeInContentVsGradeCard:timeInContentVsGrade')}" selectable ?selected="${this.showTicGradesCard}">
 					<div class="d2l-insights-list-flex-container">
 						<d2l-insights-tic-vs-grade-thumbnail class="d2l-demo-card" aria-hidden="true"></d2l-insights-tic-vs-grade-thumbnail>
 						<div class="d2l-card-selection-text">
@@ -148,7 +148,7 @@ class CardSelectionList extends RtlMixin(Localizer(LitElement)) {
 					</div>
 				</d2l-list-item>
 
-				<d2l-list-item key="showContentViewCard" selectable ?selected="${this.showContentViewCard}">
+				<d2l-list-item key="showContentViewCard" label="${this.localize('contentViewHistogram:title')}" selectable ?selected="${this.showContentViewCard}">
 					<div class="d2l-insights-list-flex-container">
 						<d2l-insights-content-view-card-thumbnail class="d2l-demo-card" aria-hidden="true"></d2l-insights-content-view-card-thumbnail>
 						<div class="d2l-card-selection-text">
@@ -161,7 +161,7 @@ class CardSelectionList extends RtlMixin(Localizer(LitElement)) {
 					</div>
 				</d2l-list-item>
 
-				<d2l-list-item key="showOverdueCard" selectable ?selected="${this.showOverdueCard}">
+				<d2l-list-item key="showOverdueCard" label="${this.localize('dashboard:overdueAssignmentsHeading')}" selectable ?selected="${this.showOverdueCard}">
 					<div class="d2l-insights-list-flex-container">
 						<d2l-labs-summary-card
 							class="d2l-demo-card"
@@ -181,13 +181,13 @@ class CardSelectionList extends RtlMixin(Localizer(LitElement)) {
 					</div>
 				</d2l-list-item>
 
-				<d2l-list-item key="showSystemAccessCard" selectable ?selected="${this.showSystemAccessCard}">
+				<d2l-list-item key="showSystemAccessCard" label="${this.localize('dashboard:lastSystemAccessHeading')}" selectable ?selected="${this.showSystemAccessCard}">
 					<div class="d2l-insights-list-flex-container">
 						${this._renderSystemAccessListContents()}
 					</div>
 				</d2l-list-item>
 
-				<d2l-list-item key="showDiscussionsCard" selectable ?selected="${this.showDiscussionsCard}">
+				<d2l-list-item key="showDiscussionsCard" label="${this.localize('discussionActivityCard:cardTitle')}" selectable ?selected="${this.showDiscussionsCard}">
 					<div class="d2l-insights-list-flex-container">
 						<d2l-insights-disc-activity-thumbnail class="d2l-demo-card" aria-hidden="true"></d2l-insights-disc-activity-thumbnail>
 						<div class="d2l-card-selection-text">

--- a/components/column-configuration.js
+++ b/components/column-configuration.js
@@ -86,7 +86,7 @@ class ColumnConfiguration extends RtlMixin(Localizer(LitElement)) {
 
 		return html`
 			<d2l-list id="card-selection-list" @d2l-list-selection-change="${this._handleSelectionChange}">
-				<d2l-list-item key="showGradeCol" selectable ?selected="${this.showGradeCol}">
+				<d2l-list-item key="showGradeCol" label="${this.localize('settings:avgGrade')}" selectable ?selected="${this.showGradeCol}">
 					<div class="d2l-insights-config-list-item">
 						<div class="d2l-column-example">${formatPercent(0.8705, numberFormatOptions)}</div>
 						<div class="d2l-column-selection-text">
@@ -95,7 +95,7 @@ class ColumnConfiguration extends RtlMixin(Localizer(LitElement)) {
 						</div>
 					</div>
 				</d2l-list-item>
-				<d2l-list-item key="showTicCol" selectable ?selected="${this.showTicCol}">
+				<d2l-list-item key="showTicCol" label="${this.localize('settings:avgTimeInContent')}" selectable ?selected="${this.showTicCol}">
 					<div class="d2l-insights-config-list-item">
 						<div class="d2l-column-example">${formatNumber(92, numberFormatOptions)}</div>
 						<div class="d2l-column-selection-text">
@@ -104,7 +104,7 @@ class ColumnConfiguration extends RtlMixin(Localizer(LitElement)) {
 						</div>
 					</div>
 				</d2l-list-item>
-				<d2l-list-item key="showDiscussionsCol" selectable ?selected="${this.showDiscussionsCol}">
+				<d2l-list-item key="showDiscussionsCol" label="${this.localize('settings:avgDiscussionActivity')}" selectable ?selected="${this.showDiscussionsCol}">
 					<div class="d2l-insights-config-list-item">
 						<div class="d2l-column-example">${this._discussionsExample}</div>
 						<div class="d2l-column-selection-text">
@@ -113,7 +113,7 @@ class ColumnConfiguration extends RtlMixin(Localizer(LitElement)) {
 						</div>
 					</div>
 				</d2l-list-item>
-				<d2l-list-item key="showLastAccessCol" selectable ?selected="${this.showLastAccessCol}">
+				<d2l-list-item key="showLastAccessCol" label="${this.localize('settings:lastAccessedSystem')}" selectable ?selected="${this.showLastAccessCol}">
 					<div class="d2l-insights-config-list-item">
 						<div class="d2l-column-example">${formatDateTimeFromTimestamp(this.isDemo ? 1607546883964 : thirtyHoursAgo(), { format: 'medium' })}</div>
 						<div class="d2l-column-selection-text">
@@ -155,7 +155,7 @@ class ColumnConfiguration extends RtlMixin(Localizer(LitElement)) {
 	get _predictedGradeListItem() {
 		if (this.s3Enabled) {
 			return html`
-				<d2l-list-item key="showPredictedGradeCol" selectable ?selected="${this.showPredictedGradeCol}">
+				<d2l-list-item key="showPredictedGradeCol" label="${this.localize('settings:predictedGrade')}" selectable ?selected="${this.showPredictedGradeCol}">
 					<div class="d2l-insights-config-list-item">
 						<div class="d2l-column-example">${formatPercent(0.9175, numberFormatOptions)}</div>
 						<div class="d2l-column-selection-text">

--- a/components/user-level-card-selection-list.js
+++ b/components/user-level-card-selection-list.js
@@ -91,7 +91,7 @@ class UserLevelCardSelectionList extends RtlMixin(Localizer(LitElement)) {
 		return html`
 			<d2l-list id="card-selection-list" @d2l-list-selection-change="${this._handleCardSelectionListChange}">
 
-				<d2l-list-item key="showAverageGradeSummaryCard" selectable ?selected="${this.showAverageGradeSummaryCard}">
+				<d2l-list-item key="showAverageGradeSummaryCard" label="${this.localize('settings:avgGradeSummary')}" selectable ?selected="${this.showAverageGradeSummaryCard}">
 					<div class="d2l-insights-list-flex-container">
 						<d2l-labs-summary-card
 							class="d2l-demo-card"
@@ -111,7 +111,7 @@ class UserLevelCardSelectionList extends RtlMixin(Localizer(LitElement)) {
 					</div>
 				</d2l-list-item>
 
-				<d2l-list-item key="showGradesTrendCard" selectable ?selected="${this.showGradesTrendCard}">
+				<d2l-list-item key="showGradesTrendCard" label="${this.localize('gradesTrendCard:gradesOverTime')}" selectable ?selected="${this.showGradesTrendCard}">
 					<div class="d2l-insights-list-flex-container">
 						<d2l-insights-grades-trend-thumbnail class="d2l-demo-card" aria-hidden="true"></d2l-insights-grades-trend-thumbnail>
 						<div class="d2l-card-selection-text">
@@ -124,7 +124,7 @@ class UserLevelCardSelectionList extends RtlMixin(Localizer(LitElement)) {
 					</div>
 				</d2l-list-item>
 
-				<d2l-list-item key="showCourseAccessTrendCard" selectable ?selected="${this.showCourseAccessTrendCard}">
+				<d2l-list-item key="showCourseAccessTrendCard" label="${this.localize('accessTrendCard:title')}" selectable ?selected="${this.showCourseAccessTrendCard}">
 					<div class="d2l-insights-list-flex-container">
 						<d2l-insights-course-access-trend-thumbnail class="d2l-demo-card" aria-hidden="true"></d2l-insights-course-access-trend-thumbnail>
 						<div class="d2l-card-selection-text">
@@ -137,7 +137,7 @@ class UserLevelCardSelectionList extends RtlMixin(Localizer(LitElement)) {
 					</div>
 				</d2l-list-item>
 
-				<d2l-list-item key="showContentViewsTrendCard" selectable ?selected="${this.showContentViewsTrendCard}">
+				<d2l-list-item key="showContentViewsTrendCard" label="${this.localize('contentViewsCard:contentViewOverTime')}" selectable ?selected="${this.showContentViewsTrendCard}">
 					<div class="d2l-insights-list-flex-container">
 						<d2l-insights-content-views-trend-thumbnail class="d2l-demo-card" aria-hidden="true"></d2l-insights-content-views-trend-thumbnail>
 						<div class="d2l-card-selection-text">


### PR DESCRIPTION
This PR adds labels to selectable d2l-list-items that will be required in the near future in order to support changes that are being made to lists for selection, multi-selection, and multi-actions,