### PR TITLE
No Roles Error Messaging

### DIFF
--- a/components/engagement-dashboard-errors.js
+++ b/components/engagement-dashboard-errors.js
@@ -11,7 +11,7 @@ class EngagementDashboardErrors extends Localizer(MobxLitElement) {
 	static get properties() {
 		return {
 			data: { type: Object, attribute: false },
-			isNoDataReturned: { type: Boolean, attribute: 'no-data' },
+			isNoDataReturned: { type: Boolean, attribute: 'no-results' },
 			isNoRoles: { type: Boolean, attribute: 'no-roles' }
 		};
 	}

--- a/components/engagement-dashboard-errors.js
+++ b/components/engagement-dashboard-errors.js
@@ -11,7 +11,8 @@ class EngagementDashboardErrors extends Localizer(MobxLitElement) {
 	static get properties() {
 		return {
 			data: { type: Object, attribute: false },
-			isNoDataReturned: { type: Boolean, attribute: false }
+			isNoDataReturned: { type: Boolean, attribute: false },
+			isNoRoles: { attribute: false }
 		};
 	}
 
@@ -34,7 +35,12 @@ class EngagementDashboardErrors extends Localizer(MobxLitElement) {
 		let messageType, text, linkText, href, buttonText;
 
 		// conditionally render message text and body
-		if (this._isQueryFails) {
+		if (this.isNoRoles) {
+			messageType = 'button';
+			text = this.localize('dashboard:noRolesSelected');
+			buttonText = this.localize('dashboard:goToSettings');
+
+		} else if (this._isQueryFails) {
 			messageType = 'link';
 			text = this.localize('dashboard:queryFailed');
 			linkText = this.localize('dashboard:queryFailedLink');
@@ -66,7 +72,11 @@ class EngagementDashboardErrors extends Localizer(MobxLitElement) {
 	}
 
 	_handleClick() {
-		this.dispatchEvent(new Event('d2l-insights-undo-last-filter'));
+		if (this.isNoRoles) {
+			this.dispatchEvent(new Event('d2l-insights-go-to-settings'));
+		} else {
+			this.dispatchEvent(new Event('d2l-insights-undo-last-filter'));
+		}
 	}
 }
 

--- a/components/engagement-dashboard-errors.js
+++ b/components/engagement-dashboard-errors.js
@@ -11,8 +11,8 @@ class EngagementDashboardErrors extends Localizer(MobxLitElement) {
 	static get properties() {
 		return {
 			data: { type: Object, attribute: false },
-			isNoDataReturned: { type: Boolean, attribute: false },
-			isNoRoles: { attribute: false }
+			isNoDataReturned: { type: Boolean, attribute: 'no-data' },
+			isNoRoles: { type: Boolean, attribute: 'no-roles' }
 		};
 	}
 

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -428,8 +428,8 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 			</div>
 			<d2l-insights-engagement-dashboard-errors
 				.data="${this._data}"
-				.isNoDataReturned="${this._isNoUserResults}"
-				.isNoRoles="${this._parsedIncludeRoles.length === 0}"
+				?no-data="${this._isNoUserResults}"
+				?no-roles="${this._parsedIncludeRoles.length === 0}"
 				@d2l-insights-undo-last-filter="${this._handleUndo}"
 				@d2l-insights-go-to-settings="${this._openSettingsPage}">
 			</d2l-insights-engagement-dashboard-errors>

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -428,7 +428,7 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 			</div>
 			<d2l-insights-engagement-dashboard-errors
 				.data="${this._data}"
-				?no-data="${this._isNoUserResults}"
+				?no-results="${this._isNoUserResults}"
 				?no-roles="${this._parsedIncludeRoles.length === 0}"
 				@d2l-insights-undo-last-filter="${this._handleUndo}"
 				@d2l-insights-go-to-settings="${this._openSettingsPage}">

--- a/engagement-dashboard.js
+++ b/engagement-dashboard.js
@@ -429,7 +429,9 @@ class EngagementDashboard extends Localizer(MobxLitElement) {
 			<d2l-insights-engagement-dashboard-errors
 				.data="${this._data}"
 				.isNoDataReturned="${this._isNoUserResults}"
-				@d2l-insights-undo-last-filter="${this._handleUndo}">
+				.isNoRoles="${this._parsedIncludeRoles.length === 0}"
+				@d2l-insights-undo-last-filter="${this._handleUndo}"
+				@d2l-insights-go-to-settings="${this._openSettingsPage}">
 			</d2l-insights-engagement-dashboard-errors>
 			${this._summaryViewHeader}
 			<div class="d2l-insights-summary-container-applied-filters">

--- a/locales/en.js
+++ b/locales/en.js
@@ -26,9 +26,11 @@ export default {
 	"dashboard:print": "Print",
 	"dashboard:noUsersSelectedDialogText": "Please select one or more users to email.",
 	"dashboard:noResultsAvailable": "There are no results available that match your filters.",
+	"dashboard:noRolesSelected": "We couldn't find any data because there are no selected user roles.",
 	"dashboard:queryFailed": "Unable to load your results. If this problem persists, please ",
 	"dashboard:queryFailedLink": "contact D2L Support.",
 	"dashboard:undoLastAction": "Undo Last Action",
+	"dashboard:goToSettings": "Go To Settings",
 
 	"settings:roleListTitle": "Roles filter",
 	"settings:roleListDescription": "Set which learner roles to include in your dashboard data. All other roles will be filtered out.",

--- a/model/data.js
+++ b/model/data.js
@@ -96,6 +96,9 @@ export class Data {
 		};
 		try {
 			const data = await this.recordProvider(filters, this._metronEndpoint);
+			// Fixes a case where an existing users role selections are excluded by the
+			// config variable. This scenario causes the selectedRolesIds to be null.
+			// This block does not affect first time users with no role selections.
 			if (data.selectedRolesIds === null) {
 				this.onServerDataReload(this.serverData);
 				this.isQueryError = false;

--- a/model/data.js
+++ b/model/data.js
@@ -96,6 +96,11 @@ export class Data {
 		};
 		try {
 			const data = await this.recordProvider(filters, this._metronEndpoint);
+			if (data.selectedRolesIds === null) {
+				this.onServerDataReload(this.serverData);
+				this.isQueryError = false;
+				return;
+			}
 			this.onServerDataReload(data);
 			this.isQueryError = false;
 		} catch (ignored) {

--- a/test/components/engagement-dashboard-errors.test.js
+++ b/test/components/engagement-dashboard-errors.test.js
@@ -57,14 +57,14 @@ describe('d2l-insights-engagement-dashboard-errors', () => {
 
 	describe('render', () => {
 		it('should render as expected with truncated records', async() => {
-			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithTruncatedRecords}" ?no-data="${Boolean(0)}"></d2l-insights-engagement-dashboard-errors>`);
+			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithTruncatedRecords}" ?no-results="${Boolean(0)}"></d2l-insights-engagement-dashboard-errors>`);
 			const innerMessageContainer = el.shadowRoot.querySelector('d2l-insights-message-container');
 			expect(innerMessageContainer.type).to.equal('default');
 			expect(innerMessageContainer.text).to.equal('There are too many results in your filters. Please refine your selection.');
 		});
 
 		it('should not render without truncated records', async() => {
-			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithoutTruncatedRecords}" ?no-data="${Boolean(1)}"></d2l-insights-engagement-dashboard-errors>`);
+			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithoutTruncatedRecords}" ?no-results="${Boolean(1)}"></d2l-insights-engagement-dashboard-errors>`);
 			const innerMessageContainer = el.shadowRoot.querySelector('d2l-insights-message-container');
 			expect(innerMessageContainer.type).to.equal('button');
 			expect(innerMessageContainer.text).to.equal('There are no results available that match your filters.');
@@ -72,7 +72,7 @@ describe('d2l-insights-engagement-dashboard-errors', () => {
 		});
 
 		it('should render as expected with contact support message', async() => {
-			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithQueryError}" ?no-data="${Boolean(0)}"></d2l-insights-engagement-dashboard-errors>`);
+			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithQueryError}" ?no-results="${Boolean(0)}"></d2l-insights-engagement-dashboard-errors>`);
 			const innerMessageContainer = el.shadowRoot.querySelector('d2l-insights-message-container');
 			expect(innerMessageContainer.type).to.equal('link');
 			expect(innerMessageContainer.text).to.equal('Unable to load your results. If this problem persists, please ');
@@ -80,7 +80,7 @@ describe('d2l-insights-engagement-dashboard-errors', () => {
 		});
 
 		it('should render nothing if there are no issues', async() => {
-			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithoutTruncatedRecords}" ?no-data="${Boolean(0)}"></d2l-insights-engagement-dashboard-errors>`);
+			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithoutTruncatedRecords}" ?no-results="${Boolean(0)}"></d2l-insights-engagement-dashboard-errors>`);
 			const innerMessageContainer = el.shadowRoot.querySelector('d2l-insights-message-container');
 			expect(innerMessageContainer).to.be.null;
 		});

--- a/test/components/engagement-dashboard-errors.test.js
+++ b/test/components/engagement-dashboard-errors.test.js
@@ -1,6 +1,6 @@
 import '../../components/engagement-dashboard-errors';
 
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
 
 describe('d2l-insights-engagement-dashboard-errors', () => {
@@ -91,6 +91,18 @@ describe('d2l-insights-engagement-dashboard-errors', () => {
 			expect(innerMessageContainer.type).to.equal('button');
 			expect(innerMessageContainer.text).to.equal("We couldn't find any data because there are no selected user roles.");
 			expect(innerMessageContainer.buttonText).to.equal('Go To Settings');
+		});
+
+		it('should send the settings event when the button is pressed', async() => {
+			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithRoleError}" ?no-roles="${Boolean(1)}"></d2l-insights-engagement-dashboard-errors>`);
+			const innerMessageContainer = el.shadowRoot.querySelector('d2l-insights-message-container');
+			expect(innerMessageContainer.type).to.equal('button');
+			expect(innerMessageContainer.text).to.equal("We couldn't find any data because there are no selected user roles.");
+			expect(innerMessageContainer.buttonText).to.equal('Go To Settings');
+
+			const listener = oneEvent(el, 'd2l-insights-go-to-settings');
+			el.shadowRoot.querySelector('d2l-insights-message-container').shadowRoot.querySelector('d2l-button').click();
+			await listener;
 		});
 	});
 });

--- a/test/components/engagement-dashboard-errors.test.js
+++ b/test/components/engagement-dashboard-errors.test.js
@@ -32,6 +32,14 @@ describe('d2l-insights-engagement-dashboard-errors', () => {
 		}
 	};
 
+	const dataWithRoleError = {
+		_data: {
+			serverData: {
+				selectedRolesIds: null
+			}
+		}
+	};
+
 	describe('constructor', () => {
 		it('should construct', () => {
 			runConstructor('d2l-insights-engagement-dashboard-errors');
@@ -49,14 +57,14 @@ describe('d2l-insights-engagement-dashboard-errors', () => {
 
 	describe('render', () => {
 		it('should render as expected with truncated records', async() => {
-			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithTruncatedRecords}" .isNoDataReturned="${Boolean(0)}"></d2l-insights-engagement-dashboard-errors>`);
+			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithTruncatedRecords}" ?no-data="${Boolean(0)}"></d2l-insights-engagement-dashboard-errors>`);
 			const innerMessageContainer = el.shadowRoot.querySelector('d2l-insights-message-container');
 			expect(innerMessageContainer.type).to.equal('default');
 			expect(innerMessageContainer.text).to.equal('There are too many results in your filters. Please refine your selection.');
 		});
 
 		it('should not render without truncated records', async() => {
-			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithoutTruncatedRecords}" .isNoDataReturned="${Boolean(1)}"></d2l-insights-engagement-dashboard-errors>`);
+			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithoutTruncatedRecords}" ?no-data="${Boolean(1)}"></d2l-insights-engagement-dashboard-errors>`);
 			const innerMessageContainer = el.shadowRoot.querySelector('d2l-insights-message-container');
 			expect(innerMessageContainer.type).to.equal('button');
 			expect(innerMessageContainer.text).to.equal('There are no results available that match your filters.');
@@ -64,7 +72,7 @@ describe('d2l-insights-engagement-dashboard-errors', () => {
 		});
 
 		it('should render as expected with contact support message', async() => {
-			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithQueryError}" .isNoDataReturned="${Boolean(0)}"></d2l-insights-engagement-dashboard-errors>`);
+			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithQueryError}" ?no-data="${Boolean(0)}"></d2l-insights-engagement-dashboard-errors>`);
 			const innerMessageContainer = el.shadowRoot.querySelector('d2l-insights-message-container');
 			expect(innerMessageContainer.type).to.equal('link');
 			expect(innerMessageContainer.text).to.equal('Unable to load your results. If this problem persists, please ');
@@ -72,9 +80,17 @@ describe('d2l-insights-engagement-dashboard-errors', () => {
 		});
 
 		it('should render nothing if there are no issues', async() => {
-			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithoutTruncatedRecords}" .isNoDataReturned="${Boolean(0)}"></d2l-insights-engagement-dashboard-errors>`);
+			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithoutTruncatedRecords}" ?no-data="${Boolean(0)}"></d2l-insights-engagement-dashboard-errors>`);
 			const innerMessageContainer = el.shadowRoot.querySelector('d2l-insights-message-container');
 			expect(innerMessageContainer).to.be.null;
+		});
+
+		it('should render as expected with go to setting message', async() => {
+			const el = await fixture(html`<d2l-insights-engagement-dashboard-errors .data="${dataWithRoleError}" ?no-roles="${Boolean(1)}"></d2l-insights-engagement-dashboard-errors>`);
+			const innerMessageContainer = el.shadowRoot.querySelector('d2l-insights-message-container');
+			expect(innerMessageContainer.type).to.equal('button');
+			expect(innerMessageContainer.text).to.equal("We couldn't find any data because there are no selected user roles.");
+			expect(innerMessageContainer.buttonText).to.equal('Go To Settings');
 		});
 	});
 });

--- a/test/engagement-dashboard.test.js
+++ b/test/engagement-dashboard.test.js
@@ -175,4 +175,14 @@ describe('d2l-insights-engagement-dashboard', () => {
 			});
 		});
 	});
+
+	describe('events', () => {
+		it('Should open the settings page on an event', async() => {
+			const el = await fixture(html`<d2l-insights-engagement-dashboard></d2l-insights-engagement-dashboard>`);
+			const errorAlert = el.shadowRoot.querySelector('d2l-insights-engagement-dashboard-errors');
+			errorAlert.dispatchEvent(new Event('d2l-insights-go-to-settings'));
+			await el.updateComplete;
+			expect(window.location.search.includes('?v=settings')).to.be.true;
+		});
+	});
 });


### PR DESCRIPTION
We now show an error message if the user's roles that they previously had selected are now excluded by the config variables.

The buton on this error message opens the settings page when pressed (reuses the same code as the settings button in the collapsable menu)

This change also observes the differences between a new user with no roles selected seeing the dashboard for the firest time; where the lms returns all results, and a user whos selected roles have been disabled in the config; in which the lms returns null.

Quality Notes

Testing
- Tested on demo
- Tested on Local LMS with mock bdp query
- Tested on Local LMS with bdp Draco stack
- [x] Should open the settings page when dashboard errors emits the appropriate event
- [x] Should display the role errors alert when the selectedRoles is null

UX
 - Wording approved by kevin
 
All others N/A

FYI: @Brightspace/draco-vis 
